### PR TITLE
Add date format localization system

### DIFF
--- a/lib/trmnl/i18n/locales/plugin_renders/da.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/da.yml
@@ -61,3 +61,14 @@ da:
       right_now: Lige nu
       today: I dag
       tomorrow: I morgen
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
@@ -61,3 +61,14 @@ de-AT:
       right_now: Jetzt
       today: Heute
       tomorrow: Morgen
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/de.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de.yml
@@ -61,3 +61,14 @@ de:
       right_now: jetzt
       today: heute
       tomorrow: morgen
+  date:
+    formats:
+      short: "%d.%m.%Y"
+      short_weekday: "%a %d.%m"
+      numeric: "%d.%m.%Y"
+      medium: "%d. %b %Y"
+      medium_no_year: "%d. %B"
+      month_day: "%d. %B"
+      long: "%A, %d. %B %Y"
+      long_no_year: "%A, %d. %B"
+      full: "%d. %B %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/en.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/en.yml
@@ -61,3 +61,14 @@ en:
       right_now: Right Now
       today: Today
       tomorrow: Tomorrow
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
@@ -61,3 +61,14 @@ es-ES:
       right_now: Ahora
       today: Hoy
       tomorrow: Mañana
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/fr.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/fr.yml
@@ -61,3 +61,14 @@ fr:
       right_now: Maintenant
       today: Aujourd'hui
       tomorrow: Demain
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/he.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/he.yml
@@ -61,3 +61,14 @@ he:
       right_now: כעת
       today: היום
       tomorrow: מחר
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/id.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/id.yml
@@ -61,3 +61,14 @@ id:
       right_now: Right Now
       today: Today
       tomorrow: Tomorrow
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/it.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/it.yml
@@ -61,3 +61,14 @@ it:
       right_now: Adesso
       today: Oggi
       tomorrow: Domani
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/ja.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ja.yml
@@ -61,3 +61,14 @@ ja:
       right_now: 現在
       today: 今日
       tomorrow: 明日
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/ko.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ko.yml
@@ -61,3 +61,14 @@ ko:
       right_now: 지금
       today: 오늘
       tomorrow: 내일
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/nl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/nl.yml
@@ -61,3 +61,14 @@ nl:
       right_now: Op dit moment
       today: Vandaag
       tomorrow: Morgen
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/no.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/no.yml
@@ -61,3 +61,14 @@
       right_now: Akkurat nå
       today: I dag
       tomorrow: I morgen
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/pl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pl.yml
@@ -61,6 +61,17 @@ pl:
       right_now: Right Now
       today: Today
       tomorrow: Tomorrow
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"
   custom_plugins:
     today: today
     tomorrow: tomorrow

--- a/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
@@ -61,3 +61,14 @@ pt-BR:
       right_now: Agora
       today: Hoje
       tomorrow: Amanhã
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/raw.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/raw.yml
@@ -61,3 +61,14 @@ raw:
       right_now: weather.right_now
       today: weather.today
       tomorrow: weather.tomorrow
+  date:
+    formats:
+      short: date.formats.short
+      short_weekday: date.formats.short_weekday
+      numeric: date.formats.numeric
+      medium: date.formats.medium
+      medium_no_year: date.formats.medium_no_year
+      month_day: date.formats.month_day
+      long: date.formats.long
+      long_no_year: date.formats.long_no_year
+      full: date.formats.full

--- a/lib/trmnl/i18n/locales/plugin_renders/sv.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sv.yml
@@ -61,3 +61,14 @@ sv:
       right_now: Right Now
       today: Today
       tomorrow: Tomorrow
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/uk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/uk.yml
@@ -61,3 +61,14 @@ uk:
       right_now: Right Now
       today: Today
       tomorrow: Tomorrow
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
@@ -61,3 +61,14 @@ zh-CN:
       right_now: Right Now
       today: Today
       tomorrow: Tomorrow
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
@@ -61,3 +61,14 @@ zh-HK:
       right_now: 即時
       today: 今日
       tomorrow: 明日
+  date:
+    formats:
+      short: "%m/%d/%Y"
+      short_weekday: "%a %m/%d"
+      numeric: "%Y-%m-%d"
+      medium: "%b %d, %Y"
+      medium_no_year: "%B %d"
+      month_day: "%B %d"
+      long: "%A, %B %d, %Y"
+      long_no_year: "%A, %B %d"
+      full: "%B %d, %Y"


### PR DESCRIPTION
## Overview
This PR establishes a robust internationalization foundation for date formatting that can be culturally adapted across different locales. (Personal note: This is a first for me, so please review and let me know if this is going into the right direction.)

## Screenshots/Screencasts
<!-- Optional. Provide supporting image/video. -->

## Details
- **Created standardized date format structure** in `raw.yml` and `en.yml` as base templates
- **Implemented consistent naming convention**: `[length]_[modifier]` (e.g., `short`, `medium`, `long_no_year`)
- **Defined comprehensive format coverage** for common date display patterns already used in existing TRMNL plugins:
  - Short formats: numeric and abbreviated styles
  - Medium formats: with/without year variants
  - Long formats: including weekday variations
- **Added German localization** as first cultural adaptation example
- Date formats can now be localized in ERB templates.