### PR TITLE
Updated version

### DIFF
--- a/trmnl-i18n.gemspec
+++ b/trmnl-i18n.gemspec
@@ -2,9 +2,9 @@
 
 Gem::Specification.new do |spec|
   spec.name = "trmnl-i18n"
-  spec.version = "0.1.0"
-  spec.authors = ["Brooke Kuhlmann"]
-  spec.email = ["brooke@alchemists.io"]
+  spec.version = "0.2.0"
+  spec.authors = ["TRMNL"]
+  spec.email = ["support@usetrmnl.com"]
   spec.homepage = "https://github.com/usetrmnl/trmnl-i18n"
   spec.summary = "A collection of TRMNL locales."
   spec.license = "MIT"


### PR DESCRIPTION
## Overview

This preps us for a new gem release. I had created a 0.2.0 tag earlier but forgot to release the gem. I've deleted that tag since this will be the new Version 0.2.0 (because we never published to RubyGems) and ensures our tags are consistent with RubyGems versions.
