### PR TITLE
Update de.yml

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -3,7 +3,7 @@ de:
   locale_name: Deutsch
   add: Hinzufügen
   add_new: Neu hinzufügen
-  ago: alt
+  ago: vor
   already_have_account: Ich besitze bereits ein Konto
   back: Zurück
   back_to_all_blog_posts: Zurück zu allen Posts
@@ -141,12 +141,12 @@ de:
       developer_perks: Nur für Entwickler
       developer_perks_hint: Für die folgenden Optionen ist das __Entwickler-Add-on__ erforderlich.
       device_credentials: Geräteinformationen
-      device_credentials_hint: Lerne mehr über die Verwendungsmöglichkeiten der Infos __hier__
+      device_credentials_hint: Erfahre __hier__ mehr über die Verwendungsmöglichkeiten der Infos
       device_name: Gerätename
       device_name_hint: Wir verwenden den Gerätenamen, um die TRMNL-Benutzeroberfläche zu personalisieren.
-      device_model: Device Model
-      device_model_hint: Your hardware Model
-      device_model_switch_warning: This is a dangerous operation, learn more __here__
+      device_model: Gerätemodell
+      device_model_hint: Dein Hardware-Modell
+      device_model_switch_warning: Diese Aktion kann gefährlich sein, erfahre __hier__ mehr darüber
       edit_device: Gerät bearbeiten
       identify: Identifizieren
       identify_device: Gerät identifizieren
@@ -217,7 +217,7 @@ de:
       time: Zeit
   markups:
     console_logs:
-      js_logs: JS Logs
+      js_logs: JS-Logs
     form:
       back_to_plugin_settings: Zurück zu den Erweiterungs-Einstellungen
       design_system: Nutze unser natives Design-System


### PR DESCRIPTION
Add missing translations

Note: `ago` is not working correctly right now, since it requires another word order; would need `%{count} ago` => `vor %{count}` to work as intended.

## Overview
<!-- Required. Why is this important/necessary and what is the overarching architecture. -->

## Screenshots/Screencasts
<!-- Optional. Provide supporting image/video. -->

## Details
<!-- Optional. List the key features/highlights as bullet points. -->
