### PR TITLE
Fixed plural keys for recipe forks and installs

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -335,10 +335,10 @@ da:
     connected: Recipe connected
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: Opskrift ikke fundet
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -335,10 +335,10 @@ de-AT:
     connected: Recipe connected
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -335,10 +335,10 @@ de:
     connected: Recipe connected
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -333,10 +333,10 @@ en:
     connected: Recipe connected
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -335,10 +335,10 @@ es-ES:
     connected: Recipe connected
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -335,10 +335,10 @@ fr:
     connected: Recipe connected
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: Recette introuvable
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -335,10 +335,10 @@ he:
     connected: Recipe connected
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -335,10 +335,10 @@ id:
     connected: Recipe connected
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -335,10 +335,10 @@ it:
     connected: Recipe connected
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -335,10 +335,10 @@ ja:
     connected: Recipe connected
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: レシピが見つかりません
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -335,10 +335,10 @@ ko:
     connected: Recipe connected
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -335,10 +335,10 @@ nl:
     connected: Recipe connected
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: Recept niet gevonden
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -335,10 +335,10 @@
     connected: Recipe connected
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: Oppskrift ikke funnet
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -335,10 +335,10 @@ pt-BR:
     connected: Recipe connected
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: Receita não encontrada
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -337,10 +337,10 @@ raw:
     connected: plugin_recipes.connected
     connections:
       one: plugin_recipes.connections.one
-      many: plugin_recipes.connections.many
+      other: plugin_recipes.connections.many
     forks:
       one: plugin_recipes.forks.one
-      many: plugin_recipes.forks.many
+      other: plugin_recipes.forks.many
     new:
       error: plugin_recipes.new.error
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -335,10 +335,10 @@ uk:
     connected: Recipe connected
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -335,10 +335,10 @@ zh-CN:
     connected: Recipe connected
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: Recipe not found
   plugin_settings:

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -335,10 +335,10 @@ zh-HK:
     connected: 已連接模板
     connections:
       one: Connection
-      many: Connections
+      other: Connections
     forks:
       one: Fork
-      many: Forks
+      other: Forks
     new:
       error: 找不到模板
   plugin_settings:


### PR DESCRIPTION
This fixes #87. I should have used the key "other", not "many".