### PR TITLE
Refactored repo to use Pathname

### DIFF
--- a/lib/trmnl/i18n/synchronization/repo.rb
+++ b/lib/trmnl/i18n/synchronization/repo.rb
@@ -25,7 +25,7 @@ module TRMNL
         def load(locale) = YAML.load_file locale_path(locale)
 
         def save locale, data
-          File.open locale_path(locale), "w" do |file|
+          locale_path(locale).open "w" do |file|
             Psych.dump data, file, indentation: 2, line_width: -1
           end
         end

--- a/spec/lib/trmnl/i18n/synchronization/repo_spec.rb
+++ b/spec/lib/trmnl/i18n/synchronization/repo_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe TRMNL::I18n::Synchronization::Repo do
                                    "aliqua."
                 }
 
-      result = File.read temp_dir.join("fr.yml")
+      result = temp_dir.join("fr.yml").read
 
       expected = <<~YAML
         ---


### PR DESCRIPTION
## Overview

We already use pathnames for all of our paths so good to keep this code consistent in terms of readability but also encourage others to embrace the Pathname API since it's far more powerful than the standard File API.
