### PR TITLE
Fixed RuboCop Style/RedundantParentheses issues

### DIFF
--- a/spec/lib/trmnl/i18n/custom_plugins_spec.rb
+++ b/spec/lib/trmnl/i18n/custom_plugins_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Custom Plugins", type: :feature do
   Bundler.root.join("lib/trmnl/i18n/locales/custom_plugins").files("*.yml").each do |path|
     it "verifies #{path.name} has key parity with default locale" do
       current = YAML.safe_load(path.read).fetch(path.name.to_s).flatten_keys.keys
-      expect((default - current)).to eq([])
+      expect(default - current).to eq([])
     end
   end
 end

--- a/spec/lib/trmnl/i18n/plugin_readers_spec.rb
+++ b/spec/lib/trmnl/i18n/plugin_readers_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Plugin Renders", type: :feature do
   Bundler.root.join("lib/trmnl/i18n/locales/plugin_renders").files("*.yml").each do |path|
     it "verifies #{path.name} has key parity with default locale" do
       current = YAML.safe_load(path.read).fetch(path.name.to_s).flatten_keys.keys
-      expect((default - current)).to eq([])
+      expect(default - current).to eq([])
     end
   end
 end

--- a/spec/lib/trmnl/i18n/web_ui_spec.rb
+++ b/spec/lib/trmnl/i18n/web_ui_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Web UI", type: :feature do
   Bundler.root.join("lib/trmnl/i18n/locales/web_ui").files("*.yml").each do |path|
     it "verifies #{path.name} has key parity with default locale" do
       current = YAML.safe_load(path.read).fetch(path.name.to_s).flatten_keys.keys
-      expect((default - current)).to eq([])
+      expect(default - current).to eq([])
     end
   end
 end


### PR DESCRIPTION
## Overview

RuboCop fixed this issue in Version 1.75.3, I think, so I ran auto-correct to fix this.
