### PR TITLE
Updated formatting of YAML output in Repo#save

### DIFF
--- a/lib/trmnl/i18n/synchronization/repo.rb
+++ b/lib/trmnl/i18n/synchronization/repo.rb
@@ -24,7 +24,11 @@ module TRMNL
 
         def load(locale) = YAML.load_file locale_path(locale)
 
-        def save(locale, data) = locale_path(locale).write data.to_yaml
+        def save locale, data
+          File.open locale_path(locale), "w" do |file|
+            Psych.dump data, file, indentation: 2, line_width: -1
+          end
+        end
 
         def locales = directory.files("*.yml").map { |path| path.name.to_s }
 

--- a/spec/lib/trmnl/i18n/synchronization/repo_spec.rb
+++ b/spec/lib/trmnl/i18n/synchronization/repo_spec.rb
@@ -52,5 +52,24 @@ RSpec.describe TRMNL::I18n::Synchronization::Repo do
       result = repo.load "fr"
       expect(result).to eq("fr" => {"hello" => "Bonjour", "world" => "Monde"})
     end
+
+    it "saves YAML content with desired formatting" do
+      repo.save "fr",
+                "fr" => {
+                  "lorem_ipsum" => "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " \
+                                   "Sed do eiusmod tempor incididunt ut labore et dolore magna " \
+                                   "aliqua."
+                }
+
+      result = File.read temp_dir.join("fr.yml")
+
+      expected = <<~YAML
+        ---
+        fr:
+          lorem_ipsum: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      YAML
+
+      expect(result).to eq(expected)
+    end
   end
 end


### PR DESCRIPTION
Line wrapping has been disabled, and indentation level is explicitly set. This will minimize the occurence of noisy diffs arising from long translations that would have been automatically wrapped.

Milestone: minor
