### PR TITLE
Added friendly locale_name to improve web app dropdown picker

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -1,5 +1,6 @@
 ---
 da:
+  locale_name: Dansk
   add: Tilføj
   add_new: Tilføj ny
   ago: siden

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -1,5 +1,6 @@
 ---
 de-AT:
+  locale_name: Deutsch (Austria)
   add: Hinzufügen
   add_new: Neu hinzufügen
   ago: ago

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -1,5 +1,6 @@
 ---
 de:
+  locale_name: Deutsch
   add: Hinzufügen
   add_new: Neu hinzufügen
   ago: ago

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -1,5 +1,6 @@
 ---
 en:
+  locale_name: English
   add: Add
   add_new: Add new
   ago: ago

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -1,5 +1,6 @@
 ---
 es-ES:
+  locale_name: Español (España)
   add: Crear
   add_new: Crear nuevo
   ago: ago

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -1,5 +1,6 @@
 ---
 fr:
+  locale_name: Française
   add: Ajouter
   add_new: Ajouter nouveau
   ago: plutôt

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -1,5 +1,6 @@
 ---
 he:
+  locale_name: Hebrew
   add: Add
   add_new: Add new
   ago: ago

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -1,5 +1,6 @@
 ---
 id:
+  locale_name: Indonesian
   add: Tambah
   add_new: Tambah baru
   ago: ago

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -1,5 +1,6 @@
 ---
 it:
+  locale_name: Italiano
   add: Aggiungi
   add_new: Aggiungi nuovo
   ago: fa

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -1,5 +1,6 @@
 ---
 ja:
+  locale_name: 日本語
   add: 追加
   add_new: 新規追加
   ago: ago

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -1,5 +1,6 @@
 ---
 ko:
+  locale_name: 한국어
   add: 추가하기
   add_new: 새로 추가하기
   ago: ago

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -1,5 +1,6 @@
 ---
 nl:
+  locale_name: Dutch
   add: Toevoegen
   add_new: Nieuwe toevoegen
   ago: ago

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -1,5 +1,6 @@
 ---
 'no':
+  locale_name: Norwegian
   add: Legg til
   add_new: Legg til ny
   ago: siden

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -1,5 +1,6 @@
 ---
 pt-BR:
+  locale_name: Portuguese (Brazil)
   add: Adicionar
   add_new: Adicionar novo
   ago: ago

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -1,5 +1,6 @@
 ---
 raw:
+  locale_name: locale_name
   add: add
   add_new: add_new
   ago: ago

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -1,5 +1,6 @@
 ---
 uk:
+  locale_name: Ukrainian
   add: Додати
   add_new: Додати новий
   ago: ago

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -1,5 +1,6 @@
 ---
 zh-CN:
+  locale_name: Chinese (Simplified)
   add: 添加
   add_new: 添加新设备
   ago: 之前

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -1,5 +1,6 @@
 ---
 zh-HK:
+  locale_name: Chinese (Hong Kong)
   add: 加入
   add_new: 新增
   ago: 前


### PR DESCRIPTION
## Overview
a user mentioned that our iso639 dropdown values are a bit confusing, and i agree.

<img width="513" alt="image" src="https://github.com/user-attachments/assets/ded94d86-7c19-42bb-91e6-ac987ed1385e" />

this PR lets the core web app expose friendlier labels in the relevant locale's language. stubbed a few to get us started.