### PR TITLE
Fixes for Lunar Calendar es-ES

### DIFF
--- a/lib/trmnl/i18n/locales/plugin_renders/da.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/da.yml
@@ -21,7 +21,7 @@ da:
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by

--- a/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
@@ -21,7 +21,7 @@ de-AT:
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Lieferung bis

--- a/lib/trmnl/i18n/locales/plugin_renders/de.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de.yml
@@ -21,7 +21,7 @@ de:
         waxing_gibbous: Zunehmender Mond
         full_moon: Vollmond
         waning_gibbous: Abnehmender Mond
-        last_quarter: Letztes Viertel
+        third_quarter: Letztes Viertel
         waning_crescent: Abnehmende Sichel
     parcel:
       delivery_by: Lieferung bis

--- a/lib/trmnl/i18n/locales/plugin_renders/en.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/en.yml
@@ -21,7 +21,7 @@ en:
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by

--- a/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
@@ -11,18 +11,18 @@ es-ES:
       current_phase: Fase Actual
       illumination: Luminosidad Lunar
       next_full_moon: Próxima Luna Llena
-      next_new_moon: Próxima Luna Nueva
+      next_new_moon: Próx. Luna Nueva
       next_phase: Próxima Fase
-      next_phase_short: Próxima
+      next_phase_short: Próx.
       moon_phases:
         new_moon: Luna Nueva
-        waxing_crescent: Creciente Cóncava
+        waxing_crescent: Luna Creciente
         first_quarter: Cuarto Creciente
-        waxing_gibbous: Creciente Convexa
+        waxing_gibbous: Gibosa Creciente
         full_moon: Luna Llena
-        waning_gibbous: Menguante Convexa
+        waning_gibbous: Gibosa Menguante
         third_quarter: Cuarto Menguante
-        waning_crescent: Menguante Cóncava
+        waning_crescent: Luna Menguante
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
@@ -21,7 +21,7 @@ es-ES:
         waxing_gibbous: Creciente Convexa
         full_moon: Luna Llena
         waning_gibbous: Menguante Convexa
-        last_quarter: Cuarto Menguante
+        third_quarter: Cuarto Menguante
         waning_crescent: Menguante Cóncava
     parcel:
       delivery_by: Delivery by

--- a/lib/trmnl/i18n/locales/plugin_renders/fr.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/fr.yml
@@ -21,7 +21,7 @@ fr:
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by

--- a/lib/trmnl/i18n/locales/plugin_renders/he.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/he.yml
@@ -21,7 +21,7 @@ he:
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by

--- a/lib/trmnl/i18n/locales/plugin_renders/id.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/id.yml
@@ -21,7 +21,7 @@ id:
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by

--- a/lib/trmnl/i18n/locales/plugin_renders/it.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/it.yml
@@ -21,7 +21,7 @@ it:
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Consegna da

--- a/lib/trmnl/i18n/locales/plugin_renders/ja.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ja.yml
@@ -21,7 +21,7 @@ ja:
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by

--- a/lib/trmnl/i18n/locales/plugin_renders/ko.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ko.yml
@@ -21,7 +21,7 @@ ko:
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by

--- a/lib/trmnl/i18n/locales/plugin_renders/nl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/nl.yml
@@ -21,7 +21,7 @@ nl:
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by

--- a/lib/trmnl/i18n/locales/plugin_renders/no.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/no.yml
@@ -21,7 +21,7 @@
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by

--- a/lib/trmnl/i18n/locales/plugin_renders/pl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pl.yml
@@ -21,7 +21,7 @@ pl:
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by

--- a/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
@@ -21,7 +21,7 @@ pt-BR:
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by

--- a/lib/trmnl/i18n/locales/plugin_renders/raw.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/raw.yml
@@ -21,7 +21,7 @@ raw:
         waxing_gibbous: renders.lunar_calendar.moon_phases.waxing_gibbous
         full_moon: renders.lunar_calendar.moon_phases.full_moon
         waning_gibbous: renders.lunar_calendar.moon_phases.waning_gibbous
-        last_quarter: renders.lunar_calendar.moon_phases.last_quarter
+        third_quarter: renders.lunar_calendar.moon_phases.third_quarter
         waning_crescent: renders.lunar_calendar.moon_phases.waning_crescent
     parcel:
       delivery_by: parcel.delivery_by

--- a/lib/trmnl/i18n/locales/plugin_renders/sv.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sv.yml
@@ -21,7 +21,7 @@ sv:
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by

--- a/lib/trmnl/i18n/locales/plugin_renders/uk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/uk.yml
@@ -21,7 +21,7 @@ uk:
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
@@ -21,7 +21,7 @@ zh-CN:
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
@@ -21,7 +21,7 @@ zh-HK:
         waxing_gibbous: Waxing Gibbous
         full_moon: Full Moon
         waning_gibbous: Waning Gibbous
-        last_quarter: Last Quarter
+        third_quarter: Third Quarter
         waning_crescent: Waning Crescent
     parcel:
       delivery_by: Delivery by


### PR DESCRIPTION
## Overview
- changes `lunar_calendar.moon_phases.last_quarter` to the correct `lunar_calendar.moon_phases.third_quarter` used by the render and re-synched all locales
- used shorter terms on the spanish locale so that they don't break the layouts.
