### PR TITLE
Add persona and discover device translation keys

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -328,6 +328,23 @@ da:
         warning_1: Jeg forstår, at denne opgradering er <strong>irreversibel</strong> og kan ikke fortrydes.
         warning_2: Jeg forstår, at dette er en <strong>farlig</strong> handling og kan beskadige min enhed.
         cta: Opgrader til TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Enheder
       tagline: Dine TRMNL-enheder

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -328,6 +328,23 @@ de-AT:
         warning_1: Mir ist bewusst, dass dieses Upgrade <strong>nicht rückgängig gemacht werden kann</strong>.
         warning_2: Mir ist bewusst, dass dies ein <strong>gefährlicher</strong> Vorgang ist, der mein Gerät dauerhaft beschädigen kann.
         cta: Auf TRMNL OG (2-bit) upgraden
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Geräte
       tagline: Deine TRMNL-Geräte

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -328,6 +328,23 @@ de:
         warning_1: Mir ist bewusst, dass dieses Upgrade <strong>nicht rückgängig gemacht werden kann</strong>.
         warning_2: Mir ist bewusst, dass dies ein <strong>gefährlicher</strong> Vorgang ist, der mein Gerät dauerhaft beschädigen kann.
         cta: Auf TRMNL OG (2-bit) upgraden
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Geräte
       tagline: Deine TRMNL-Geräte

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -328,6 +328,23 @@ en-GB:
         warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
         warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
         cta: Upgrade to TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Devices
       tagline: Your TRMNL devices

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -328,6 +328,23 @@ en:
         warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
         warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
         cta: Upgrade to TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Devices
       tagline: Your TRMNL devices

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -328,6 +328,23 @@ es-ES:
         warning_1: Entiendo que esta actualización es <strong>irreversible</strong> y no puede deshacerse.
         warning_2: Entiendo que es una acción <strong>peligrosa</strong> y puede inutilizar mi dispositivo.
         cta: Actualizar a TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Dispositivos
       tagline: Tus dispositivos TRMNL

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -330,6 +330,23 @@ fr:
         warning_1: Je comprends que cette mise à niveau est <strong>irréversible</strong> et ne peut pas être annulée.
         warning_2: Je comprends qu'il s'agit d'une opération <strong>risquée</strong> qui peut endommager mon appareil.
         cta: Mettre à niveau vers TRMNL OG (2 bits)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Appareils
       tagline: Vos appareils TRMNL

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -330,6 +330,23 @@ he:
         warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
         warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
         cta: Upgrade to TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Devices
       tagline: Your TRMNL devices

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -328,6 +328,23 @@ hu:
         warning_1: Megértem, hogy ez a frissítés <strong>visszavonhatatlan</strong> és nem vonható vissza.
         warning_2: Megértem, hogy ez egy <strong>veszélyes</strong> művelet, amely tönkreteheti az eszközt.
         cta: Frissítés TRMNL OG (2-bit) verzióra
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Eszközök
       tagline: A te TRMNL eszközeid

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -330,6 +330,23 @@ id:
         warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
         warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
         cta: Upgrade to TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Perangkat
       tagline: Perangkat TRMNL Anda

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -328,6 +328,23 @@ is:
         warning_1: Ég skil að þessi uppfærsla er <strong>óafturkræf</strong> og ekki hægt að afturkalla.
         warning_2: Ég skil að þetta er <strong>hætta</strong> og getur skemmt tækið.
         cta: Uppfæra í TRMNL OG (2-bita)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Tæki
       tagline: TRMNL tækin þín

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -328,6 +328,23 @@ it:
         warning_1: Sono consapevole che questo aggiornamento è <strong>irreversibile</strong> e non può esssere annullato.
         warning_2: Sono consapevole che questa è un azione <strong>pericolosa</strong> e che può bloccare il mio dispositivo.
         cta: Aggiorna al TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Dispositivi
       tagline: I tuoi dispositivi TRMNL

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -328,6 +328,23 @@ ja:
         warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
         warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
         cta: Upgrade to TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: デバイス管理
       tagline: あなたのTRMNLデバイス

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -328,6 +328,23 @@ ko:
         warning_1: 이 업그레이드는 <strong>되돌릴 수 없다</strong>는 걸 이해해요.
         warning_2: 이 작업은 <strong>위험</strong>하고 기기가 벽돌이 될 수 있다는 걸 이해해요.
         cta: TRMNL OG (2-bit)로 업그레이드
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: 기기 관리
       tagline: 내 TRMNL 기기

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -328,6 +328,23 @@ lt:
         warning_1: Suprantu, kad šis atnaujinimas yra <strong>negrįžtamas</strong> ir jo negalima atšaukti.
         warning_2: Suprantu, kad tai yra <strong>pavojingas</strong> veiksmas ir gali sugadinti mano įrenginį.
         cta: Atnaujinti į TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Įrenginiai
       tagline: Jūsų TRMNL įrenginiai

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -328,6 +328,23 @@ nl:
         warning_1: Ik snap dat deze upgrade <strong>onomkeerbaar</strong> is en niet ongedaan gemaakt kan worden.
         warning_2: Ik snap dat dit een <strong>gevaarlijke</strong> actie is en dat ik mijn device onbruikmaar kan maken (bricken).
         cta: Upgrade naar TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Apparaten
       tagline: Jouw TRMNL apparaten

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -328,6 +328,23 @@
         warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
         warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
         cta: Upgrade to TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Enheter
       tagline: Dine TRMNL-enheter

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -350,6 +350,23 @@ pl:
         warning_1: Rozumiem, że ta aktualizacja jest  <strong>nieodwracalna</strong> i nie da się jej w żaden sposób cofnąć.
         warning_2: Rozumiem, że ten proces jest <strong>niebezpieczny</strong> i może on uszkodzić moje urządzenie.
         cta: Aktualizuj do TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Urządzenia
       tagline: Twoje urządzenia TRMNL

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -328,6 +328,23 @@ pt-BR:
         warning_1: Entendo que essa atualização é <strong>irreversível</strong> e não pode ser desfeita.
         warning_2: Entendo que essa ação é <strong>perigosa</strong> e pode inutilizar meu dispositivo.
         cta: Atualizar para o TRMNL OG (2 bits)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Dispositivos
       tagline: Seus dispositivos TRMNL

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -328,6 +328,23 @@ raw:
         warning_1: devices.edit.upgrade_og.warning_1
         warning_2: devices.edit.upgrade_og.warning_2
         cta: devices.edit.upgrade_og.cta
+      persona:
+        discover: devices.edit.persona.discover
+        discover_hint: devices.edit.persona.discover_hint
+        discover_banner_toggle: devices.edit.persona.discover_banner_toggle
+        persona: devices.edit.persona.persona
+        persona_hint: devices.edit.persona.persona_hint
+        provisioned_by_html: devices.edit.persona.provisioned_by_html
+        mirror_disabled_hint: devices.edit.persona.mirror_disabled_hint
+        save_persona: devices.edit.persona.save_persona
+        reset_persona: devices.edit.persona.reset_persona
+        reset_persona_hint: devices.edit.persona.reset_persona_hint
+        reset_persona_confirm: devices.edit.persona.reset_persona_confirm
+    discover_persona:
+      label: devices.discover_persona.label
+      disabled_hint: devices.discover_persona.disabled_hint
+      completed_hint: devices.discover_persona.completed_hint
+      setup_hint: devices.discover_persona.setup_hint
     index:
       title: devices.index.title
       tagline: devices.index.tagline

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -328,6 +328,23 @@ ro:
         warning_1: Înțeleg că acest upgrade este <strong>ireversibil</strong> și nu poate fi anulat.
         warning_2: Înțeleg că aceasta este o acțiune <strong>periculoasă</strong> și îmi poate deteriora dispozitivul.
         cta: Upgrade la TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Dispozitive
       tagline: Dispozitivele tale TRMNL

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -350,6 +350,23 @@ ru:
         warning_1: Я понимаю, что это обновление <strong>необратимо</strong> и не может быть отменено.
         warning_2: Я понимаю, что это <strong>опасное</strong> действие и может привести к «окирпичиванию» моего устройства.
         cta: Обновить до TRMNL OG (2-бит)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Устройства
       tagline: Ваши устройства TRMNL

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -339,6 +339,23 @@ sk:
         warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
         warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
         cta: Upgrade to TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Devices
       tagline: Your TRMNL devices

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -328,6 +328,23 @@ sv:
         warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
         warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
         cta: Upgrade to TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Devices
       tagline: Your TRMNL devices

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -350,6 +350,23 @@ uk:
         warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
         warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
         cta: Upgrade to TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: Пристрої
       tagline: Ваші пристрої TRMNL

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -363,6 +363,23 @@ zh-CN:
         warning_1: 我理解此升级操作<strong>不可逆转</strong>且无法撤销。
         warning_2: 本人知悉此操作<strong>存在风险</strong>，可能导致设备变砖。
         cta: 升级至 TRMNL OG（2 位）
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: 设备列表
       tagline: 您的 TRMNL 设备

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -328,6 +328,23 @@ zh-HK:
         warning_1: 我明白此升級是<strong>不可逆轉</strong>，並且無法復原。
         warning_2: 我明白這是<strong>危險</strong>操作，可能會導致我的裝置變磚。
         cta: 升級至 TRMNL OG (2-bit)
+      persona:
+        discover: Discover
+        discover_hint: Discover suggests plugins and recipes tailored to this device
+        discover_banner_toggle: Show the Discover banner on the dashboard for this device
+        persona: Persona
+        persona_hint: A device persona shapes Discover recommendations
+        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
+        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+        save_persona: Save persona
+        reset_persona: Reset persona
+        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
+        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+    discover_persona:
+      label: Persona & Discover
+      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
+      completed_hint: Persona is set up for this device
+      setup_hint: Set up a persona for this device
     index:
       title: 裝置
       tagline: 你的TRMNL裝置


### PR DESCRIPTION
The device edit "Persona" sub-page and its "Persona & Discover" card row on the main device edit page were hardcoded in English while every sibling row already used `t()`. Adds the missing `devices.edit.persona.*` and `devices.discover_persona.*` keys to `en.yml` and propagates them (as untranslated placeholders) to every other `web_ui` locale via `bin/sync`.
