### PR TITLE
Fixed GitHub Actions to include repository head ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{github.head_ref}}
+
+      - name: Git Default Branch
+        run: git config set init.defaultBranch master
 
       - name: Ruby Setup
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Overview

Necessary for Git Lint to lint commit messages properly since GitHub Actions doesn't provide this by default. Git Lint needs to this determine which commits are on the feature branch.

This includes setting the default branch to `master` since Git Lint assumes `main` by default.

This'll be a huge help in generating consistent release notes in the future.

## Screenshots/Screencasts

![2025-02-21_11-56-08-Brave Browser](https://github.com/user-attachments/assets/5ec73020-d02f-4ac7-88ca-9c9dd92e8851)
