### PR TITLE
Removed Git Lint gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gemspec
 
 group :quality do
   gem "caliber", "~> 0.68"
-  gem "git-lint", "~> 9.0"
   gem "reek", "~> 6.4", require: false
   gem "simplecov", "~> 0.22", require: false
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "git/lint/rake/register"
 require "reek/rake/task"
 require "rspec/core/rake_task"
 require "rubocop/rake_task"
 
-Git::Lint::Rake::Register.call
 Reek::Rake::Task.new
 RSpec::Core::RakeTask.new { |task| task.verbose = false }
 RuboCop::RakeTask.new
 
 desc "Run code quality checks"
-task quality: %i[git_lint reek rubocop]
+task quality: %i[reek rubocop]
 
 task default: %i[quality spec]


### PR DESCRIPTION
## Overview

We are removing the linter in order to make community contributions easier at the cost of degrading Git commit history and release note generation. The majority of this gem houses translations with very little code (this is on purpose) that happens to be wrapped as a gem.

This is a partial revert of 90ba60b68ffb (Added project skeleton) when first setting up the project.
