### PR TITLE
Added lunar phases translations to es-ES

### DIFF
--- a/lib/trmnl/i18n/locales/plugin_renders/da.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/da.yml
@@ -14,6 +14,15 @@ da:
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
@@ -14,6 +14,15 @@ de-AT:
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Lieferung bis
       empty: Es gibt keine Lieferungen

--- a/lib/trmnl/i18n/locales/plugin_renders/de.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de.yml
@@ -14,6 +14,15 @@ de:
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Lieferung bis
       empty: Es gibt keine Lieferungen

--- a/lib/trmnl/i18n/locales/plugin_renders/en.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/en.yml
@@ -14,6 +14,15 @@ en:
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
@@ -7,13 +7,22 @@ es-ES:
       days_left: Días Restantes
     lunar_calendar:
       title: Calendario Lunar
-      age: Lunar Age
-      current_phase: Current Phase
-      illumination: Moon Illumination
-      next_full_moon: Next Full Moon
-      next_new_moon: Next New Moon
-      next_phase: Next Phase
-      next_phase_short: Next
+      age: Edad Lunar
+      current_phase: Fase Actual
+      illumination: Luminosidad Lunar
+      next_full_moon: Próxima Luna Llena
+      next_new_moon: Próxima Luna Nueva
+      next_phase: Próxima Fase
+      next_phase_short: Próxima
+      moon_phases:
+        new_moon: Luna Nueva
+        waxing_crescent: Creciente Cóncava
+        first_quarter: Cuarto Creciente
+        waxing_gibbous: Creciente Convexa
+        full_moon: Luna Llena
+        waning_gibbous: Menguante Convexa
+        last_quarter: Cuarto Menguante
+        waning_crescent: Menguante Cóncava
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/fr.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/fr.yml
@@ -14,6 +14,15 @@ fr:
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/he.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/he.yml
@@ -14,6 +14,15 @@ he:
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/id.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/id.yml
@@ -14,6 +14,15 @@ id:
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/it.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/it.yml
@@ -14,6 +14,15 @@ it:
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Consegna da
       empty: Non ci sono spedizioni

--- a/lib/trmnl/i18n/locales/plugin_renders/ja.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ja.yml
@@ -14,6 +14,15 @@ ja:
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/ko.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ko.yml
@@ -14,6 +14,15 @@ ko:
       next_new_moon: Next New Moon
       next_phase: 다음 단계
       next_phase_short: 다음
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/nl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/nl.yml
@@ -14,6 +14,15 @@ nl:
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/no.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/no.yml
@@ -14,6 +14,15 @@
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/pl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pl.yml
@@ -14,6 +14,15 @@ pl:
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
@@ -14,6 +14,15 @@ pt-BR:
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/raw.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/raw.yml
@@ -14,6 +14,15 @@ raw:
       next_new_moon: renders.lunar_calendar.next_new_moon
       next_phase: renders.lunar_calendar.next_phase
       next_phase_short: renders.lunar_calendar.next_phase_short
+      moon_phases:
+        new_moon: renders.lunar_calendar.moon_phases.new_moon
+        waxing_crescent: renders.lunar_calendar.moon_phases.waxing_crescent
+        first_quarter: renders.lunar_calendar.moon_phases.first_quarter
+        waxing_gibbous: renders.lunar_calendar.moon_phases.waxing_gibbous
+        full_moon: renders.lunar_calendar.moon_phases.full_moon
+        waning_gibbous: renders.lunar_calendar.moon_phases.waning_gibbous
+        last_quarter: renders.lunar_calendar.moon_phases.last_quarter
+        waning_crescent: renders.lunar_calendar.moon_phases.waning_crescent
     parcel:
       delivery_by: parcel.delivery_by
       empty: parcel.empty

--- a/lib/trmnl/i18n/locales/plugin_renders/sv.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sv.yml
@@ -14,6 +14,15 @@ sv:
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/uk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/uk.yml
@@ -14,6 +14,15 @@ uk:
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
@@ -14,6 +14,15 @@ zh-CN:
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
@@ -14,6 +14,15 @@ zh-HK:
       next_new_moon: Next New Moon
       next_phase: Next Phase
       next_phase_short: Next
+      moon_phases:
+        new_moon: New Moon
+        waxing_crescent: Waxing Crescent
+        first_quarter: First Quarter
+        waxing_gibbous: Waxing Gibbous
+        full_moon: Full Moon
+        waning_gibbous: Waning Gibbous
+        last_quarter: Last Quarter
+        waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries


### PR DESCRIPTION
## Overview
The lunar phases were added as keys to `en` and then translated in `es-ES`.