### PR TITLE
Add translations for Parcel native plugin

### DIFF
--- a/lib/trmnl/i18n/locales/plugin_renders/da.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/da.yml
@@ -8,6 +8,32 @@ da:
       days_passed: Dage gået
       days_left: Dage tilbage
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: Vejr
       temperature: Temperatur

--- a/lib/trmnl/i18n/locales/plugin_renders/da.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/da.yml
@@ -1,7 +1,6 @@
 da:
   # namespace to not interfere with other localizations
   renders:
-
     # plugin-specific localizations; alphabetize by plugin's keyname
     days_left_year:
       title: Dage tilbage i år
@@ -33,6 +32,8 @@ da:
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: Vejr

--- a/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
@@ -1,7 +1,6 @@
 de-AT:
   # namespace to not interfere with other localizations
   renders:
-
     # plugin-specific localizations; alphabetize by plugin's keyname
     days_left_year:
       title: Verbleibende Tage dieses Jahr
@@ -33,6 +32,8 @@ de-AT:
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: Wetter

--- a/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
@@ -8,6 +8,32 @@ de-AT:
       days_passed: Vergangene Tage
       days_left: Verbleibende Tage
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: Wetter
       temperature: Temperatur

--- a/lib/trmnl/i18n/locales/plugin_renders/de.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de.yml
@@ -8,6 +8,32 @@ de:
       days_passed: Vergangene Tage
       days_left: Verbleibende Tage
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: Wetter
       temperature: Temperatur

--- a/lib/trmnl/i18n/locales/plugin_renders/de.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de.yml
@@ -1,7 +1,6 @@
 de:
   # namespace to not interfere with other localizations
   renders:
-
     # plugin-specific localizations; alphabetize by plugin's keyname
     days_left_year:
       title: Verbleibende Tage dieses Jahr
@@ -33,6 +32,8 @@ de:
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: Wetter

--- a/lib/trmnl/i18n/locales/plugin_renders/en.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/en.yml
@@ -8,6 +8,32 @@ en:
       days_passed: Days Passed
       days_left: Days Left
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: Weather
       temperature: Temperature

--- a/lib/trmnl/i18n/locales/plugin_renders/en.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/en.yml
@@ -1,7 +1,6 @@
 en:
   # namespace to not interfere with other localizations
   renders:
-
     # plugin-specific localizations; alphabetize by plugin's keyname
     days_left_year:
       title: Days Left This Year
@@ -33,6 +32,8 @@ en:
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: Weather

--- a/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
@@ -7,6 +7,32 @@ es-ES:
       days_passed: Días Pasados
       days_left: Días Restantes
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: El Tiempo
       temperature: Temperatura

--- a/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
@@ -32,6 +32,8 @@ es-ES:
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: El Tiempo

--- a/lib/trmnl/i18n/locales/plugin_renders/fr.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/fr.yml
@@ -1,7 +1,6 @@
 fr:
   # namespace to not interfere with other localizations
   renders:
-
     # plugin-specific localizations; alphabetize by plugin's keyname
     days_left_year:
       title: Jours restants cette année
@@ -33,6 +32,8 @@ fr:
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: Météo

--- a/lib/trmnl/i18n/locales/plugin_renders/fr.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/fr.yml
@@ -8,6 +8,32 @@ fr:
       days_passed: Jours passés
       days_left: Jours restants
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: Météo
       temperature: Température

--- a/lib/trmnl/i18n/locales/plugin_renders/he.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/he.yml
@@ -8,6 +8,32 @@ he:
       days_passed: ימים שחלפו
       days_left: ימים שנותרו
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: מזג אויר
       temperature: טמפרטורה

--- a/lib/trmnl/i18n/locales/plugin_renders/he.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/he.yml
@@ -1,7 +1,6 @@
 he:
   # namespace to not interfere with other localizations
   renders:
-
     # plugin-specific localizations; alphabetize by plugin's keyname
     days_left_year:
       title: ימים שנותרו עד לסוף השנה
@@ -33,11 +32,13 @@ he:
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: מזג אויר
       temperature: טמפרטורה
-      feels_like: תחושה 
+      feels_like: תחושה
       humidity: לחות
       low: נמוכה
       high: גבוהה

--- a/lib/trmnl/i18n/locales/plugin_renders/id.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/id.yml
@@ -1,7 +1,6 @@
 id:
   # namespace to not interfere with other localizations
   renders:
-
     # plugin-specific localizations; alphabetize by plugin's keyname
     days_left_year:
       title: Days Left This Year
@@ -33,6 +32,8 @@ id:
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: Weather

--- a/lib/trmnl/i18n/locales/plugin_renders/id.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/id.yml
@@ -8,6 +8,32 @@ id:
       days_passed: Days Passed
       days_left: Days Left
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: Weather
       temperature: Temperature

--- a/lib/trmnl/i18n/locales/plugin_renders/it.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/it.yml
@@ -8,6 +8,32 @@ it:
       days_passed: Days Passed
       days_left: Days Left
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: Weather
       temperature: Temperature

--- a/lib/trmnl/i18n/locales/plugin_renders/it.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/it.yml
@@ -1,7 +1,6 @@
 it:
   # namespace to not interfere with other localizations
   renders:
-
     # plugin-specific localizations; alphabetize by plugin's keyname
     days_left_year:
       title: Days Left This Year
@@ -33,6 +32,8 @@ it:
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: Weather

--- a/lib/trmnl/i18n/locales/plugin_renders/ja.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ja.yml
@@ -8,6 +8,32 @@ ja:
       days_passed: 経過日数
       days_left: 残り日数
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: 天気
       temperature: 温度

--- a/lib/trmnl/i18n/locales/plugin_renders/ja.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ja.yml
@@ -1,7 +1,6 @@
 ja:
   # namespace to not interfere with other localizations
   renders:
-
     # plugin-specific localizations; alphabetize by plugin's keyname
     days_left_year:
       title: 今年の残り日数
@@ -33,6 +32,8 @@ ja:
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: 天気

--- a/lib/trmnl/i18n/locales/plugin_renders/ko.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ko.yml
@@ -1,7 +1,6 @@
 ko:
   # namespace to not interfere with other localizations
   renders:
-
     # plugin-specific localizations; alphabetize by plugin's keyname
     days_left_year:
       title: 올해 남은 날
@@ -33,6 +32,8 @@ ko:
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: 날씨

--- a/lib/trmnl/i18n/locales/plugin_renders/ko.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ko.yml
@@ -8,6 +8,32 @@ ko:
       days_passed: 일 후
       days_left: 남은 날
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: 날씨
       temperature: 온도

--- a/lib/trmnl/i18n/locales/plugin_renders/nl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/nl.yml
@@ -1,7 +1,6 @@
 nl:
   # namespace to not interfere with other localizations
   renders:
-
     # plugin-specific localizations; alphabetize by plugin's keyname
     days_left_year:
       title: Dagen over dit jaar
@@ -33,6 +32,8 @@ nl:
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: Weer

--- a/lib/trmnl/i18n/locales/plugin_renders/nl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/nl.yml
@@ -8,6 +8,32 @@ nl:
       days_passed: Verstreken dagen
       days_left: Resterende dagen
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: Weer
       temperature: Temperatuur

--- a/lib/trmnl/i18n/locales/plugin_renders/no.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/no.yml
@@ -8,6 +8,32 @@
       days_passed: Dager som har gått
       days_left: Gjenstående dager
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: Vær
       temperature: Temperatur

--- a/lib/trmnl/i18n/locales/plugin_renders/no.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/no.yml
@@ -1,7 +1,6 @@
 "no":
   # namespace to not interfere with other localizations
   renders:
-
     # plugin-specific localizations; alphabetize by plugin's keyname
     days_left_year:
       title: Dager igjen i år
@@ -33,6 +32,8 @@
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: Vær

--- a/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
@@ -1,7 +1,6 @@
 pt-BR:
   # namespace to not interfere with other localizations
   renders:
-
     # plugin-specific localizations; alphabetize by plugin's keyname
     days_left_year:
       title: Dias Restantes Neste Ano
@@ -33,6 +32,8 @@ pt-BR:
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: Clima

--- a/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
@@ -8,6 +8,32 @@ pt-BR:
       days_passed: Dias Corridos
       days_left: Dias Restantes
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: Clima
       temperature: Temperatura

--- a/lib/trmnl/i18n/locales/plugin_renders/raw.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/raw.yml
@@ -33,6 +33,8 @@ raw:
         not_found: parcel.status.not_found
         out_for_delivery: parcel.status.out_for_delivery
         unknown: parcel.status.unknown
+      today: parcel.today
+      tomorrow: parcel.tomorrow
 
     weather:
       title: weather.title

--- a/lib/trmnl/i18n/locales/plugin_renders/raw.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/raw.yml
@@ -8,6 +8,32 @@ raw:
       days_passed: days_left_year.title
       days_left: days_left_year.title
 
+    parcel:
+      delivery_by: parcel.delivery_by
+      empty: parcel.empty
+      errors:
+        api: parcel.errors.api
+        http: parcel.errors.http
+        internal: parcel.errors.internal
+      filter_modes:
+        active:
+          one: parcel.filter_modes.active.one
+          other: parcel.filter_modes.active.other
+        recent:
+          one: parcel.filter_modes.recent.one
+          other: parcel.filter_modes.recent.other
+      status:
+        delivered: parcel.status.delivered
+        delivery_exception: parcel.status.delivery_exception
+        expecting_pickup: parcel.status.expecting_pickup
+        failed_delivery_attempt: parcel.status.failed_delivery_attempt
+        frozen: parcel.status.frozen
+        in_transit: parcel.status.in_transit
+        information_received: parcel.status.information_received
+        not_found: parcel.status.not_found
+        out_for_delivery: parcel.status.out_for_delivery
+        unknown: parcel.status.unknown
+
     weather:
       title: weather.title
       temperature: weather.temperature

--- a/lib/trmnl/i18n/locales/plugin_renders/uk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/uk.yml
@@ -1,7 +1,6 @@
 uk:
   # namespace to not interfere with other localizations
   renders:
-
     # plugin-specific localizations; alphabetize by plugin's keyname
     days_left_year:
       title: Days Left This Year
@@ -33,6 +32,8 @@ uk:
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: Weather

--- a/lib/trmnl/i18n/locales/plugin_renders/uk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/uk.yml
@@ -8,6 +8,32 @@ uk:
       days_passed: Days Passed
       days_left: Days Left
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: Weather
       temperature: Temperature

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
@@ -8,6 +8,32 @@ zh-CN:
       days_passed: Days Passed
       days_left: Days Left
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: Weather
       temperature: Temperature

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
@@ -1,7 +1,6 @@
 zh-CN:
   # namespace to not interfere with other localizations
   renders:
-
     # plugin-specific localizations; alphabetize by plugin's keyname
     days_left_year:
       title: Days Left This Year
@@ -33,6 +32,8 @@ zh-CN:
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: Weather

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
@@ -1,7 +1,6 @@
 zh-HK:
   # namespace to not interfere with other localizations
   renders:
-
     # plugin-specific localizations; alphabetize by plugin's keyname
     days_left_year:
       title: 今年剩餘日數
@@ -33,6 +32,8 @@ zh-HK:
         not_found: Not Found
         out_for_delivery: Out For Delivery
         unknown: Unknown
+      today: Today
+      tomorrow: Tomorrow
 
     weather:
       title: 天氣

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
@@ -8,6 +8,32 @@ zh-HK:
       days_passed: 經過日數
       days_left: 剩餘日數
 
+    parcel:
+      delivery_by: Delivery by
+      empty: There are no deliveries
+      errors:
+        api: Parcel API error
+        http: HTTP error %{code}
+        internal: Internal error
+      filter_modes:
+        active:
+          one: Active Delivery
+          other: Active Deliveries
+        recent:
+          one: Recent Delivery
+          other: Recent Deliveries
+      status:
+        delivered: Delivered
+        delivery_exception: Delivery Exception
+        expecting_pickup: Expecting Pickup
+        failed_delivery_attempt: Failed Delivery Attempt
+        frozen: Frozen
+        in_transit: In Transit
+        information_received: Information Received
+        not_found: Not Found
+        out_for_delivery: Out For Delivery
+        unknown: Unknown
+
     weather:
       title: 天氣
       temperature: 氣溫


### PR DESCRIPTION
## Overview
This adds i18n translations for the new Parcel native plugin.

They are all in English.