### PR TITLE
Prepare localization of hardcoded 'and x more' string in plugins

### DIFF
--- a/lib/trmnl/i18n/locales/plugin_renders/da.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/da.yml
@@ -61,3 +61,4 @@ da:
       right_now: Lige nu
       today: I dag
       tomorrow: I morgen
+    and_more: And %{hidden_events_count} more

--- a/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
@@ -61,3 +61,4 @@ de-AT:
       right_now: Jetzt
       today: Heute
       tomorrow: Morgen
+    and_more: And %{hidden_events_count} more

--- a/lib/trmnl/i18n/locales/plugin_renders/de.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de.yml
@@ -61,3 +61,4 @@ de:
       right_now: jetzt
       today: heute
       tomorrow: morgen
+    and_more: Und %{hidden_events_count} weitere

--- a/lib/trmnl/i18n/locales/plugin_renders/en.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/en.yml
@@ -61,3 +61,4 @@ en:
       right_now: Right Now
       today: Today
       tomorrow: Tomorrow
+    and_more: And %{hidden_events_count} more

--- a/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
@@ -61,3 +61,4 @@ es-ES:
       right_now: Ahora
       today: Hoy
       tomorrow: Mañana
+    and_more: And %{hidden_events_count} more

--- a/lib/trmnl/i18n/locales/plugin_renders/fr.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/fr.yml
@@ -61,3 +61,4 @@ fr:
       right_now: Maintenant
       today: Aujourd'hui
       tomorrow: Demain
+    and_more: And %{hidden_events_count} more

--- a/lib/trmnl/i18n/locales/plugin_renders/he.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/he.yml
@@ -61,3 +61,4 @@ he:
       right_now: כעת
       today: היום
       tomorrow: מחר
+    and_more: And %{hidden_events_count} more

--- a/lib/trmnl/i18n/locales/plugin_renders/id.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/id.yml
@@ -61,3 +61,4 @@ id:
       right_now: Right Now
       today: Today
       tomorrow: Tomorrow
+    and_more: And %{hidden_events_count} more

--- a/lib/trmnl/i18n/locales/plugin_renders/it.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/it.yml
@@ -61,3 +61,4 @@ it:
       right_now: Adesso
       today: Oggi
       tomorrow: Domani
+    and_more: And %{hidden_events_count} more

--- a/lib/trmnl/i18n/locales/plugin_renders/ja.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ja.yml
@@ -61,3 +61,4 @@ ja:
       right_now: 現在
       today: 今日
       tomorrow: 明日
+    and_more: And %{hidden_events_count} more

--- a/lib/trmnl/i18n/locales/plugin_renders/ko.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ko.yml
@@ -61,3 +61,4 @@ ko:
       right_now: 지금
       today: 오늘
       tomorrow: 내일
+    and_more: And %{hidden_events_count} more

--- a/lib/trmnl/i18n/locales/plugin_renders/nl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/nl.yml
@@ -61,3 +61,4 @@ nl:
       right_now: Op dit moment
       today: Vandaag
       tomorrow: Morgen
+    and_more: And %{hidden_events_count} more

--- a/lib/trmnl/i18n/locales/plugin_renders/no.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/no.yml
@@ -61,3 +61,4 @@
       right_now: Akkurat nå
       today: I dag
       tomorrow: I morgen
+    and_more: And %{hidden_events_count} more

--- a/lib/trmnl/i18n/locales/plugin_renders/pl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pl.yml
@@ -61,6 +61,7 @@ pl:
       right_now: Right Now
       today: Today
       tomorrow: Tomorrow
+    and_more: And %{hidden_events_count} more
   custom_plugins:
     today: today
     tomorrow: tomorrow

--- a/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
@@ -61,3 +61,4 @@ pt-BR:
       right_now: Agora
       today: Hoje
       tomorrow: Amanhã
+    and_more: And %{hidden_events_count} more

--- a/lib/trmnl/i18n/locales/plugin_renders/raw.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/raw.yml
@@ -61,3 +61,4 @@ raw:
       right_now: weather.right_now
       today: weather.today
       tomorrow: weather.tomorrow
+    and_more: renders.and_more

--- a/lib/trmnl/i18n/locales/plugin_renders/sv.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sv.yml
@@ -61,3 +61,4 @@ sv:
       right_now: Right Now
       today: Today
       tomorrow: Tomorrow
+    and_more: And %{hidden_events_count} more

--- a/lib/trmnl/i18n/locales/plugin_renders/uk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/uk.yml
@@ -61,3 +61,4 @@ uk:
       right_now: Right Now
       today: Today
       tomorrow: Tomorrow
+    and_more: And %{hidden_events_count} more

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
@@ -61,3 +61,4 @@ zh-CN:
       right_now: Right Now
       today: Today
       tomorrow: Tomorrow
+    and_more: And %{hidden_events_count} more

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
@@ -61,3 +61,4 @@ zh-HK:
       right_now: 即時
       today: 今日
       tomorrow: 明日
+    and_more: And %{hidden_events_count} more


### PR DESCRIPTION
## Overview
Added `and_more` key to all locale files to replace the hardcoded "and x more" string. In English it would show e.g. "And 7 more" (as current) and in e.g. German "Und 7 weitere".

## Screenshots/Screencasts
<!-- Optional. Provide supporting image/video. -->

## Details
This is a necessary step to support proper localization of calendar and other plugins that mention hidden entries because of space constraints. If this PR is greenlit, the line `<span class="title title--<%= heading_size %>">And <%= hidden_events_count %> more</span>` in various plugins could be changed to `<span class="title title--<%= heading_size %>"><%= t('and_more', hidden_events_count: hidden_events_count) %></span>` in the /plugins repo.