### PR TITLE
Add new strings for localization

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -155,6 +155,10 @@ da:
     edit:
       accepts_beta_firmware: Firmware Tidlig Udgivelse
       accepts_beta_firmware_hint: Slå til for at få de nyeste firmwareforbedringer før andre brugere.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Tilbage til enheder
       battery_consumption: Batteriforbrug
       battery_consumption_hint: Spar strøm og forlæng batterilevetiden ved at aktivere dvaletilstand.
@@ -163,6 +167,8 @@ da:
       developer_perks_hint: Nogle muligheder kræver __Udviklerudgave-tilføjelse__.
       device_credentials: Enhedsoplysninger
       device_credentials_hint: Se hvad du kan gøre med disse oplysninger __her__
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Enhedsnavn
       device_name_hint: Bruges til at gøre TRMNL-grænsefladen mere personlig
       device_model: Enhedsmodel
@@ -190,6 +196,7 @@ da:
       ota_byod_not_supported: OTA understøttes ikke for BYOD-enheder. Flash en kompatibel version direkte fra usetrmnl.com/flash
       maximum_compatibility: Aktivér maksimal kompatibilitet
       maximum_compatibility_hint: Løser visningsproblemer forårsaget af visse e-ink driverchips. Deaktiverer hurtig opdatering. Firmware 1.6.0+ kræves.
+      refresh_rate: Refresh Rate
       sleep_mode: Dvaletilstand
       sleep_mode_hint: Juster opdateringshastigheden for at optimere fokus og batterilevetid.
       sleep_screen: Dvaleskærm
@@ -207,6 +214,8 @@ da:
       unlink_device_learn_more: Følg den fulde guide __her__.
       visibility: Synlighed
       visibility_hint: Gør din TRMNL-enhed spejlbar ved at ændre indstillingerne nedenfor.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Din TRMNL
       upgrade_og:
         title: Opgradering til 2-bit Display tilgængelig
@@ -244,6 +253,14 @@ da:
     update:
       error: Fejl ved opdatering af enhed
       success: "%{device} enhedsindstillinger opdateret med succes"
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: For mange forsøg, vent venligst og prøv igen
     invoice_not_found: Faktura ikke fundet
@@ -333,6 +350,8 @@ da:
       displayed_now: Vist nu
       not_displayed_yet: Afventer
       remove_from_playlist: Fjern fra playliste
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Skjul dette element
       show_playlist: Vis dette element
     create:

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -155,6 +155,10 @@ de-AT:
     edit:
       accepts_beta_firmware: Beta-Firmware
       accepts_beta_firmware_hint: Aktiviere diese Option, um vor anderen Benutzern die neuesten Firmware-Updates für das Gerät zu erhalten.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Zurück zur Geräteübersicht
       battery_consumption: Batterieverbrauch
       battery_consumption_hint: Spare Strom und verlängere die Laufzeit durch Aktivierung des Schlafmodus.
@@ -163,6 +167,8 @@ de-AT:
       developer_perks_hint: Für die folgenden Optionen ist das __Entwickler-Add-on__ erforderlich.
       device_credentials: Geräteinformationen
       device_credentials_hint: Erfahre __hier__ mehr über die Verwendungsmöglichkeiten der Infos
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Gerätename
       device_name_hint: Wir verwenden den Gerätenamen, um die TRMNL-Benutzeroberfläche zu personalisieren.
       device_model: Gerätemodell
@@ -190,6 +196,7 @@ de-AT:
       ota_byod_not_supported: OTA wird für BYOD-Geräte nicht unterstützt. Überspiele eine kompatible Version direkt unter usetrmnl.com/flash.
       maximum_compatibility: Maximale Kompatibilität aktivieren
       maximum_compatibility_hint: Behebt Anzeigefehler aufgrund bestimmter E-Ink-Treiber-Chips. Schaltet optimale Renderqualität ein. Benötigt Firmware 1.6.0+.
+      refresh_rate: Refresh Rate
       sleep_mode: Schlafmodus
       sleep_mode_hint: Aktualisierungsrate für bessere Konzentration und Batterielaufzeit anpassen.
       sleep_screen: Schlaf-Bildschirm
@@ -207,6 +214,8 @@ de-AT:
       unlink_device_learn_more: __Hier__ gibt es die vollständige Anleitung dazu.
       visibility: Sichtbarkeit
       visibility_hint: Macht das TRMNL öffentlich sichtbar.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Dein TRMNL
       upgrade_og:
         title: Upgrade auf 2-bit-Anzeige verfügbar
@@ -244,6 +253,14 @@ de-AT:
     update:
       error: Fehler beim Aktualisieren des Gerätes
       success: Einstellungen von %{device} erfolgreich aktualisiert
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: Zu viele Versuche, bitte warte kurz und versuche es noch einmal
     invoice_not_found: Rechnung nicht gefunden
@@ -333,6 +350,8 @@ de-AT:
       displayed_now: Wird angezeigt
       not_displayed_yet: Wird nicht angezeigt
       remove_from_playlist: Von Wiedergabeliste entfernen
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Eintrag verstecken
       show_playlist: Eintrag anzeigen
     create:

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -155,6 +155,10 @@ de:
     edit:
       accepts_beta_firmware: Beta-Firmware
       accepts_beta_firmware_hint: Aktiviere diese Option, um vor anderen Benutzern die neuesten Firmware-Updates für das Gerät zu erhalten.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Zurück zur Geräteübersicht
       battery_consumption: Batterieverbrauch
       battery_consumption_hint: Spare Strom und verlängere die Laufzeit durch Aktivierung des Schlafmodus.
@@ -163,6 +167,8 @@ de:
       developer_perks_hint: Für die folgenden Optionen ist das __Entwickler-Add-on__ erforderlich.
       device_credentials: Geräteinformationen
       device_credentials_hint: Erfahre __hier__ mehr über die Verwendungsmöglichkeiten der Infos
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Gerätename
       device_name_hint: Wir verwenden den Gerätenamen, um die TRMNL-Benutzeroberfläche zu personalisieren.
       device_model: Gerätemodell
@@ -190,6 +196,7 @@ de:
       ota_byod_not_supported: OTA wird für BYOD-Geräte nicht unterstützt. Überspiele eine kompatible Version direkt unter usetrmnl.com/flash.
       maximum_compatibility: Maximale Kompatibilität aktivieren
       maximum_compatibility_hint: Behebt Anzeigefehler aufgrund bestimmter E-Ink-Treiber-Chips. Schaltet optimale Renderqualität ein. Benötigt Firmware 1.6.0+.
+      refresh_rate: Refresh Rate
       sleep_mode: Schlafmodus
       sleep_mode_hint: Aktualisierungsrate für bessere Konzentration und Batterielaufzeit anpassen.
       sleep_screen: Schlaf-Bildschirm
@@ -207,6 +214,8 @@ de:
       unlink_device_learn_more: __Hier__ gibt es die vollständige Anleitung dazu.
       visibility: Sichtbarkeit
       visibility_hint: Macht das TRMNL öffentlich sichtbar.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Dein TRMNL
       upgrade_og:
         title: Upgrade auf 2-bit-Anzeige verfügbar
@@ -244,6 +253,14 @@ de:
     update:
       error: Fehler beim Aktualisieren des Gerätes
       success: Einstellungen von %{device} erfolgreich aktualisiert
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: Zu viele Versuche, bitte warte kurz und versuche es noch einmal
     invoice_not_found: Rechnung nicht gefunden
@@ -333,6 +350,8 @@ de:
       displayed_now: Wird angezeigt
       not_displayed_yet: Wird nicht angezeigt
       remove_from_playlist: Von Wiedergabeliste entfernen
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Eintrag verstecken
       show_playlist: Eintrag anzeigen
     create:

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -155,6 +155,10 @@ en-GB:
     edit:
       accepts_beta_firmware: Firmware Early Release
       accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Back to Devices
       battery_consumption: Battery Consumption
       battery_consumption_hint: Save power and enjoy a longer battery life by enabling Sleep Mode.
@@ -163,6 +167,8 @@ en-GB:
       developer_perks_hint: Options below require the __Developer add-on__.
       device_credentials: Device Credentials
       device_credentials_hint: See what you can do with these credentials __here__
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Device Name
       device_name_hint: We use this to make the TRMNL interface more comfortable
       device_model: Device Model
@@ -190,6 +196,7 @@ en-GB:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      refresh_rate: Refresh Rate
       sleep_mode: Sleep Mode
       sleep_mode_hint: Adjust your refresh rate to optimize focus and battery life.
       sleep_screen: Sleep Screen
@@ -207,6 +214,8 @@ en-GB:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Your TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
@@ -244,6 +253,14 @@ en-GB:
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: Too many attempts, please wait and try again
     invoice_not_found: Invoice not found
@@ -333,6 +350,8 @@ en-GB:
       displayed_now: Displayed now
       not_displayed_yet: Not displayed yet
       remove_from_playlist: Remove from playlist
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Hide this item
       show_playlist: Show this item
     create:

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -155,6 +155,10 @@ en:
     edit:
       accepts_beta_firmware: Firmware Early Release
       accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Back to Devices
       battery_consumption: Battery Consumption
       battery_consumption_hint: Save power and enjoy a longer battery life by enabling Sleep Mode.
@@ -163,6 +167,8 @@ en:
       developer_perks_hint: Options below require the __Developer add-on__.
       device_credentials: Device Credentials
       device_credentials_hint: See what you can do with these credentials __here__
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Device Name
       device_name_hint: We use this to make the TRMNL interface more comfortable
       device_model: Device Model
@@ -190,6 +196,7 @@ en:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      refresh_rate: Refresh Rate
       sleep_mode: Sleep Mode
       sleep_mode_hint: Adjust your refresh rate to optimize focus and battery life.
       sleep_screen: Sleep Screen
@@ -207,6 +214,8 @@ en:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Your TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
@@ -244,6 +253,14 @@ en:
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: Too many attempts, please wait and try again
     invoice_not_found: Invoice not found
@@ -333,6 +350,8 @@ en:
       displayed_now: Displayed now
       not_displayed_yet: Not displayed yet
       remove_from_playlist: Remove from playlist
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Hide this item
       show_playlist: Show this item
     create:

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -155,6 +155,10 @@ es-ES:
     edit:
       accepts_beta_firmware: Firmware de versión de pruebas
       accepts_beta_firmware_hint: Activa para obtener las últimas mejoras de firmware del dispositivo antes que otros usuarios.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Volver a Dispositivos
       battery_consumption: Consumo de Batería
       battery_consumption_hint: Ahorra energía y mejora el uso de batería habilitando el Modo de Suspensión.
@@ -163,6 +167,8 @@ es-ES:
       developer_perks_hint: Las opciones a continuación requieren el __plugin de Desarrollador__.
       device_credentials: Credenciales del dispositivo
       device_credentials_hint: Puedes ver qué puedes hacer con estas credenciales __aquí__
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Nombre del Dispositivo
       device_name_hint: Lo utilizamos para hacer la interfaz de TRMNL más cómoda
       device_model: Device Model
@@ -190,6 +196,7 @@ es-ES:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      refresh_rate: Refresh Rate
       sleep_mode: Modo de Suspensión
       sleep_mode_hint: Ajusta tu tasa de refresco para optimizar el enfoque y la duración de la batería.
       sleep_screen: Sleep Screen
@@ -207,6 +214,8 @@ es-ES:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibilidad
       visibility_hint: Haz que tu dispositivo TRMNL sea espejeable cambiando la configuración a continuación.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Tu TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
@@ -244,6 +253,14 @@ es-ES:
     update:
       error: Error al actualizar el dispositivo
       success: Configuración del dispositivo %{device} actualizada con éxito
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: Demasiados intentos, por favor, espera e intentalo de nuevo
     invoice_not_found: Factura no encontrada
@@ -333,6 +350,8 @@ es-ES:
       displayed_now: Mostrado ahora
       not_displayed_yet: Pendiente
       remove_from_playlist: Eliminar de la lista de reproducción
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Ocultar este elemento
       show_playlist: Mostrar este elemento
     create:

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -155,6 +155,10 @@ fr:
     edit:
       accepts_beta_firmware: Mise à jour en accès anticipé
       accepts_beta_firmware_hint: Activer pour obtenir les dernières améliorations du firmware de l'appareil avant les autres utilisateurs.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Retour aux appareils
       battery_consumption: Consommation de la batterie
       battery_consumption_hint: Économisez de l'énergie et appréciez une meilleure durée de vie de la batterie en activant le Mode Veille.
@@ -163,6 +167,8 @@ fr:
       developer_perks_hint: Les options ci-dessous requièrent le __complément payant Developer__.
       device_credentials: Identifiants de l'appareil
       device_credentials_hint: Voir ce que vous pouvez faire avec ces identifiants __en cliquant ici__
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Nom de l'appareil
       device_name_hint: Nous utilisons cela pour rendre l'interface de TRMNL plus agréable
       device_model: Modèle d'appareil
@@ -190,6 +196,7 @@ fr:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Activer la compatibilité maximale
       maximum_compatibility_hint: Résout les problèmes d'affichage causés par certaines puces de pilote e-ink. Désactive le rafraîchissement rapide. Firmware 1.6.0+ requis.
+      refresh_rate: Refresh Rate
       sleep_mode: Mode Veille
       sleep_mode_hint: Ajustez la fréquence de rafraîchissement pour réduire les distractions et augmenter l'autonomie de la batterie.
       sleep_screen: Écran de veille
@@ -207,6 +214,8 @@ fr:
       unlink_device_learn_more: Suivez le guide complet __ici__.
       visibility: Visibilité
       visibility_hint: Synchroniser votre appareil TRMNL en changeant la configuration ci-dessous.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Votre TRMNL
       upgrade_og:
         title: Mise à niveau vers écran 2 bits disponible
@@ -244,6 +253,14 @@ fr:
     update:
       error: Erreur lors de la mise à jour de l'appareil
       success: "%{device} mis à jour avec succès"
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: Trop de tentatives, veuillez patienter et réessayer
     invoice_not_found: Facture introuvable
@@ -333,6 +350,8 @@ fr:
       displayed_now: Actuellement affiché
       not_displayed_yet: Pas encore affiché
       remove_from_playlist: Retirer de la playlist
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Masquer cet élément
       show_playlist: Afficher cet élément
     create:

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -155,6 +155,10 @@ he:
     edit:
       accepts_beta_firmware: Firmware Early Release
       accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Back to Devices
       battery_consumption: Battery Consumption
       battery_consumption_hint: Save power and enjoy a longer battery life by enabling Sleep Mode.
@@ -163,6 +167,8 @@ he:
       developer_perks_hint: Options below require the __Developer add-on__.
       device_credentials: Device Credentials
       device_credentials_hint: See what you can do with these credentials __here__
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Device Name
       device_name_hint: We use this to make the TRMNL interface more comfortable
       device_model: Device Model
@@ -190,6 +196,7 @@ he:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      refresh_rate: Refresh Rate
       sleep_mode: Sleep Mode
       sleep_mode_hint: Adjust your refresh rate to optimize focus and battery life.
       sleep_screen: Sleep Screen
@@ -207,6 +214,8 @@ he:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Your TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
@@ -244,6 +253,14 @@ he:
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: Too many attempts, please wait and try again
     invoice_not_found: Invoice not found
@@ -333,6 +350,8 @@ he:
       displayed_now: Displayed now
       not_displayed_yet: Not displayed yet
       remove_from_playlist: Remove from playlist
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Hide this item
       show_playlist: Show this item
     create:

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -155,6 +155,10 @@ id:
     edit:
       accepts_beta_firmware: Firmware tahap Beta
       accepts_beta_firmware_hint: Aktifkan untuk mendapatkan pembaruan firmware perangkat terbaru sebelum pengguna lain.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Kembali ke Perangkat
       battery_consumption: Penggunaan Baterai
       battery_consumption_hint: Hemat daya dan nikmati masa pakai baterai yang lebih lama dengan mengaktifkan Mode Tidur.
@@ -163,6 +167,8 @@ id:
       developer_perks_hint: Opsi di bawah ini membutuhkan __add-on Pengembang__.
       device_credentials: Device Credentials
       device_credentials_hint: See what you can do with these credentials __here__
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Nama Perangkat
       device_name_hint: Kami menggunakan ini untuk membuat antarmuka TRMNL lebih nyaman
       device_model: Device Model
@@ -190,6 +196,7 @@ id:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      refresh_rate: Refresh Rate
       sleep_mode: Mode Tidur
       sleep_mode_hint: Sesuaikan tingkat penyegaran untuk fokus dan hemat baterai.
       sleep_screen: Sleep Screen
@@ -207,6 +214,8 @@ id:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibilitas
       visibility_hint: Jadikan perangkat TRMNL Anda dapat di-mirroring dengan mengubah pengaturan di bawah ini.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: TRMNL Anda
       upgrade_og:
         title: Upgrade to 2-bit Display Available
@@ -244,6 +253,14 @@ id:
     update:
       error: Terjadi kesalahan saat memperbarui perangkat
       success: Pengaturan perangkat %{device} berhasil diperbarui
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: Too many attempts, please wait and try again
     invoice_not_found: Invoice not found
@@ -333,6 +350,8 @@ id:
       displayed_now: Ditampilkan sekarang
       not_displayed_yet: Tertunda
       remove_from_playlist: Hapus dari daftar putar
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Hide this item
       show_playlist: Show this item
     create:

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -155,6 +155,10 @@ is:
     edit:
       accepts_beta_firmware: Snemmútgáfa fastbúnaðar
       accepts_beta_firmware_hint: Kveiktu á þessu til að fá nýjustu fastbúnaðaruppfærslur á undan öðrum.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Til baka í tæki
       battery_consumption: Rafhlöðunotkun
       battery_consumption_hint: Sparaðu orku og lengdu rafhlöðuendingu með því að virkja svefnham.
@@ -163,6 +167,8 @@ is:
       developer_perks_hint: Valkostir hér að neðan krefjast __forritaraviðbótar__.
       device_credentials: Auðkenni tækis
       device_credentials_hint: Sjáðu hvað þú getur gert með þessum auðkennum __hér__
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Heiti tækis
       device_name_hint: Við notum þetta til að gera TRMNL viðmótið þægilegra.
       device_model: Gerð tækis
@@ -190,6 +196,7 @@ is:
       ota_byod_not_supported: OTA er ekki stutt fyrir BYOD-tæki. "Flassaðu" samhæfða útgáfu beint frá usetrmnl.com/flash
       maximum_compatibility: Hámarkssamhæfni
       maximum_compatibility_hint: Leysir skjávandamál af völdum sumra e-ink rekla. Slekkur á hraðri uppfærslu. Krefst fastbúnaðar 1.6.0+.
+      refresh_rate: Refresh Rate
       sleep_mode: Svefnhamur
       sleep_mode_hint: Stilltu uppfærslutíðni til að bæta einbeitingu og lengja rafhlöðuendingu.
       sleep_screen: Svefnskjár
@@ -207,6 +214,8 @@ is:
       unlink_device_learn_more: Fylgdu leiðbeiningum __hér__.
       visibility: Sýnileiki
       visibility_hint: Gera TRMNL tækið þitt speglanlegt með því að breyta stillingunum hér að neðan.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Þitt TRMNL tæki
       upgrade_og:
         title: Uppfærsla í 2-bita skjá í boði
@@ -244,6 +253,14 @@ is:
     update:
       error: Villa við að uppfæra tæki
       success: Stillingar tækis %{device} uppfærðar
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: Of margar tilraunir, vinsamlegast bíðið og reynið aftur
     invoice_not_found: Reikningur fannst ekki
@@ -333,6 +350,8 @@ is:
       displayed_now: Birt núna
       not_displayed_yet: Ekki birt enn
       remove_from_playlist: Fjarlægja úr spilunarlista
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Fela þetta atriði
       show_playlist: Sýna þetta atriði
     create:

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -155,6 +155,10 @@ it:
     edit:
       accepts_beta_firmware: Firmware Accesso Anticipato
       accepts_beta_firmware_hint: Attiva per riceve gli aggiornamenti del firmware più recenti prima degli degli altri utenti.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Torna a Dispositivi
       battery_consumption: Consumo Batteria
       battery_consumption_hint: Risparmia energia e aumenta la durata della batteria attivando la Modalità Riposo.
@@ -163,6 +167,8 @@ it:
       developer_perks_hint: Queste opzioni richiedono la __Modalità Sviluppatore__.
       device_credentials: Credenziali Dispositivo
       device_credentials_hint: Scopri cosa puoi fare con queste credenziali __qui__
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Nome Dispositivo
       device_name_hint: Lo usiamo per migliorare l'interfaccia TRMNL
       device_model: Modello dispositivo
@@ -190,6 +196,7 @@ it:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Abilita compatibilità massima
       maximum_compatibility_hint: Risolve problemi dello schermo causati da alcuni chip driver per e-ink. Disattiva il fast refresh. Richiede Firmware 1.6.0 o successivo.
+      refresh_rate: Refresh Rate
       sleep_mode: Modalità Riposo
       sleep_mode_hint: Regola la frequenza di aggiornamento per ottimizzare la concentrazione e la durata della batteria.
       sleep_screen: Schermata di riposo
@@ -207,6 +214,8 @@ it:
       unlink_device_learn_more: Segui la guida completa __qui__.
       visibility: Visibilità
       visibility_hint: Permetti la duplicazione di questo dispositivo TRMNL modificando le impostazioni seguenti.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Il tuo TRMNL
       upgrade_og:
         title: Aggiornamento per display a 2-bit disponibile
@@ -244,6 +253,14 @@ it:
     update:
       error: Errore nell'aggiornamento del dispositivo
       success: "%{device} impostazioni dispositivo aggiornate con successo"
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: Troppi tentativi, riprova più tardi
     invoice_not_found: Fattura non trovata
@@ -333,6 +350,8 @@ it:
       displayed_now: Mostrato ora
       not_displayed_yet: Non ancora mostrato
       remove_from_playlist: Rimuovi dalla playlist
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Nascondi questo elemento
       show_playlist: Mostra questo elemento
     create:

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -155,6 +155,10 @@ ja:
     edit:
       accepts_beta_firmware: 新しいファームウェアを受け入れる
       accepts_beta_firmware_hint: 通常のユーザーよりも早く新しいデバイスファームウェアを使用するには、ボタンを押してください。
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: デバイス管理画面に戻る
       battery_consumption: バッテリー消費
       battery_consumption_hint: デバイスをスリープ モードにすると、バッテリー寿命を延ばすことができます
@@ -163,6 +167,8 @@ ja:
       developer_perks_hint: 以下は、__開発者オプション__を追加した場合に利用可能です。
       device_credentials: デバイス認証情報
       device_credentials_hint: この認証情報でできることは__こちら__で確認できます
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: デバイス名
       device_name_hint: TRMNLインターフェースをより快適に使用するためです。
       device_model: Device Model
@@ -190,6 +196,7 @@ ja:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      refresh_rate: Refresh Rate
       sleep_mode: スリープモード
       sleep_mode_hint: 集中力とバッテリー寿命を最適化するために、更新頻度を調整します。
       sleep_screen: スリープ画面
@@ -207,6 +214,8 @@ ja:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: 共有設定
       visibility_hint: 以下の設定を使用して、TRMNLデバイスをミラーモードにすることができます。
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: あなたのTRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
@@ -244,6 +253,14 @@ ja:
     update:
       error: デバイス更新エラー
       success: "%{device}デバイスの設定が正常に更新されました"
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: 試行回数が多すぎます。しばらく待ってから再度お試しください。
     invoice_not_found: 請求書が見つかりませんでした。
@@ -333,6 +350,8 @@ ja:
       displayed_now: 今表示中
       not_displayed_yet: まだ表示されていません
       remove_from_playlist: プレイリストから削除
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Hide this item
       show_playlist: Show this item
     create:

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -155,6 +155,10 @@ ko:
     edit:
       accepts_beta_firmware: 새로 출시된 펌웨어
       accepts_beta_firmware_hint: 다른 사용자들보다 먼저 새로 나온 디바이스 펌웨어를 사용하려면 버튼을 눌러주세요.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: 기기 관리 화면으로 돌아가기
       battery_consumption: 배터리 소모
       battery_consumption_hint: 기기 절전 모드 설정을 하시면 더 오랫동안 배터리 수명을 유지할 수 있습니다.
@@ -163,6 +167,8 @@ ko:
       developer_perks_hint: 아래는 __개발자 옵션을 추가한 경우__ 사용 가능합니다.
       device_credentials: 기기 정보
       device_credentials_hint: 이 정보들로 무엇을 할 수 있는지 __여기서__ 확인하세요.
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: 기기 이름
       device_name_hint: 당신이 TRMNL 인터페이스를 더 편안하게 쓸 수 있도록 합니다.
       device_model: 디바이스 모델
@@ -190,6 +196,7 @@ ko:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      refresh_rate: Refresh Rate
       sleep_mode: 절전 모드
       sleep_mode_hint: 당신의 집중력과 배터리 수명을 최적화하기 위해 새로 고침 비율을 조정합니다.
       sleep_screen: 절전 화면
@@ -207,6 +214,8 @@ ko:
       unlink_device_learn_more: __여기__에 있는 모든 가이드를 따라하세요.
       visibility: 공유 설정
       visibility_hint: 아래 설정을 통해 당신의 TRMNL 기기가 거울모드가 가능합니다.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: 당신의 TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
@@ -244,6 +253,14 @@ ko:
     update:
       error: 기기 업데이트 오류
       success: "%{device} 기기 설정이 성공적으로 업데이트 되었습니다"
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: 너무 많이 시도되었습니다. 잠시만 기다렸다가 다시 해주세요.
     invoice_not_found: 인보이스를 찾을 수 없음
@@ -333,6 +350,8 @@ ko:
       displayed_now: 지금 화면에 보여짐
       not_displayed_yet: 아직 화면에 보여지지 않음
       remove_from_playlist: 플레이리스트에서 삭제
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Hide this item
       show_playlist: Show this item
     create:

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -155,6 +155,10 @@ nl:
     edit:
       accepts_beta_firmware: Beta firmware-release
       accepts_beta_firmware_hint: Schakel in om de nieuwste beta firmwareverbeteringen voor je apparaat te ontvangen.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Terug naar apparaten
       battery_consumption: Batterijgebruik
       battery_consumption_hint: Bespaar energie en geniet van een langere batterijduur door slaapmodus te activeren.
@@ -163,6 +167,8 @@ nl:
       developer_perks_hint: De onderstaande opties vereisen de __ontwikkelaars-add-on__.
       device_credentials: Apparaatgegevens
       device_credentials_hint: Beijk __hier__ wat je met deze gegevens kunt doen.
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Apparaatnaam
       device_name_hint: We gebruiken dit om de TRMNL interface persoonlijker te maken
       device_model: Device Model
@@ -190,6 +196,7 @@ nl:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Activeer Maximale Compatibiliteit
       maximum_compatibility_hint: Los scherm issues op met bepaalde e-ink driver chips. Zet snelle verversing uit. Firmware 1.6.0+ benodigd.
+      refresh_rate: Refresh Rate
       sleep_mode: Slaapmodus
       sleep_mode_hint: Pas de refresh rate aan om focus en batterijduur te optimaliseren.
       sleep_screen: Slaapscherm
@@ -207,6 +214,8 @@ nl:
       unlink_device_learn_more: Volg __hier__ de volledige handleiding.
       visibility: Vindbaarheid
       visibility_hint: Maak jouw TRMNL apparaat spiegelbaar door onderstaande instelling aan te passen.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Jouw TRMNL
       upgrade_og:
         title: Upgrade naar 2-bit scherm beschikbaar
@@ -244,6 +253,14 @@ nl:
     update:
       error: Fout bij updaten apparaat
       success: "%{device} apparaatinstellingen succesvol bijgewerkt"
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: Te vaak geprobeerd. Wacht even en probeer het laten nog eens
     invoice_not_found: Factuur niet gevonden
@@ -333,6 +350,8 @@ nl:
       displayed_now: Nu getoond
       not_displayed_yet: Nog niet getoond
       remove_from_playlist: Verwijderen van afspeellijst
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Vergerg dit item
       show_playlist: Toon dit item
     create:

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -155,6 +155,10 @@
     edit:
       accepts_beta_firmware: Tidlig utgivelse av fastvare
       accepts_beta_firmware_hint: Slå på for å få de nyeste fastvareoppdateringene før andre brukere.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Tilbake til enheter
       battery_consumption: Batteriforbruk
       battery_consumption_hint: Spar strøm og få lengre batterilevetid ved å aktivere dvalemodus.
@@ -163,6 +167,8 @@
       developer_perks_hint: Valgene nedenfor krever __Utviklertillegget__.
       device_credentials: Enhetslegitimasjon
       device_credentials_hint: Se hva du kan gjøre med denne legitimasjonen __her__
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Enhetsnavn
       device_name_hint: Vi bruker dette for å gjøre TRMNL-grensesnittet mer brukervennlig
       device_model: Device Model
@@ -190,6 +196,7 @@
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      refresh_rate: Refresh Rate
       sleep_mode: Dvalemodus
       sleep_mode_hint: Juster oppdateringsfrekvensen for å optimalisere fokus og batterilevetid.
       sleep_screen: Dvaleskjerm
@@ -207,6 +214,8 @@
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Synlighet
       visibility_hint: Gjør TRMNL-enheten din speilbar ved å endre innstillingene nedenfor.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Din TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
@@ -244,6 +253,14 @@
     update:
       error: Feil ved oppdatering av enhet
       success: "%{device} enhetsinnstillingene ble oppdatert"
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: For mange forsøk, vennligst vent og prøv igjen
     invoice_not_found: Faktura ikke funnet
@@ -333,6 +350,8 @@
       displayed_now: Vises nå
       not_displayed_yet: Venter
       remove_from_playlist: Fjern fra spilleliste
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Hide this item
       show_playlist: Show this item
     create:

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -155,6 +155,10 @@ pl:
     edit:
       accepts_beta_firmware: Firmware Early Release
       accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Back to Devices
       battery_consumption: Battery Consumption
       battery_consumption_hint: Save power and enjoy a longer battery life by enabling Sleep Mode.
@@ -163,6 +167,8 @@ pl:
       developer_perks_hint: Options below require the __Developer add-on__.
       device_credentials: Device Credentials
       device_credentials_hint: See what you can do with these credentials __here__
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Device Name
       device_name_hint: We use this to make the TRMNL interface more comfortable
       device_model: Device Model
@@ -190,6 +196,7 @@ pl:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      refresh_rate: Refresh Rate
       sleep_mode: Sleep Mode
       sleep_mode_hint: Adjust your refresh rate to optimize focus and battery life.
       sleep_screen: Sleep Screen
@@ -207,6 +214,8 @@ pl:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Your TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
@@ -244,6 +253,14 @@ pl:
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: Too many attempts, please wait and try again
     invoice_not_found: Invoice not found
@@ -333,6 +350,8 @@ pl:
       displayed_now: Displayed now
       not_displayed_yet: Not displayed yet
       remove_from_playlist: Remove from playlist
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Hide this item
       show_playlist: Show this item
     create:

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -155,6 +155,10 @@ pt-BR:
     edit:
       accepts_beta_firmware: Versões Antecipadas de Firmware
       accepts_beta_firmware_hint: Ative para obter as últimas versões do firmware de dispositivo antes dos outros usuários.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Voltar para Dispositivos
       battery_consumption: Consumo da Bateria
       battery_consumption_hint: Economize energia desfrute de mais bateria ativando o Modo de Suspensão.
@@ -163,6 +167,8 @@ pt-BR:
       developer_perks_hint: Opções abaixo requerem o __Add-on de Desenvolvedor__.
       device_credentials: Credenciais do Dispositivo
       device_credentials_hint: Veja o que você pode fazer com essas credenciais __aqui__
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Nome do Dispositivo
       device_name_hint: Usamos esse nome para tornar a interface do TRMNL mais confortável
       device_model: Device Model
@@ -190,6 +196,7 @@ pt-BR:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      refresh_rate: Refresh Rate
       sleep_mode: Modo de Suspensão
       sleep_mode_hint: Ajuste sua taxa de atualização para otimizar foco e duração da bateria.
       sleep_screen: Sleep Screen
@@ -207,6 +214,8 @@ pt-BR:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibilidade
       visibility_hint: Torne seu TRMNL espelhável mudando a configuração abaixo.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Seu TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
@@ -244,6 +253,14 @@ pt-BR:
     update:
       error: Erro ao atualizar dispositivo
       success: Configurações do dispositivo %{device} atualizadas com sucesso
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: Too many attempts, please wait and try again
     invoice_not_found: Invoice not found
@@ -333,6 +350,8 @@ pt-BR:
       displayed_now: Exibindo agora
       not_displayed_yet: Pendente
       remove_from_playlist: Remover da playlist
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Hide this item
       show_playlist: Show this item
     create:

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -155,6 +155,10 @@ raw:
     edit:
       accepts_beta_firmware: devices.edit.accepts_beta_firmware
       accepts_beta_firmware_hint: devices.edit.accepts_beta_firmware_hint
+      accepts_beta_firmware_current: devices.edit.accepts_beta_firmware_current
+      accepts_beta_firmware_stable: devices.edit.accepts_beta_firmware_stable
+      accepts_beta_firmware_staging: devices.edit.accepts_beta_firmware_staging
+      accepts_beta_firmware_github: devices.edit.accepts_beta_firmware_github
       back_to_devices: devices.edit.back_to_devices
       battery_consumption: devices.edit.battery_consumption
       battery_consumption_hint: devices.edit.battery_consumption_hint
@@ -163,6 +167,8 @@ raw:
       developer_perks_hint: devices.edit.developer_perks_hint
       device_credentials: devices.edit.device_credentials
       device_credentials_hint: device_credentials_hint __here__
+      device_credentials_mac: devices.edit.device_credentials_mac
+      device_credentials_api_key: devices.edit.device_credentials_api_key
       device_name: devices.edit.device_name
       device_name_hint: devices.edit.device_name_hint
       device_model: devices.edit.device_model
@@ -190,6 +196,7 @@ raw:
       ota_byod_not_supported: devices.edit.ota_byod_not_supported
       maximum_compatibility: devices.edit.maximum_compatibility
       maximum_compatibility_hint: devices.edit.maximum_compatibility_hint
+      refresh_rate: devices.edit.refresh_rate
       sleep_mode: devices.edit.sleep_mode
       sleep_mode_hint: devices.edit.sleep_mode_hint
       sleep_screen: devices.edit.sleep_screen
@@ -207,6 +214,8 @@ raw:
       unlink_device_learn_more: devices.edit.unlink_device_learn_more
       visibility: devices.edit.visibility
       visibility_hint: devices.edit.visibility_hint
+      visibility_standalone: devices.edit.visibility_standalone
+      visibility_shareable: devices.edit.visibility_shareable
       your_device: devices.edit.your_device
       upgrade_og:
         title: devices.edit.upgrade_og.title
@@ -244,6 +253,14 @@ raw:
     update:
       error: devices.update.error
       success: devices.update.success
+    special_functions:
+      identify: devices.special_functions.identify
+      sleep: devices.special_functions.sleep
+      add_wifi: devices.special_functions.add_wifi
+      restart_playlist: devices.special_functions.restart_playlist
+      rewind: devices.special_functions.rewind
+      send_to_me: devices.special_functions.send_to_me
+      guest_mode: devices.special_functions.guest_mode
   invoices:
     rate_limit: invoices.rate_limit
     invoice_not_found: invoices.invoice_not_found
@@ -333,6 +350,8 @@ raw:
       displayed_now: playlists.playlist.displayed_now
       not_displayed_yet: playlists.playlist.not_displayed_yet
       remove_from_playlist: playlists.playlist.remove_from_playlist
+      copy_plugin: playlist_items.playlist_item.copy_plugin
+      edit_plugin: playlist_items.playlist_item.edit_plugin
       hide_playlist: playlists.playlist.hide_playlist
       show_playlist: playlists.playlist.show_playlist
     create:

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -155,6 +155,10 @@ sk:
     edit:
       accepts_beta_firmware: Firmware Early Release
       accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Back to Devices
       battery_consumption: Battery Consumption
       battery_consumption_hint: Save power and enjoy a longer battery life by enabling Sleep Mode.
@@ -163,6 +167,8 @@ sk:
       developer_perks_hint: Options below require the __Developer add-on__.
       device_credentials: Device Credentials
       device_credentials_hint: See what you can do with these credentials __here__
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Device Name
       device_name_hint: We use this to make the TRMNL interface more comfortable
       device_model: Device Model
@@ -190,6 +196,7 @@ sk:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      refresh_rate: Refresh Rate
       sleep_mode: Sleep Mode
       sleep_mode_hint: Adjust your refresh rate to optimize focus and battery life.
       sleep_screen: Sleep Screen
@@ -207,6 +214,8 @@ sk:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Your TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
@@ -244,6 +253,14 @@ sk:
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: Too many attempts, please wait and try again
     invoice_not_found: Invoice not found
@@ -333,6 +350,8 @@ sk:
       displayed_now: Displayed now
       not_displayed_yet: Not displayed yet
       remove_from_playlist: Remove from playlist
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Hide this item
       show_playlist: Show this item
     create:

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -155,6 +155,10 @@ sv:
     edit:
       accepts_beta_firmware: Firmware Early Release
       accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Back to Devices
       battery_consumption: Battery Consumption
       battery_consumption_hint: Save power and enjoy a longer battery life by enabling Sleep Mode.
@@ -163,6 +167,8 @@ sv:
       developer_perks_hint: Options below require the __Developer add-on__.
       device_credentials: Device Credentials
       device_credentials_hint: See what you can do with these credentials __here__
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Device Name
       device_name_hint: We use this to make the TRMNL interface more comfortable
       device_model: Device Model
@@ -190,6 +196,7 @@ sv:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      refresh_rate: Refresh Rate
       sleep_mode: Sleep Mode
       sleep_mode_hint: Adjust your refresh rate to optimize focus and battery life.
       sleep_screen: Sleep Screen
@@ -207,6 +214,8 @@ sv:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Your TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
@@ -244,6 +253,14 @@ sv:
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: Too many attempts, please wait and try again
     invoice_not_found: Invoice not found
@@ -333,6 +350,8 @@ sv:
       displayed_now: Displayed now
       not_displayed_yet: Not displayed yet
       remove_from_playlist: Remove from playlist
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Hide this item
       show_playlist: Show this item
     create:

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -155,6 +155,10 @@ uk:
     edit:
       accepts_beta_firmware: Firmware Early Release
       accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: Назад до пристроїв
       battery_consumption: Споживання батареї
       battery_consumption_hint: Заощаджуйте енергію та насолоджуйтесь тривалим часом роботи батареї, увімкнувши Режим сну.
@@ -163,6 +167,8 @@ uk:
       developer_perks_hint: Options below require the __Developer add-on__.
       device_credentials: Device Credentials
       device_credentials_hint: See what you can do with these credentials __here__
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: Назва пристрою
       device_name_hint: Ми використовуємо імʼя пристрою, щоб зробити інтерфейс TRMNL більш зручним
       device_model: Device Model
@@ -190,6 +196,7 @@ uk:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      refresh_rate: Refresh Rate
       sleep_mode: Режим сну
       sleep_mode_hint: Налаштуйте частоту оновлення, щоб покращити концентрацію та час роботи батареї.
       sleep_screen: Sleep Screen
@@ -207,6 +214,8 @@ uk:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Спільний доступ
       visibility_hint: Зробіть ваш пристрій TRMNL доступним для віддзеркалення, змінивши налаштування нижче.
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: Ваш TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
@@ -244,6 +253,14 @@ uk:
     update:
       error: Помилка оновлення пристрою
       success: Налаштування пристрою %{device} успішно оновлено
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: Too many attempts, please wait and try again
     invoice_not_found: Invoice not found
@@ -333,6 +350,8 @@ uk:
       displayed_now: Відображається зараз
       not_displayed_yet: Ще не відображається
       remove_from_playlist: Видалити з плейлиста
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Hide this item
       show_playlist: Show this item
     create:

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -155,6 +155,10 @@ zh-CN:
     edit:
       accepts_beta_firmware: beta测试固件
       accepts_beta_firmware_hint: 打开以提前使用最新固件
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: 返回设备列表
       battery_consumption: 电池消耗
       battery_consumption_hint: 在晚上10点到早上8点之间启用睡眠模式，节省电量并延长电池寿命。
@@ -163,6 +167,8 @@ zh-CN:
       developer_perks_hint: 下列选项需要__开发者选项__
       device_credentials: 设备密码
       device_credentials_hint: See what you can do with these credentials __here__
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: 设备名称
       device_name_hint: 用于TRMNL界面
       device_model: Device Model
@@ -190,6 +196,7 @@ zh-CN:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      refresh_rate: Refresh Rate
       sleep_mode: 睡眠模式
       sleep_mode_hint: 降低刷新率以优化焦点和电池寿命
       sleep_screen: 休眠屏幕
@@ -207,6 +214,8 @@ zh-CN:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: 隐藏
       visibility_hint: 让TRMNL设备显示镜像播放列表
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: 您的TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
@@ -244,6 +253,14 @@ zh-CN:
     update:
       error: 设备更新错误
       success: "“%{device} 更新成功”"
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: 尝试次数过多，请耐心等待之后再次尝试
     invoice_not_found: 未找到发票
@@ -333,6 +350,8 @@ zh-CN:
       displayed_now: 正在显示
       not_displayed_yet: 尚未显示
       remove_from_playlist: 从播放列表中删除
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Hide this item
       show_playlist: Show this item
     create:

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -155,6 +155,10 @@ zh-HK:
     edit:
       accepts_beta_firmware: 韌體搶先發佈
       accepts_beta_firmware_hint: 啟用設定後，你會在其他用戶之前取得最新的硬件韌體改進。
+      accepts_beta_firmware_current: Current
+      accepts_beta_firmware_stable: Stable
+      accepts_beta_firmware_staging: Staging
+      accepts_beta_firmware_github: View on GitHub
       back_to_devices: 返回裝置
       battery_consumption: 電池消耗
       battery_consumption_hint: 啟用「睡眠模式」可節省電量，並延長電池續航時間。
@@ -163,6 +167,8 @@ zh-HK:
       developer_perks_hint: 以下選項需要購買「__開發者版本__」。.
       device_credentials: 裝置認證
       device_credentials_hint: __按此__了解如何使用裝置認證
+      device_credentials_mac: MAC Address
+      device_credentials_api_key: API Key
       device_name: 裝置名稱
       device_name_hint: 此名稱可讓TRMNL介面更舒適
       device_model: Device Model
@@ -190,6 +196,7 @@ zh-HK:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from usetrmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      refresh_rate: Refresh Rate
       sleep_mode: 睡眠模式
       sleep_mode_hint: 調整重新整理頻率，以提升專注度及電池續航時間。
       sleep_screen: 睡眠畫面
@@ -207,6 +214,8 @@ zh-HK:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: 共享狀態
       visibility_hint: 讓其他TRMNL裝置可鏡像共享此裝置的內容。
+      visibility_standalone: Standalone
+      visibility_shareable: Shareable
       your_device: 你的TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
@@ -244,6 +253,14 @@ zh-HK:
     update:
       error: 更新裝置時發生錯誤
       success: 成功更新「%{device}」的裝置設定
+    special_functions:
+      identify: Identify
+      sleep: Sleep
+      add_wifi: Add WiFi
+      restart_playlist: Restart Playlist
+      rewind: Rewind
+      send_to_me: Send to me
+      guest_mode: Guest Mode
   invoices:
     rate_limit: 嘗試次數過多，請稍後再試
     invoice_not_found: 找不到發票
@@ -333,6 +350,8 @@ zh-HK:
       displayed_now: 正在顯示
       not_displayed_yet: 待處理
       remove_from_playlist: 從播放清單中移除
+      copy_plugin: Copy
+      edit_plugin: Edit
       hide_playlist: Hide this item
       show_playlist: Show this item
     create:


### PR DESCRIPTION
Adding more strings to tackle #114 (which could be closed shortly)

This should make most of the currently un-localized strings ready for translation. (Will have to be added to currently hard-coded lines in the Web UI.)

Next step would probably be the various strings in the "Private Plugin" Advanced Settings (Polling URL etc, but also "Build your own" string, see [this comment by Mario](https://github.com/usetrmnl/trmnl-i18n/issues/114#issuecomment-2989685166)), but these live in core/db/data/plugins.yml, not sure how to make those ready for i18n yet.
