### PR TITLE
Removed GitHub Actions default branch setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
           fetch-depth: 0
           ref: ${{github.head_ref}}
 
-      - name: Git Default Branch
-        run: git config set init.defaultBranch master
-
       - name: Ruby Setup
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Overview

No longer necessary now that the default branch is `main`.

