### PR TITLE
Plugin recipes - stub missing locales

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -319,6 +319,7 @@ da:
       name: Navn
       description: Beskrivelse
   plugin_recipes:
+    connected: Recipe connected
     new:
       error: Opskrift ikke fundet
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -320,6 +320,7 @@ de-AT:
       name: Name
       description: Beschreibung
   plugin_recipes:
+    connected: Recipe connected
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -320,6 +320,7 @@ de:
       name: Name
       description: Beschreibung
   plugin_recipes:
+    connected: Recipe connected
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -320,6 +320,7 @@ en:
       name: Name
       description: Description
   plugin_recipes:
+    connected: Recipe connected # success toast message following "Install"
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -320,6 +320,7 @@ es-ES:
       name: Nombre
       description: Descripción
   plugin_recipes:
+    connected: Recipe connected
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -320,6 +320,7 @@ fr:
       name: Nom
       description: Description
   plugin_recipes:
+    connected: Recipe connected
     new:
       error: Recette introuvable
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -320,6 +320,7 @@ he:
       name: Name
       description: Description
   plugin_recipes:
+    connected: Recipe connected
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -320,6 +320,7 @@ id:
       name: Nama
       description: Deskripsi
   plugin_recipes:
+    connected: Recipe connected
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -320,6 +320,7 @@ it:
       name: Nome
       description: Descrizione
   plugin_recipes:
+    connected: Recipe connected
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -320,6 +320,7 @@ ja:
       name: 名前
       description: 説明
   plugin_recipes:
+    connected: Recipe connected
     new:
       error: レシピが見つかりません
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -320,6 +320,7 @@ ko:
       name: Name
       description: Description
   plugin_recipes:
+    connected: Recipe connected
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -320,6 +320,7 @@ nl:
       name: Naam
       description: Beschrijving
   plugin_recipes:
+    connected: Recipe connected
     new:
       error: Recept niet gevonden
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -323,6 +323,7 @@
       name: Navn
       description: Beskrivelse
   plugin_recipes:
+    connected: Recipe connected
     new:
       error: Oppskrift ikke funnet
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -320,6 +320,7 @@ pt-BR:
       name: Nome
       description: Descrição
   plugin_recipes:
+    connected: Recipe connected
     new:
       error: Receita não encontrada
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -322,9 +322,6 @@ raw:
       name: plugins.edit.name
       description: plugins.edit.description
   plugin_recipes:
-    index:
-      title: Community Recipe
-      tagline: Installable Recipe Shared by Community
     connected: plugin_recipes.connected
     new:
       error: plugin_recipes.new.error

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -320,6 +320,7 @@ uk:
       name: Name
       description: Description
   plugin_recipes:
+    connected: Recipe connected
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -320,6 +320,7 @@ zh-CN:
       name: 名称
       description: 简介
   plugin_recipes:
+    connected: Recipe connected
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -320,6 +320,7 @@ zh-HK:
       name: 名稱
       description: 描述
   plugin_recipes:
+    connected: Recipe connected
     new:
       error: 找不到模板
   plugin_settings:


### PR DESCRIPTION
## Overview
during our migration from self-hosted locales to this gem, we missed a spot.

## Screenshots/Screencasts

![image](https://github.com/user-attachments/assets/f317cff3-4d50-4a72-8846-e4b295c71612)
