### PR TITLE
Fix ym_format typo

### DIFF
--- a/lib/trmnl/i18n/locales/custom_plugins/ko.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/ko.yml
@@ -94,7 +94,7 @@ ko:
         - 赤口
         nengo:
           reiwa: 레이와
-        ym_format: "%Y년 (%{nengo}% {alt_year}년) %-m월"
+        ym_format: "%Y년 (%{nengo} %{alt_year}년) %-m월"
         year_1: 원
       hebrew:
         ym_format: ", %{month_label} %{alt_year}"


### PR DESCRIPTION
## Overview
Space character in a loc string got misplaced. Only affects a rare case where the Japanese calendar is displayed in Korean locale.

## Screenshots/Screencasts
Right hand side of title bar.
<img width="793" alt="image" src="https://github.com/user-attachments/assets/d26ea88f-3e02-4f4c-8524-c48d1370c601" />

## Details
<!-- Optional. List the key features/highlights as bullet points. -->
