### PR TITLE
Added the five UI keys core asks for but never had

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -292,6 +292,7 @@ da:
       maximum_compatibility: Aktivér maksimal kompatibilitet
       maximum_compatibility_hint: Løser visningsproblemer forårsaget af visse ePaper driverchips. Deaktiverer hurtig opdatering. Firmware 1.6.0+ kræves.
       color_and_rotation: Farve og rotation
+      image_rotation: Image Rotation
       screen_rotation: Skærmrotation
       screen_rotation_not_supported: Skærmrotation er ikke understøttet på din enhed.
       palette: Color Palette
@@ -311,6 +312,7 @@ da:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
@@ -436,6 +438,7 @@ da:
       design_system: Udnyt vores indbyggede designsystem
       design_system_docs: Designsystem dokumentation
       dirty_confirm: Du har ikke-gemte ændringer. Er du sikker på, at du vil forlade siden?
+      edit_composition: Edit Composition
       edit_markup: Rediger markup
       edit_markup_for_plugin: Rediger markup for %{plugin_setting_name}
       edit_markup_please_save_first: Gem venligst før redigering af markup
@@ -511,6 +514,7 @@ da:
       show_playlist: Vis dette element
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -542,6 +546,7 @@ da:
       tagline: Hvad vil du sætte på din TRMNL?
       available: Tilgængelig
       connected: Forbundet
+      supported_by_this_device: Supported by this device
       recipes: Opskrifter
       recipes_hint: Private plugins fra fællesskabsmedlemmer, som kan installeres med 1 klik. __Læs mere__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -292,6 +292,7 @@ de-AT:
       maximum_compatibility: Maximale Kompatibilität aktivieren
       maximum_compatibility_hint: Behebt Anzeigefehler aufgrund bestimmter ePaper-Treiber-Chips. Deaktiviert schnelles Rendern. Benötigt Firmware 1.6.0+.
       color_and_rotation: Farbe & Rotation
+      image_rotation: Image Rotation
       screen_rotation: Bildschirmrotation
       screen_rotation_not_supported: Bildschirmrotation ist derzeit nicht auf deinem Gerät unterstützt.
       palette: Farbpalette
@@ -311,6 +312,7 @@ de-AT:
       touchbar_mode_hint: Auf welche Art von Gesten soll dein Gerät reagieren?
       tidbyt_credentials: Tidbyt-Anmeldedaten
       tidbyt_credentials_hint: Gib hier die API-Zugangsdaten deines Tidbyt-Geräts ein (Einstellungen → Entwickler → API-Schlüssel in der Tidbyt-App).
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Ungültige Tidbyt-API-Zugangsdaten. Bitte prüfen und erneut versuchen.
       tidbyt_device_id: Geräte-ID
       tidbyt_device_api_key: API-Schlüssel
@@ -435,6 +437,7 @@ de-AT:
       design_system: Nutze unser natives Design-System
       design_system_docs: Dokumentation anzeigen
       dirty_confirm: Es gibt ungespeicherte Änderungen. Möchtest Du diese Seite wirklich verlassen?
+      edit_composition: Edit Composition
       edit_markup: Markup bearbeiten
       edit_markup_for_plugin: Markup von %{plugin_setting_name} bearbeiten
       edit_markup_please_save_first: Bitte vor dem Bearbeiten des Markups speichern
@@ -510,6 +513,7 @@ de-AT:
       show_playlist: Eintrag anzeigen
       duplicate: Duplizieren
       duplicate_confirm: Es wird eine Kopie dieses Eintrags erstellt und am Ende der Wiedergabeliste hinzugefügt. Fortfahren?
+      presentation: Presentation
       color_palette: Farbpalette
       device_default: Geräte-Standard (%{name})
       palette_unavailable: Nur verfügbar für Geräte mit mehreren Farbpaletten
@@ -541,6 +545,7 @@ de-AT:
       tagline: Was soll auf dem TRMNL angezeigt werden?
       available: Verfügbar
       connected: Verbunden
+      supported_by_this_device: Supported by this device
       recipes: Blaupausen
       recipes_hint: Private Erweiterungen aus der Community können mit einem Klick installiert werden. __Mehr erfahren__
     search:

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -292,6 +292,7 @@ de:
       maximum_compatibility: Maximale Kompatibilität aktivieren
       maximum_compatibility_hint: Behebt Anzeigefehler aufgrund bestimmter ePaper-Treiber-Chips. Deaktiviert schnelles Rendern. Benötigt Firmware 1.6.0+.
       color_and_rotation: Farbe & Rotation
+      image_rotation: Image Rotation
       screen_rotation: Bildschirmrotation
       screen_rotation_not_supported: Bildschirmrotation ist derzeit nicht auf deinem Gerät unterstützt.
       palette: Farbpalette
@@ -311,6 +312,7 @@ de:
       touchbar_mode_hint: Auf welche Art von Gesten soll dein Gerät reagieren?
       tidbyt_credentials: Tidbyt-Anmeldedaten
       tidbyt_credentials_hint: Gib hier die API-Zugangsdaten deines Tidbyt-Geräts ein (Einstellungen → Entwickler → API-Schlüssel in der Tidbyt-App).
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Ungültige Tidbyt-API-Zugangsdaten. Bitte prüfen und erneut versuchen.
       tidbyt_device_id: Geräte-ID
       tidbyt_device_api_key: API-Schlüssel
@@ -435,6 +437,7 @@ de:
       design_system: Nutze unser natives Design-System
       design_system_docs: Dokumentation anzeigen
       dirty_confirm: Es gibt ungespeicherte Änderungen. Möchtest Du diese Seite wirklich verlassen?
+      edit_composition: Edit Composition
       edit_markup: Markup bearbeiten
       edit_markup_for_plugin: Markup von %{plugin_setting_name} bearbeiten
       edit_markup_please_save_first: Bitte vor dem Bearbeiten des Markups speichern
@@ -510,6 +513,7 @@ de:
       show_playlist: Eintrag anzeigen
       duplicate: Duplizieren
       duplicate_confirm: Es wird eine Kopie dieses Eintrags erstellt und am Ende der Wiedergabeliste hinzugefügt. Fortfahren?
+      presentation: Presentation
       color_palette: Farbpalette
       device_default: Geräte-Standard (%{name})
       palette_unavailable: Nur verfügbar für Geräte mit mehreren Farbpaletten
@@ -541,6 +545,7 @@ de:
       tagline: Was soll auf dem TRMNL angezeigt werden?
       available: Verfügbar
       connected: Verbunden
+      supported_by_this_device: Supported by this device
       recipes: Blaupausen
       recipes_hint: Private Erweiterungen aus der Community können mit einem Klick installiert werden. __Mehr erfahren__
     search:

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -292,6 +292,7 @@ en-GB:
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: Colour & Rotation
+      image_rotation: Image Rotation
       screen_rotation: Screen Rotation
       screen_rotation_not_supported: Screen rotation is currently not supported on your device.
       palette: Colour Palette
@@ -311,6 +312,7 @@ en-GB:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
@@ -436,6 +438,7 @@ en-GB:
       design_system: Leverage our native design system
       design_system_docs: Design System Docs
       dirty_confirm: You have unsaved changes. Are you sure you want to leave this page?
+      edit_composition: Edit Composition
       edit_markup: Edit Markup
       edit_markup_for_plugin: Edit markup for %{plugin_setting_name}
       edit_markup_please_save_first: Please save before editing markup
@@ -511,6 +514,7 @@ en-GB:
       show_playlist: Show this item
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Colour Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple colour palettes
@@ -542,6 +546,7 @@ en-GB:
       tagline: What will you put on your TRMNL?
       available: Available
       connected: Connected
+      supported_by_this_device: Supported by this device
       recipes: Recipes
       recipes_hint: Private plugins by community members that can be installed in 1 click. __Learn more__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -292,6 +292,7 @@ en:
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: Color & Rotation
+      image_rotation: Image Rotation
       screen_rotation: Screen Rotation
       screen_rotation_not_supported: Screen rotation is currently not supported on your device.
       palette: Color Palette
@@ -311,6 +312,7 @@ en:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
@@ -435,6 +437,7 @@ en:
       design_system: Leverage our native design system
       design_system_docs: Design System Docs
       dirty_confirm: You have unsaved changes. Are you sure you want to leave this page?
+      edit_composition: Edit Composition
       edit_markup: Edit Markup
       edit_markup_for_plugin: Edit markup for %{plugin_setting_name}
       edit_markup_please_save_first: Please save before editing markup
@@ -510,6 +513,7 @@ en:
       show_playlist: Show this item
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -541,6 +545,7 @@ en:
       tagline: What will you put on your TRMNL?
       available: Available
       connected: Connected
+      supported_by_this_device: Supported by this device
       recipes: Recipes
       recipes_hint: Private plugins by community members that can be installed in 1 click. __Learn more__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -292,6 +292,7 @@ es-ES:
       maximum_compatibility: Habilitar Compatibilidad Máxima
       maximum_compatibility_hint: Resuelve problemas de visualización causados por ciertos chips de tinta electrónica. Desactiva la actualización rápida. Firmware 1.6.0+ requerido.
       color_and_rotation: Color & Rotación
+      image_rotation: Image Rotation
       screen_rotation: Rotación de pantalla
       screen_rotation_not_supported: La rotación de pantalla no está actualmente soportada en tu dispositivo.
       palette: Paleta de colores
@@ -311,6 +312,7 @@ es-ES:
       touchbar_mode_hint: "¿A qué tipo de gestos debe responder tu dispositivo?"
       tidbyt_credentials: Credenciales Tidbyt
       tidbyt_credentials_hint: Introduce las credenciales API de tu dispositivo Tidbyt desde la app de Tidbyt en Ajustes → Developer → Obtener clave API.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Las credenciales API de Tidbyt no son válidas. Por favor, comprueba y vuelve a intentarlo.
       tidbyt_device_id: ID del dispositivo
       tidbyt_device_api_key: Clave API
@@ -436,6 +438,7 @@ es-ES:
       design_system: Aprovecha nuestro sistema de diseño nativo
       design_system_docs: Documentación del sistema de diseño
       dirty_confirm: Tienes cambios sin guardar. ¿Seguro que quieres salir de esta página?
+      edit_composition: Edit Composition
       edit_markup: Editar markup
       edit_markup_for_plugin: Editar markup para %{plugin_setting_name}
       edit_markup_please_save_first: Por favor guarda antes de editar el markup
@@ -511,6 +514,7 @@ es-ES:
       show_playlist: Mostrar este elemento
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -542,6 +546,7 @@ es-ES:
       tagline: "¿Qué pondrás en tu TRMNL?"
       available: Disponible
       connected: Conectado
+      supported_by_this_device: Supported by this device
       recipes: Recetas
       recipes_hint: Plugins privados creados por miembros de la comunidad que se pueden instalar en 1 click. __Aprende más__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -294,6 +294,7 @@ fr:
       maximum_compatibility: Activer la compatibilité maximale
       maximum_compatibility_hint: Résout les problèmes d'affichage causés par certaines puces de pilote ePaper. Désactive le rafraîchissement rapide. Firmware 1.6.0+ requis.
       color_and_rotation: Couleur & Rotation
+      image_rotation: Image Rotation
       screen_rotation: Rotation de l'écran
       screen_rotation_not_supported: La rotation de l'écran n'est pas actuellement prise en charge sur votre appareil.
       palette: Color Palette
@@ -313,6 +314,7 @@ fr:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Identifiants Tidbyt
       tidbyt_credentials_hint: Entrez les identifiants API de votre appareil Tidbyt depuis l'app Tidbyt sous Paramètres → Développeur → Obtenir la clé API.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Les identifiants API Tidbyt sont invalides. Veuillez vérifier et réessayer.
       tidbyt_device_id: ID de l'appareil
       tidbyt_device_api_key: Clé API
@@ -438,6 +440,7 @@ fr:
       design_system: Utilisez notre système de design natif
       design_system_docs: Documentation système de design
       dirty_confirm: Vous avez des modifications non enregistrées. Êtes-vous sûr de vouloir quitter cette page ?
+      edit_composition: Edit Composition
       edit_markup: Modifier le balisage
       edit_markup_for_plugin: Modifier le balisage pour %{plugin_setting_name}
       edit_markup_please_save_first: Enregistrez avant de modifier le balisage
@@ -513,6 +516,7 @@ fr:
       show_playlist: Afficher cet élément
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -544,6 +548,7 @@ fr:
       tagline: Qu'allez-vous afficher sur votre TRMNL ?
       available: Disponible
       connected: Connecté
+      supported_by_this_device: Supported by this device
       recipes: Recettes
       recipes_hint: Plugins privés créés par des membres de la communauté pouvant être installés en 1 clic. __En apprendre plus__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -294,6 +294,7 @@ he:
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: Color & Rotation
+      image_rotation: Image Rotation
       screen_rotation: Screen Rotation
       screen_rotation_not_supported: Screen rotation is currently not supported on your device.
       palette: Color Palette
@@ -313,6 +314,7 @@ he:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
@@ -438,6 +440,7 @@ he:
       design_system: Leverage our native design system
       design_system_docs: Design System Docs
       dirty_confirm: You have unsaved changes. Are you sure you want to leave this page?
+      edit_composition: Edit Composition
       edit_markup: Edit Markup
       edit_markup_for_plugin: Edit markup for %{plugin_setting_name}
       edit_markup_please_save_first: Please save before editing markup
@@ -513,6 +516,7 @@ he:
       show_playlist: Show this item
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -544,6 +548,7 @@ he:
       tagline: What will you put on your TRMNL?
       available: Available
       connected: Connected
+      supported_by_this_device: Supported by this device
       recipes: Recipes
       recipes_hint: Private plugins by community members that can be installed in 1 click. __Learn more__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -292,6 +292,7 @@ hu:
       maximum_compatibility: Maximális kompatibilitás engedélyezése
       maximum_compatibility_hint: Kijavítja az egyes ePaper kijelzőchipek által okozott megjelenítési hibákat. Kikapcsolja a gyors frissítést. Firmware 1.6.0+ szükséges.
       color_and_rotation: Szín & forgatás
+      image_rotation: Image Rotation
       screen_rotation: Képernyő forgatása
       screen_rotation_not_supported: A képernyő forgatása jelenleg nem támogatott a te eszközödön.
       palette: Color Palette
@@ -311,6 +312,7 @@ hu:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
@@ -436,6 +438,7 @@ hu:
       design_system: Használd a beépített tervezési rendszert
       design_system_docs: Tervezési rendszer dokumentáció
       dirty_confirm: Vannak nem mentett módosításaid. Biztosan el szeretnéd hagyni az oldalt?
+      edit_composition: Edit Composition
       edit_markup: Jelölés szerkesztése
       edit_markup_for_plugin: 'Jelölés szerkesztése ehhez a bővítményhez: %{plugin_setting_name}'
       edit_markup_please_save_first: Kérlek, mentsd el a módosításokat, mielőtt szerkesztenéd a jelölést
@@ -511,6 +514,7 @@ hu:
       show_playlist: Elem megjelenítése
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -542,6 +546,7 @@ hu:
       tagline: Mit szeretnél megjeleníteni a TRMNL-on?
       available: Elérhető
       connected: Csatlakoztatva
+      supported_by_this_device: Supported by this device
       recipes: Receptek
       recipes_hint: Közösségi tagok által készített privát bővítmények, amelyek egy kattintással telepíthetők. __Tudj meg többet__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -294,6 +294,7 @@ id:
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: Warna dan Rotasi Layar
+      image_rotation: Image Rotation
       screen_rotation: Rotasi Layar
       screen_rotation_not_supported: Rotasi layar saat ini tidak didukung pada perangkat Anda.
       palette: Color Palette
@@ -313,6 +314,7 @@ id:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
@@ -438,6 +440,7 @@ id:
       design_system: Leverage our native design system
       design_system_docs: Design System Docs
       dirty_confirm: You have unsaved changes. Are you sure you want to leave this page?
+      edit_composition: Edit Composition
       edit_markup: Edit Markup
       edit_markup_for_plugin: Edit markup for %{plugin_setting_name}
       edit_markup_please_save_first: Please save before editing markup
@@ -513,6 +516,7 @@ id:
       show_playlist: Show this item
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -544,6 +548,7 @@ id:
       tagline: Apa yang ingin Anda tampilkan di TRMNL Anda?
       available: Tersedia
       connected: Terhubung
+      supported_by_this_device: Supported by this device
       recipes: Recipes
       recipes_hint: Private plugins by community members that can be installed in 1 click. __Learn more__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -292,6 +292,7 @@ is:
       maximum_compatibility: Hámarkssamhæfni
       maximum_compatibility_hint: Leysir skjávandamál af völdum sumra ePaper rekla. Slekkur á hraðri uppfærslu. Krefst fastbúnaðar 1.6.0+.
       color_and_rotation: Litur og Snúningur
+      image_rotation: Image Rotation
       screen_rotation: Skjásnúningur
       screen_rotation_not_supported: Skjásnúningur er ekki í boði fyrir þetta tæki.
       palette: Color Palette
@@ -311,6 +312,7 @@ is:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
@@ -436,6 +438,7 @@ is:
       design_system: Nýttu innbyggða hönnunarkerfið okkar
       design_system_docs: Skjöl hönnunarkerfis
       dirty_confirm: Þú er með óvistaðar breytingar. Ertu viss um að þú viljir yfirgefa síðuna?
+      edit_composition: Edit Composition
       edit_markup: Breyta ívafsmáli
       edit_markup_for_plugin: Breyta ívafsmáli fyrir %{plugin_setting_name}
       edit_markup_please_save_first: Vinsamlegast vistaðu áður en þú breytir ívafsmáli
@@ -511,6 +514,7 @@ is:
       show_playlist: Sýna þetta atriði
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -542,6 +546,7 @@ is:
       tagline: Hvað viltu setja á TRMNL tækið þitt?
       available: Tiltækar
       connected: Tengdar
+      supported_by_this_device: Supported by this device
       recipes: Uppskriftir
       recipes_hint: Einkaviðbætur frá samfélaginu sem hægt er að setja upp með einum smelli. __Lesa meira__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -292,6 +292,7 @@ it:
       maximum_compatibility: Abilita compatibilità massima
       maximum_compatibility_hint: Risolve problemi dello schermo causati da alcuni chip driver per ePaper. Disattiva il fast refresh. Richiede Firmware 1.6.0 o successivo.
       color_and_rotation: Colore e Rotazione
+      image_rotation: Image Rotation
       screen_rotation: Rotazione Schermo
       screen_rotation_not_supported: La rotazione dello schermo non è attualmente supportata sul tuo dispositivo.
       palette: Palette Colori
@@ -311,6 +312,7 @@ it:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Credenziali Tidbyt.
       tidbyt_credentials_hint: Inserisci le tue credenziali API per il dispositivo Tidbyt dall'applicazione Tidbyt nelle impostazioni -> Sviluppo -> Ottieni chiave API.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Credenziali API Tidbyt API Invalide. Perfavore controlla e riprova.
       tidbyt_device_id: ID Dispositivo
       tidbyt_device_api_key: Chiave API
@@ -436,6 +438,7 @@ it:
       design_system: Utilizza il nostro sistema di design nativo
       design_system_docs: Documentazione del sistema di design
       dirty_confirm: Hai dei cambiamenti non salvati. Sei sicuro di voler lasciare questa pagina?
+      edit_composition: Edit Composition
       edit_markup: Modifica Markup
       edit_markup_for_plugin: Modifica markup per %{plugin_setting_name}
       edit_markup_please_save_first: Per favore salva prima di modificare il markup
@@ -511,6 +514,7 @@ it:
       show_playlist: Mostra elemento
       duplicate: Duplica
       duplicate_confirm: Verrà creata una copia di questo articolo e aggiunta alla fine della playlist. Vuoi continuare?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Dispositivo Default (%{name})
       palette_unavailable: Disponibile solo per dispositivi con pattern a più colori
@@ -542,6 +546,7 @@ it:
       tagline: Cosa metterai sul tuo TRMNL?
       available: Disponibile
       connected: Connesso
+      supported_by_this_device: Supported by this device
       recipes: Recipes
       recipes_hint: Plugin privati dai membri della comunità possono essere installati in 1 click. __Scopri di più__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -292,6 +292,7 @@ ja:
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: 色と回転
+      image_rotation: Image Rotation
       screen_rotation: 画面回転
       screen_rotation_not_supported: 画面回転は現在、あなたのデバイスではサポートされていません。
       palette: Color Palette
@@ -311,6 +312,7 @@ ja:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
@@ -436,6 +438,7 @@ ja:
       design_system: ネイティブデザインシステムを活用する
       design_system_docs: デザインシステムドキュメント
       dirty_confirm: 保存されていない変更があります。このページを離れてもよろしいですか？
+      edit_composition: Edit Composition
       edit_markup: マークアップを編集
       edit_markup_for_plugin: "%{plugin_setting_name}のマークアップを編集"
       edit_markup_please_save_first: マークアップを編集する前に保存してください
@@ -511,6 +514,7 @@ ja:
       show_playlist: Show this item
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -542,6 +546,7 @@ ja:
       tagline: TRMNLに何を表示しますか？
       available: 利用可能なプラグイン
       connected: 接続済み
+      supported_by_this_device: Supported by this device
       recipes: レシピ
       recipes_hint: コミュニティメンバーによるプライベートプラグインで、ワンクリックでインストールできます。__詳細はこちら__。
     search:

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -292,6 +292,7 @@ ko:
       maximum_compatibility: 최대 호환성 활성화
       maximum_compatibility_hint: 특정 ePaper 드라이버 칩의 디스플레이 문제를 해결해요. 빠른 새로고침이 비활성화돼요. 펌웨어 1.6.0 이상 필요.
       color_and_rotation: 색상과 회전
+      image_rotation: Image Rotation
       screen_rotation: 화면 회전
       screen_rotation_not_supported: 화면 회전은 현재 지원되지 않아요.
       palette: 색상 팔레트
@@ -311,6 +312,7 @@ ko:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt 인증 정보
       tidbyt_credentials_hint: Tidbyt 앱의 설정 → 개발자 → API 키 받기에서 기기 API 인증 정보를 입력하세요.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API 인증 정보가 올바르지 않아요. 다시 확인해주세요.
       tidbyt_device_id: 기기 ID
       tidbyt_device_api_key: API 키
@@ -436,6 +438,7 @@ ko:
       design_system: 기본 디자인 시스템 활용하기
       design_system_docs: 디자인 시스템 문서
       dirty_confirm: 저장하지 않은 변경사항이 있어요. 이 페이지를 떠날까요?
+      edit_composition: Edit Composition
       edit_markup: 마크업 편집
       edit_markup_for_plugin: "%{plugin_setting_name} 마크업 편집"
       edit_markup_please_save_first: 마크업을 편집하기 전에 저장해주세요
@@ -511,6 +514,7 @@ ko:
       show_playlist: 이 항목 표시하기
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -542,6 +546,7 @@ ko:
       tagline: TRMNL에 무엇을 올릴까요?
       available: 사용 가능
       connected: 연결됨
+      supported_by_this_device: Supported by this device
       recipes: 레시피
       recipes_hint: 커뮤니티 멤버가 만든 비공개 플러그인을 한번의 클릭으로 설치할 수 있어요. __자세히 알아보기__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -292,6 +292,7 @@ lt:
       maximum_compatibility: Įjungti maksimalų suderinamumą
       maximum_compatibility_hint: Išsprendžia ekrano problemas, kurias sukelia tam tikros ePaper tvarkyklės. Išjungia greitąjį atnaujinimą. Reikalinga programinė įranga 1.6.0+.
       color_and_rotation: Spalvų ir ratavimas
+      image_rotation: Image Rotation
       screen_rotation: Ekranų ratavimas
       screen_rotation_not_supported: Ekranų ratavimas šiuo metu nepalaikomas jūsų įrenginyje.
       palette: Spalvų paletė
@@ -311,6 +312,7 @@ lt:
       touchbar_mode_hint: Į kokio tipo gestus turėtų reaguoti jūsų įrenginys?
       tidbyt_credentials: Tidbyt kredencialai
       tidbyt_credentials_hint: Įveskite savo Tidbyt įrenginio API kredencialus iš Tidbyt programėlės (skiltyje Settings → Developer → Get API Key).
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API kredencialai negalioja. Patikrinkite ir bandykite dar kartą.
       tidbyt_device_id: Įrenginio ID
       tidbyt_device_api_key: API raktas
@@ -436,6 +438,7 @@ lt:
       design_system: Pasinaudokite mūsų vietine dizaino sistema
       design_system_docs: Dizaino sistemos dokumentacija
       dirty_confirm: Turite neišsaugotų pakeitimų. Ar tikrai norite išeiti iš šio puslapio?
+      edit_composition: Edit Composition
       edit_markup: Redaguoti žymėjimą
       edit_markup_for_plugin: Redaguoti %{plugin_setting_name} žymėjimą
       edit_markup_please_save_first: Prieš redaguodami žymėjimą, išsaugokite
@@ -511,6 +514,7 @@ lt:
       show_playlist: Rodyti šį elementą
       duplicate: Dubliuoti
       duplicate_confirm: Tai sukurs šio elemento kopiją ir pridės ją prie jūsų grojaraščio apačios. Tęsti?
+      presentation: Presentation
       color_palette: Spalvų paletė
       device_default: Įrenginio numatytasis (%{name})
       palette_unavailable: Galima tik įrenginiams su keliomis spalvų paletėmis
@@ -542,6 +546,7 @@ lt:
       tagline: Ką įkelsite į savo TRMNL?
       available: Prieinami
       connected: Prijungti
+      supported_by_this_device: Supported by this device
       recipes: Receptai
       recipes_hint: Bendruomenės narių privatūs įskiepiai, kuriuos galima įdiegti 1 spustelėjimu. __Sužinokite daugiau__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -292,6 +292,7 @@ nl:
       maximum_compatibility: Activeer Maximale Compatibiliteit
       maximum_compatibility_hint: Los scherm issues op met bepaalde ePaper driver chips. Zet snelle verversing uit. Firmware 1.6.0+ benodigd.
       color_and_rotation: Kleur en rotatie
+      image_rotation: Image Rotation
       screen_rotation: Schermrotatie
       screen_rotation_not_supported: Schermrotatie is momenteel niet ondersteund op je apparaat.
       palette: Color Palette
@@ -311,6 +312,7 @@ nl:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
@@ -436,6 +438,7 @@ nl:
       design_system: Maak gebruik van ons native ontwerp-systeem
       design_system_docs: Documentatie van het ontwerp-systeem
       dirty_confirm: Je hebt niet-opgeslagen wijzigingen. Weet je zeker dat je deze pagina wilt verlaten?
+      edit_composition: Edit Composition
       edit_markup: Markup bewerken
       edit_markup_for_plugin: Markup voor %{plugin_setting_name} bewerken
       edit_markup_please_save_first: Sla op voordat je de markup bewerkt
@@ -511,6 +514,7 @@ nl:
       show_playlist: Toon dit item
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -542,6 +546,7 @@ nl:
       tagline: Wat ga jij op jouw TRMNL zetten?
       available: Beschikbaar
       connected: Verbonden
+      supported_by_this_device: Supported by this device
       recipes: Recepten
       recipes_hint: Privé-plugins van communityleden die met één klik kunnen worden geïnstalleerd. __Lees meer__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -292,6 +292,7 @@
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: Farge og rotasjon
+      image_rotation: Image Rotation
       screen_rotation: Skjermrotasjon
       screen_rotation_not_supported: Skjermrotasjon er ikke understøttet på din enhet.
       palette: Color Palette
@@ -311,6 +312,7 @@
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
@@ -436,6 +438,7 @@
       design_system: Dra nytte av vårt innebygde designsystem
       design_system_docs: Dokumentasjon for designsystem
       dirty_confirm: Du har uspurte endringer. Er du sikker på at du vil forlate denne siden?
+      edit_composition: Edit Composition
       edit_markup: Rediger markup
       edit_markup_for_plugin: Rediger markup for %{plugin_setting_name}
       edit_markup_please_save_first: Vennligst lagre før du redigerer markup
@@ -511,6 +514,7 @@
       show_playlist: Show this item
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -542,6 +546,7 @@
       tagline: Hva vil du vise på din TRMNL?
       available: Tilgjengelig
       connected: Tilkoblet
+      supported_by_this_device: Supported by this device
       recipes: Oppskrifter
       recipes_hint: Private plugins fra fellesskapet som kan installeres med ett klikk. __Les mer__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -314,6 +314,7 @@ pl:
       maximum_compatibility: Włącz maksymalną kompatybilność
       maximum_compatibility_hint: Rozwiązuje problemy z wyświetlaniem na niektórych wyświetlaczach ePaper. Wyłącza szybkie odświeżanie. Wymaga oprogramowania 1.6.0 lub nowszego.
       color_and_rotation: Kolor i obrót
+      image_rotation: Image Rotation
       screen_rotation: Obrót ekranu
       screen_rotation_not_supported: Obrót ekranu nie jest obecnie obsługiwany na Twoim urządzeniu.
       palette: Paleta kolorów
@@ -333,6 +334,7 @@ pl:
       touchbar_mode_hint: Na jakie gesty ma reagować Twoje urządzenie?
       tidbyt_credentials: Poświadczenia Tidbyt
       tidbyt_credentials_hint: Wprowadź poświadczenia API swojego urządzenia Tidbyt. Znajdziesz je w aplikacji Tidbyt w menu Settings → Developer → Get API Key
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Niepoprawne poświadczenia Tidbyt API. Sprawdź ich poprawność i spróbuj ponownie.
       tidbyt_device_id: ID urządzenia
       tidbyt_device_api_key: Klucz API
@@ -458,6 +460,7 @@ pl:
       design_system: Skorzystaj z naszego natywnego systemu projektowania
       design_system_docs: Dokumentacja systemu projektowania
       dirty_confirm: Masz niezapisane zmiany. Czy na pewno chcesz opuścić tę stronę?
+      edit_composition: Edit Composition
       edit_markup: Edytuj kod szablonu
       edit_markup_for_plugin: 'Edytuj kod szablonu: %{plugin_setting_name}'
       edit_markup_please_save_first: Zapisz zmiany przed rozpoczęciem edycji kodu szablonu
@@ -533,6 +536,7 @@ pl:
       show_playlist: Pokaż ten element
       duplicate: Duplikuj
       duplicate_confirm: Funkcja ta zduplikuje obiekt i umieści go na końcu playlisty. Kontynować?
+      presentation: Presentation
       color_palette: Paleta kolorów
       device_default: Domyślne dla urządzenia (%{name})
       palette_unavailable: Dostępne tylko dla urządzeń obsługujących palety kolorów
@@ -564,6 +568,7 @@ pl:
       tagline: Co umieścisz na swoim TRMNL?
       available: Dostępne
       connected: Połączone
+      supported_by_this_device: Supported by this device
       recipes: Receptury
       recipes_hint: Prywatne pluginy stworzone przez społeczność, które mogą być zainstalowane jednym kliknięciem. __Więcej informacji__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -292,6 +292,7 @@ pt-BR:
       maximum_compatibility: Habilitar Compatibilidade Máxima
       maximum_compatibility_hint: Resolve problemas de exibição causados por determinados chips ePaper. Desabilida a atualização rápida. Requer o firmware 1.6.0+.
       color_and_rotation: Color & Rotation
+      image_rotation: Image Rotation
       screen_rotation: Screen Rotation
       screen_rotation_not_supported: A rotação da tela não é suportada no seu dispositivo.
       palette: Color Palette
@@ -311,6 +312,7 @@ pt-BR:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
@@ -436,6 +438,7 @@ pt-BR:
       design_system: Utilize o nosso design system
       design_system_docs: Documentação do Design System
       dirty_confirm: Você tem alterações não salvas. Tem certeza que deseja sair dessa página?
+      edit_composition: Edit Composition
       edit_markup: Editar Markup
       edit_markup_for_plugin: Editar markup de %{plugin_setting_name}
       edit_markup_please_save_first: Por favor salve antes de editar o markup
@@ -511,6 +514,7 @@ pt-BR:
       show_playlist: Exibir esse item
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -542,6 +546,7 @@ pt-BR:
       tagline: O que você vai colocar no seu TRMNL?
       available: Disponíveis
       connected: Conectados
+      supported_by_this_device: Supported by this device
       recipes: Receitas
       recipes_hint: Plugins criados por membros da comunidade que podem ser instalados com 1 clique. __Saiba mais__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -292,6 +292,7 @@ raw:
       maximum_compatibility: devices.edit.maximum_compatibility
       maximum_compatibility_hint: devices.edit.maximum_compatibility_hint
       color_and_rotation: devices.edit.color_and_rotation
+      image_rotation: devices.edit.image_rotation
       screen_rotation: devices.edit.screen_rotation
       screen_rotation_not_supported: devices.edit.screen_rotation_not_supported
       palette: devices.edit.palette
@@ -311,6 +312,7 @@ raw:
       touchbar_mode_hint: devices.edit.touchbar_mode_hint
       tidbyt_credentials: devices.edit.tidbyt_credentials
       tidbyt_credentials_hint: devices.edit.tidbyt_credentials_hint
+      tidbyt_api_key: devices.edit.tidbyt_api_key
       tidbyt_credentials_invalid: devices.edit.tidbyt_credentials_invalid
       tidbyt_device_id: devices.edit.tidbyt_device_id
       tidbyt_device_api_key: devices.edit.tidbyt_device_api_key
@@ -436,6 +438,7 @@ raw:
       design_system: markups.form.design_system
       design_system_docs: markups.form.design_system_docs
       dirty_confirm: markups.form.dirty_confirm
+      edit_composition: markups.form.edit_composition
       edit_markup: markups.form.edit_markup
       edit_markup_for_plugin: markups.form.edit_markup_for_plugin
       edit_markup_please_save_first: markups.form.edit_markup_please_save_first
@@ -511,6 +514,7 @@ raw:
       show_playlist: playlists.playlist.show_playlist
       duplicate: playlist_items.playlist_item.duplicate
       duplicate_confirm: playlist_items.playlist_item.duplicate_confirm
+      presentation: playlist_items.playlist_item.presentation
       color_palette: playlist_items.playlist_item.color_palette
       device_default: playlist_items.playlist_item.device_default
       palette_unavailable: playlist_items.playlist_item.palette_unavailable
@@ -542,6 +546,7 @@ raw:
       tagline: plugins.index.tagline
       available: plugins.index.available
       connected: plugins.index.connected
+      supported_by_this_device: plugins.index.supported_by_this_device
       recipes: recipes
       recipes_hint: recipes_hint. __Learn more__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -292,6 +292,7 @@ ro:
       maximum_compatibility: Activează compatibilitate maximă
       maximum_compatibility_hint: Rezolvă problemele de afișare cauzate de anumite chipuri de driver ePaper. Dezactivează reîmprospătarea rapidă. Necesită firmware 1.6.0+.
       color_and_rotation: Culoare și rotație
+      image_rotation: Image Rotation
       screen_rotation: Rotație ecran
       screen_rotation_not_supported: Rotația ecranului nu este în prezent suportată pe dispozitivul tău.
       palette: Paletă de culori
@@ -311,6 +312,7 @@ ro:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Credențiale Tidbyt
       tidbyt_credentials_hint: Introdu credențialele API ale dispozitivului tău Tidbyt din aplicația Tidbyt sub Setări → Dezvoltator → Obține cheie API.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Credențialele API Tidbyt sunt invalide. Verifică și încearcă din nou.
       tidbyt_device_id: ID dispozitiv
       tidbyt_device_api_key: Cheie API
@@ -436,6 +438,7 @@ ro:
       design_system: Folosește sistemul nostru nativ de design
       design_system_docs: Documentație sistem design
       dirty_confirm: Ai modificări nesalvate. Ești sigur că vrei să părăsești această pagină?
+      edit_composition: Edit Composition
       edit_markup: Editează markup
       edit_markup_for_plugin: Editează markup pentru %{plugin_setting_name}
       edit_markup_please_save_first: Salvează înainte de a edita markup-ul
@@ -511,6 +514,7 @@ ro:
       show_playlist: Afișează acest element
       duplicate: Duplică
       duplicate_confirm: Aceasta va crea o copie a acestui element și o va adăuga la sfârșitul listei tale. Continui?
+      presentation: Presentation
       color_palette: Paletă de culori
       device_default: Implicit dispozitiv (%{name})
       palette_unavailable: Disponibil doar pentru dispozitive cu mai multe palete de culori
@@ -542,6 +546,7 @@ ro:
       tagline: Ce vei pune pe TRMNL-ul tău?
       available: Disponibile
       connected: Conectate
+      supported_by_this_device: Supported by this device
       recipes: Rețetare
       recipes_hint: Plugin-uri private create de membrii comunității care pot fi instalate cu un singur clic. __Află mai mult__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -314,6 +314,7 @@ ru:
       maximum_compatibility: Включить максимальную совместимость
       maximum_compatibility_hint: Устраняет проблемы с отображением, вызванные некоторыми чипами драйверов ePaper. Отключает быстрое обновление. Требуется прошивка 1.6.0+.
       color_and_rotation: Color & Rotation
+      image_rotation: Image Rotation
       screen_rotation: Screen Rotation
       screen_rotation_not_supported: Вращение экрана в настоящее время не поддерживается на вашем устройстве.
       palette: Color Palette
@@ -333,6 +334,7 @@ ru:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
@@ -458,6 +460,7 @@ ru:
       design_system: Используйте нашу нативную систему дизайна
       design_system_docs: Документация по системе дизайна
       dirty_confirm: У вас есть несохраненные изменения. Вы уверены, что хотите покинуть эту страницу?
+      edit_composition: Edit Composition
       edit_markup: Редактировать разметку
       edit_markup_for_plugin: Редактировать разметку для %{plugin_setting_name}
       edit_markup_please_save_first: Пожалуйста, сохраните перед редактированием разметки
@@ -533,6 +536,7 @@ ru:
       show_playlist: Показать этот элемент
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -564,6 +568,7 @@ ru:
       tagline: Что вы разместите на своем TRMNL?
       available: Доступно
       connected: Подключено
+      supported_by_this_device: Supported by this device
       recipes: Рецепты
       recipes_hint: Приватные плагины от участников сообщества, которые можно установить в 1 клик. __Узнать больше__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -303,6 +303,7 @@ sk:
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: Farba a otáčanie
+      image_rotation: Image Rotation
       screen_rotation: Otáčanie obrazovky
       screen_rotation_not_supported: Otáčanie obrazovky nie je momentálne podporované na vašom zariadení.
       palette: Color Palette
@@ -322,6 +323,7 @@ sk:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
@@ -447,6 +449,7 @@ sk:
       design_system: Leverage our native design system
       design_system_docs: Design System Docs
       dirty_confirm: You have unsaved changes. Are you sure you want to leave this page?
+      edit_composition: Edit Composition
       edit_markup: Edit Markup
       edit_markup_for_plugin: Edit markup for %{plugin_setting_name}
       edit_markup_please_save_first: Please save before editing markup
@@ -522,6 +525,7 @@ sk:
       show_playlist: Show this item
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -553,6 +557,7 @@ sk:
       tagline: What will you put on your TRMNL?
       available: Available
       connected: Connected
+      supported_by_this_device: Supported by this device
       recipes: Recipes
       recipes_hint: Private plugins by community members that can be installed in 1 click. __Learn more__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -292,6 +292,7 @@ sv:
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: Färg och rotation
+      image_rotation: Image Rotation
       screen_rotation: Skärmrotation
       screen_rotation_not_supported: Skärmrotation stöds för närvarande inte på din enhet.
       palette: Color Palette
@@ -311,6 +312,7 @@ sv:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
@@ -436,6 +438,7 @@ sv:
       design_system: Leverage our native design system
       design_system_docs: Design System Docs
       dirty_confirm: You have unsaved changes. Are you sure you want to leave this page?
+      edit_composition: Edit Composition
       edit_markup: Edit Markup
       edit_markup_for_plugin: Edit markup for %{plugin_setting_name}
       edit_markup_please_save_first: Please save before editing markup
@@ -511,6 +514,7 @@ sv:
       show_playlist: Show this item
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -542,6 +546,7 @@ sv:
       tagline: What will you put on your TRMNL?
       available: Available
       connected: Connected
+      supported_by_this_device: Supported by this device
       recipes: Recipes
       recipes_hint: Private plugins by community members that can be installed in 1 click. __Learn more__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -314,6 +314,7 @@ uk:
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: Колір і обертання
+      image_rotation: Image Rotation
       screen_rotation: Обертання екрану
       screen_rotation_not_supported: Обертання екрану в даний час не підтримується на вашому пристрої.
       palette: Color Palette
@@ -333,6 +334,7 @@ uk:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
@@ -458,6 +460,7 @@ uk:
       design_system: Leverage our native design system
       design_system_docs: Design System Docs
       dirty_confirm: You have unsaved changes. Are you sure you want to leave this page?
+      edit_composition: Edit Composition
       edit_markup: Edit Markup
       edit_markup_for_plugin: Edit markup for %{plugin_setting_name}
       edit_markup_please_save_first: Please save before editing markup
@@ -533,6 +536,7 @@ uk:
       show_playlist: Show this item
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -564,6 +568,7 @@ uk:
       tagline: Що ви бажаєте додати на свій TRMNL?
       available: Доступні
       connected: Підключені
+      supported_by_this_device: Supported by this device
       recipes: Recipes
       recipes_hint: Private plugins by community members that can be installed in 1 click. __Learn more__.
     search:

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -327,6 +327,7 @@ zh-CN:
       maximum_compatibility: 启用最大兼容模式
       maximum_compatibility_hint: 解决由某些电子墨水驱动芯片引发的显示问题。禁用快速刷新功能。需固件版本 1.6.0 及以上。
       color_and_rotation: 颜色和旋转
+      image_rotation: Image Rotation
       screen_rotation: 屏幕旋转
       screen_rotation_not_supported: 屏幕旋转目前不支持您的设备。
       palette: 调色板
@@ -346,6 +347,7 @@ zh-CN:
       touchbar_mode_hint: 您的设备应响应哪种类型的手势？
       tidbyt_credentials: Tidbyt 凭据
       tidbyt_credentials_hint: 从 Tidbyt 应用的「设置」→「开发者」→「获取 API 密钥」中输入您的 Tidbyt 设备的 API 凭据。
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API 凭据无效。请仔细检查后重试。
       tidbyt_device_id: 设备 ID
       tidbyt_device_api_key: API 密钥
@@ -471,6 +473,7 @@ zh-CN:
       design_system: 利用我们的原生设计系统
       design_system_docs: 设计系统文档
       dirty_confirm: 您有未保存的更改。确定要离开此页面吗？
+      edit_composition: Edit Composition
       edit_markup: 编辑标记
       edit_markup_for_plugin: 为 %{plugin_setting_name} 编辑标记
       edit_markup_please_save_first: 请先保存后再编辑标记
@@ -546,6 +549,7 @@ zh-CN:
       show_playlist: 显示此项
       duplicate: 复制
       duplicate_confirm: 这将创建此项的副本并将其添加到播放列表的底部。是否继续？
+      presentation: Presentation
       color_palette: 颜色调色板
       device_default: 设备默认（%{name}）
       palette_unavailable: 仅适用于具有多个颜色调色板的设备
@@ -577,6 +581,7 @@ zh-CN:
       tagline: 让您的 TRMNL 更加强大
       available: 可用
       connected: 已连接
+      supported_by_this_device: Supported by this device
       recipes: 配方
       recipes_hint: 社区成员开发的私有插件，支持一键安装。__了解更多__。
     search:

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -292,6 +292,7 @@ zh-HK:
       maximum_compatibility: 啟用最大兼容性
       maximum_compatibility_hint: 解決由某些電子墨水驅動晶片引起的顯示問題。會停用快速重新整理。需要韌體版本1.6.0或以上。
       color_and_rotation: 顏色和旋轉
+      image_rotation: Image Rotation
       screen_rotation: 屏幕旋轉
       screen_rotation_not_supported: 屏幕旋轉目前不支援你的裝置。
       palette: 色彩模式
@@ -311,6 +312,7 @@ zh-HK:
       touchbar_mode_hint: What type of gestures should your device respond to?
       tidbyt_credentials: Tidbyt憑證
       tidbyt_credentials_hint: 在Tidbyt應用程式前往「Settings → Developer → Get API Key」尋找你的Tidbyt裝置API憑證。
+      tidbyt_api_key: Tidbyt API Key
       tidbyt_credentials_invalid: Tidbyt API憑證無效。請檢查並重試。
       tidbyt_device_id: 裝置ID
       tidbyt_device_api_key: API金鑰
@@ -436,6 +438,7 @@ zh-HK:
       design_system: 活用我們的原生設計系統
       design_system_docs: 設計系統文件
       dirty_confirm: 你有未儲存的變更。確定要離開此頁面嗎？
+      edit_composition: Edit Composition
       edit_markup: 編輯標記碼
       edit_markup_for_plugin: 編輯「%{plugin_setting_name}」的標記碼
       edit_markup_please_save_first: 編輯標記碼前請先儲存
@@ -511,6 +514,7 @@ zh-HK:
       show_playlist: 顯示此項目
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
+      presentation: Presentation
       color_palette: Color Palette
       device_default: Device Default (%{name})
       palette_unavailable: Only available for devices with multiple color palettes
@@ -542,6 +546,7 @@ zh-HK:
       tagline: 你會在TRMNL上顯示什麼？
       available: 可使用
       connected: 已連接
+      supported_by_this_device: Supported by this device
       recipes: 模板(Recipe)
       recipes_hint: 社群成員開發的客製外掛，一鍵即可安裝。 __了解更多__
     search:


### PR DESCRIPTION
Core already calls `t()` for these five, so I18n had nothing to return and ActionView rendered a `translation_missing` span with a titleized fallback. English readers saw sensible words while no locale could reach the copy.

- `devices.edit.image_rotation` — the image rotate select on the device palette page, distinct from the existing `screen_rotation`, which is the orientation select above it
- `devices.edit.tidbyt_api_key` — the API key field label under the existing `tidbyt_credentials` heading
- `markups.form.edit_composition` — the Edit Composition button beside the existing Edit Markup
- `playlist_items.playlist_item.presentation` — the submenu label above the palette options in the playlist item menu
- `plugins.index.supported_by_this_device` — the heading above the supported plugins grid

Placed beside their siblings rather than alphabetically, and synced to every locale as untranslated English. Found with i18n-tasks.

Core needs a Gemfile.lock bump after this merges. The four other keys i18n-tasks flagged turned out not to need new entries and are fixed in https://github.com/usetrmnl/core/pull/4575.