### PR TITLE
Playlist Group validation error message stub

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -260,6 +260,7 @@ da:
       device_default: Device default
       display_period_from: Vis fra
       display_period_to: til
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist: # del (enkelt element)
       delete: Er du sikker på, at du vil fjerne dette element? Pluginet vil forblive tilsluttet, men ikke vist på din enhed.

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -261,6 +261,7 @@ de-AT:
       device_default: Device default
       display_period_from: Anzeige von
       display_period_to: bis
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist: # partial (single item)
       delete: Soll dieser Eintrag wirklich entfernt werden? Die Erweiterung bleibt weiterhin verbunden, wird lediglich nicht auf dem Gerät angezeigt.

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -261,6 +261,7 @@ de:
       device_default: Device default
       display_period_from: Anzeige von
       display_period_to: bis
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist: # partial (single item)
       delete: Soll dieser Eintrag wirklich entfernt werden? Die Erweiterung bleibt weiterhin verbunden, wird lediglich nicht auf dem Gerät angezeigt.

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -261,6 +261,7 @@ en:
       device_default: Device default
       display_period_from: Display from
       display_period_to: to
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist: # partial (single item)
       delete: Are you sure you want to remove this item? The plugin will remain connected, just not shown on your device.

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -261,6 +261,7 @@ es-ES:
       device_default: Device default
       display_period_from: Display from
       display_period_to: to
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist:
       delete: ¿Seguro que quieres eliminar este elemento? El plugin permanecerá conectado, pero no se mostrará en tu dispositivo.

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -261,6 +261,7 @@ fr:
       device_default: Device default
       display_period_from: Afficher entre
       display_period_to: et
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist: # partial (single item)
       delete: Êtes-vous sûr·e de vouloir supprimer cet élément ? L'extension restera connectée mais ne s'affichera plus sur votre appareil.

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -261,6 +261,7 @@ he:
       device_default: Device default
       display_period_from: Display from
       display_period_to: to
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist: # partial (single item)
       delete: Are you sure you want to remove this item? The plugin will remain connected, just not shown on your device.

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -261,6 +261,7 @@ id:
       device_default: Device default
       display_period_from: Display from
       display_period_to: to
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist: # partial (single item)
       delete: Apakah Anda yakin ingin menghapus item ini? Plugin akan tetap terhubung, hanya tidak ditampilkan di perangkat Anda.

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -261,6 +261,7 @@ it:
       device_default: Device default
       display_period_from: Mostra dalle
       display_period_to: alle
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist: # partial (single item)
       delete: Vuoi davvero rimuovere questo elemento? Il plugin resterà connesso, ma non sarà visibile sul tuo dispositivo.

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -261,6 +261,7 @@ ja:
       device_default: Device default
       display_period_from: 表示期間：
       display_period_to: 〜
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist: # partial (single item)
       delete: このプラグインを削除しますか？プラグインの接続は維持されますが、デバイスには表示されなくなります。

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -261,6 +261,7 @@ ko:
       device_default: Device default
       display_period_from: Display from
       display_period_to: to
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist: # partial (single item)
       delete: 해당 플러그인을 삭제하는 것이 맞습니까? 플러그인의 연결은 지속되지만 당신의 기기에 보여지지는 않을 것입니다.

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -261,6 +261,7 @@ nl:
       device_default: Device default
       display_period_from: Weergeven van
       display_period_to: tot
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist: # partial (single item)
       delete: Weet je zeker dat je dit item wilt verwijderen? De plugin blijft verbonden en wordt niet getoond op jouw apparaat.

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -264,6 +264,7 @@
       device_default: Device default
       display_period_from: Vis fra
       display_period_to: til
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist:
       delete: Er du sikker på at du vil fjerne dette elementet? Pluginen vil fortsatt være tilkoblet, men ikke vist på enheten din.

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -261,6 +261,7 @@ pt-BR:
       device_default: Device default
       display_period_from: Exibir de
       display_period_to: até
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist: # partial (single item)
       delete: Tem certeza que deseja remover este item? O plugin continuará conectado, apenas não será exibido no seu dispositivo.

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -252,16 +252,17 @@ raw:
     index:
       title: playlists.index.title
       tagline: playlists.index.tagline
-      add_a_group: add_a_group
-      add_a_plugin: add_a_plugin
+      add_a_group: playlists.index.add_a_group
+      add_a_plugin: playlists.index.add_a_plugin
       add_first_device_cta: playlists.index.add_first_device_cta
       add_to_playlist: playlists.index.add_to_playlist
       create_first_playlist_cta: playlists.index.create_first_playlist_cta
-      custom: Custom
-      device_default: Device default
-      display_period_from: display_period_from
-      display_period_to: display_period_to
-      every: every
+      custom: playlists.index.custom
+      device_default: playlists.index.device_default
+      display_period_from: playlists.index.display_period_from
+      display_period_to: playlists.index.display_period_to
+      display_period_validation: playlists.index.display_period_validation
+      every: playlists.index.every
     playlist: # partial (single item)
       delete: playlists.playlist.delete
       displayed_now: playlists.playlist.displayed_now

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -261,6 +261,7 @@ uk:
       device_default: Device default
       display_period_from: Display from
       display_period_to: to
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist: # partial (single item)
       delete: Ви впевнені, що хочете видалити цей елемент? Плагін залишиться підключеним, але не відображатиметься на вашому пристрої.

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -261,6 +261,7 @@ zh-CN:
       device_default: Device default
       display_period_from: Display from
       display_period_to: to
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist: # partial (single item)
       delete: 确认删除设备？尽在设备上删除，不会影响插件连接。

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -261,6 +261,7 @@ zh-HK:
       device_default: Device default
       display_period_from: 顯示時間
       display_period_to: 至
+      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
       every: every
     playlist: # partial (single item)
       delete: 確定要移除此項目嗎？外掛會保持連接，只是不會在裝置上顯示。


### PR DESCRIPTION
## Overview
some users create playlist groups with a period like "5p to 2am," however we currently operate on a 00:00-23:45 schedule. to achieve a "17:00-02:00" grouping, user must create a 17:00-23:45 group, then a 00:00-02:00 group.

![trmnl-playlist-group-time-period-validation](https://github.com/user-attachments/assets/2e951961-87b8-43c2-b837-69d6898f2c84)

this messaging helps avoid subtle bugs where a playlist group is ignored because it overlaps with another.