### PR TITLE
Added German rail departure custom plugin locales

### DIFF
--- a/lib/trmnl/i18n/locales/custom_plugins/da.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/da.yml
@@ -3,6 +3,16 @@ da:
   custom_plugins:
     today: i dag
     tomorrow: i morgen
+    deutsche_bahn_departures:
+      time: Time
+      destination: Destination
+      platform: Platform
+      delay: Delay
+      train: Train
+      on_time: On time
+      cancelled: Cancelled
+      minutes: m
+      refreshed: Refreshed
     simple_calendar:
       title: Kalender
       ym_format: "%B %Y"

--- a/lib/trmnl/i18n/locales/custom_plugins/de-AT.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/de-AT.yml
@@ -3,6 +3,16 @@ de-AT:
   custom_plugins:
     today: Heute
     tomorrow: Morgen
+    deutsche_bahn_departures:
+      time: Time
+      destination: Destination
+      platform: Platform
+      delay: Delay
+      train: Train
+      on_time: On time
+      cancelled: Cancelled
+      minutes: m
+      refreshed: Refreshed
     simple_calendar:
       title: Kalender
       ym_format: "%B %Y"

--- a/lib/trmnl/i18n/locales/custom_plugins/de.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/de.yml
@@ -3,6 +3,16 @@ de:
   custom_plugins:
     today: Heute
     tomorrow: Morgen
+    deutsche_bahn_departures:
+      time: Zeit
+      destination: Ziel
+      platform: Gleis
+      delay: Versp.
+      train: Zug
+      on_time: pünktl.
+      cancelled: fällt aus
+      minutes: Min.
+      refreshed: aktualisiert
     simple_calendar:
       title: Kalender
       ym_format: "%B %Y"

--- a/lib/trmnl/i18n/locales/custom_plugins/en.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/en.yml
@@ -3,6 +3,16 @@ en:
   custom_plugins:
     today: today
     tomorrow: tomorrow
+    deutsche_bahn_departures:
+      time: Time
+      destination: Destination
+      platform: Platform
+      delay: Delay
+      train: Train
+      on_time: On time
+      cancelled: Cancelled
+      minutes: m
+      refreshed: Refreshed
     simple_calendar:
       title: Calendar
       ym_format: "%B %Y"

--- a/lib/trmnl/i18n/locales/custom_plugins/es-ES.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/es-ES.yml
@@ -3,6 +3,16 @@ es-ES:
   custom_plugins:
     today: hoy
     tomorrow: mañana
+    deutsche_bahn_departures:
+      time: Time
+      destination: Destination
+      platform: Platform
+      delay: Delay
+      train: Train
+      on_time: On time
+      cancelled: Cancelled
+      minutes: m
+      refreshed: Refreshed
     simple_calendar:
       title: Calendario
       ym_format: "%B %Y"

--- a/lib/trmnl/i18n/locales/custom_plugins/fr.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/fr.yml
@@ -3,6 +3,16 @@ fr:
   custom_plugins:
     today: aujourd'hui
     tomorrow: demain
+    deutsche_bahn_departures:
+      time: Time
+      destination: Destination
+      platform: Platform
+      delay: Delay
+      train: Train
+      on_time: On time
+      cancelled: Cancelled
+      minutes: m
+      refreshed: Refreshed
     simple_calendar:
       title: Calendrier
       ym_format: "%B %Y"

--- a/lib/trmnl/i18n/locales/custom_plugins/he.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/he.yml
@@ -3,6 +3,16 @@ he:
   custom_plugins:
     today: היום
     tomorrow: מחר
+    deutsche_bahn_departures:
+      time: Time
+      destination: Destination
+      platform: Platform
+      delay: Delay
+      train: Train
+      on_time: On time
+      cancelled: Cancelled
+      minutes: m
+      refreshed: Refreshed
     simple_calendar:
       title: לוח שנה
       ym_format: "%B %Y"

--- a/lib/trmnl/i18n/locales/custom_plugins/id.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/id.yml
@@ -3,6 +3,16 @@ id:
   custom_plugins:
     today: today
     tomorrow: tomorrow
+    deutsche_bahn_departures:
+      time: Time
+      destination: Destination
+      platform: Platform
+      delay: Delay
+      train: Train
+      on_time: On time
+      cancelled: Cancelled
+      minutes: m
+      refreshed: Refreshed
     simple_calendar:
       title: Kalender
       ym_format: "%B %Y"

--- a/lib/trmnl/i18n/locales/custom_plugins/it.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/it.yml
@@ -3,6 +3,16 @@ it:
   custom_plugins:
     today: Oggi
     tomorrow: Domani
+    deutsche_bahn_departures:
+      time: Time
+      destination: Destination
+      platform: Platform
+      delay: Delay
+      train: Train
+      on_time: On time
+      cancelled: Cancelled
+      minutes: m
+      refreshed: Refreshed
     simple_calendar:
       title: Calendario
       ym_format: "%B %Y"

--- a/lib/trmnl/i18n/locales/custom_plugins/ja.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/ja.yml
@@ -3,6 +3,16 @@ ja:
   custom_plugins:
     today: 今日
     tomorrow: 明日
+    deutsche_bahn_departures:
+      time: Time
+      destination: Destination
+      platform: Platform
+      delay: Delay
+      train: Train
+      on_time: On time
+      cancelled: Cancelled
+      minutes: m
+      refreshed: Refreshed
     simple_calendar:
       title: カレンダー
       ym_format: "%Y年%-m月"

--- a/lib/trmnl/i18n/locales/custom_plugins/ko.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/ko.yml
@@ -3,6 +3,16 @@ ko:
   custom_plugins:
     today: 오늘
     tomorrow: 내일
+    deutsche_bahn_departures:
+      time: Time
+      destination: Destination
+      platform: Platform
+      delay: Delay
+      train: Train
+      on_time: On time
+      cancelled: Cancelled
+      minutes: m
+      refreshed: Refreshed
     simple_calendar:
       title: 캘린더
       ym_format: "%Y년 %-m월"

--- a/lib/trmnl/i18n/locales/custom_plugins/nl.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/nl.yml
@@ -3,6 +3,16 @@ nl:
   custom_plugins:
     today: vandaag
     tomorrow: morgen
+    deutsche_bahn_departures:
+      time: Time
+      destination: Destination
+      platform: Platform
+      delay: Delay
+      train: Train
+      on_time: On time
+      cancelled: Cancelled
+      minutes: m
+      refreshed: Refreshed
     simple_calendar:
       title: Kalender
       ym_format: "%B %Y"

--- a/lib/trmnl/i18n/locales/custom_plugins/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/pt-BR.yml
@@ -3,6 +3,16 @@ pt-BR:
   custom_plugins:
     today: hoje
     tomorrow: amanhã
+    deutsche_bahn_departures:
+      time: Time
+      destination: Destination
+      platform: Platform
+      delay: Delay
+      train: Train
+      on_time: On time
+      cancelled: Cancelled
+      minutes: m
+      refreshed: Refreshed
     simple_calendar:
       title: Calendário
       ym_format: "%B de %Y"

--- a/lib/trmnl/i18n/locales/custom_plugins/raw.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/raw.yml
@@ -3,6 +3,16 @@ raw:
   custom_plugins:
     today: today
     tomorrow: tomorrow
+    deutsche_bahn_departures:
+      time: Time
+      destination: Destination
+      platform: Platform
+      delay: Delay
+      train: Train
+      on_time: On time
+      cancelled: Cancelled
+      minutes: m
+      refreshed: Refreshed
     simple_calendar:
       title: Calendar
       ym_format: "%B %Y"

--- a/lib/trmnl/i18n/locales/custom_plugins/uk.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/uk.yml
@@ -3,6 +3,16 @@ uk:
   custom_plugins:
     today: today
     tomorrow: tomorrow
+    deutsche_bahn_departures:
+      time: Time
+      destination: Destination
+      platform: Platform
+      delay: Delay
+      train: Train
+      on_time: On time
+      cancelled: Cancelled
+      minutes: m
+      refreshed: Refreshed
     simple_calendar:
       title: Календар
       ym_format: "%b %Y р."

--- a/lib/trmnl/i18n/locales/custom_plugins/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/zh-CN.yml
@@ -3,6 +3,16 @@ zh-CN:
   custom_plugins:
     today: today
     tomorrow: tomorrow
+    deutsche_bahn_departures:
+      time: Time
+      destination: Destination
+      platform: Platform
+      delay: Delay
+      train: Train
+      on_time: On time
+      cancelled: Cancelled
+      minutes: m
+      refreshed: Refreshed
     simple_calendar:
       title: 日历
       ym_format: "%Y年%-m月"

--- a/lib/trmnl/i18n/locales/custom_plugins/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/zh-HK.yml
@@ -3,6 +3,16 @@ zh-HK:
   custom_plugins:
     today: 今日
     tomorrow: 明日
+    deutsche_bahn_departures:
+      time: Time
+      destination: Destination
+      platform: Platform
+      delay: Delay
+      train: Train
+      on_time: On time
+      cancelled: Cancelled
+      minutes: m
+      refreshed: Refreshed
     simple_calendar:
       title: 日曆
       ym_format: "%Y年%-m月"


### PR DESCRIPTION
## Overview

Necessary to support locales for the Deutsche Bahn Departures plugin.

## Details

- This completes the work started by @DavidOrtmann.
- I folded in David's work by squashing all commits into one and running `bin/sync` to populate all missing translations. All specs pass now.
