### PR TITLE
Stopped sync creating English placeholders, and cleared the existing ones

### DIFF
--- a/lib/trmnl/i18n/locales/custom_plugins/da.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/da.yml
@@ -8,10 +8,10 @@ da:
     done: Udført
     due: Forfald
     deutsche_bahn_departures:
-      departures: Departures
+      departures:
       time: Tid
-      line: Line
-      destination: Destination
+      line:
+      destination:
       platform: Spor
       delay: Forsinkelse
       train: Tog
@@ -21,57 +21,13 @@ da:
       refreshed: Opdateret
     simple_calendar:
       title: Kalender
-      ym_format: "%B %Y"
+      ym_format:
       chinese_korean:
         leap_format: Spring %{month_label}
-        leap_format_short: LM%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        leap_format_short:
+        ym_format:
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
         - Træ
         - Træ
@@ -98,18 +54,12 @@ da:
         - Gris
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         - nisan
         - iyar
@@ -141,7 +91,7 @@ da:
         - ad1
         - ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - muharram
@@ -157,7 +107,7 @@ da:
         - dhuʻl-Qiʻdah
         - dhuʻl-Hijjah
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - boishakh
@@ -173,7 +123,7 @@ da:
         - falgun
         - choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - chaitra
@@ -191,25 +141,25 @@ da:
     public_recipe_stats:
       connections: ".input {$value :number} .match $value one {{{$value :number} forbindelse}} * {{{$value :number} forbindelser}}"
       forks: ".input {$value :number} .match $value one {{{$value :number} fork}} * {{{$value :number} forks}}"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
+      installs:
       and_more: og {$value :number} mere
-      error_keyword_title: "“{$keyword}” did not match any result."
-      error_keyword_subtitle: Try searching for something else.
-      error_new_title: No new recipe is found.
-      error_new_subtitle: This shouldn’t happen.
-      error_self_title: You did not publish any recipe.
-      error_self_subtitle: Learn how to publish your first one at https://help.trmnl.com/en/articles/9510536-private-plugins
-      error_author_id_title: 'User #{$authorId} did not publish any recipe.'
-      error_author_id_subtitle: No recipe is found associated with this ID.
-      error_recipe_ids_title: No recipe ID is found.
-      error_recipe_ids_subtitle: Add a recipe ID to get started.
+      error_keyword_title:
+      error_keyword_subtitle:
+      error_new_title:
+      error_new_subtitle:
+      error_self_title:
+      error_self_subtitle:
+      error_author_id_title:
+      error_author_id_subtitle:
+      error_recipe_ids_title:
+      error_recipe_ids_subtitle:
     horizontal_world_clock:
-      name: World clock
+      name:
     language_learning_sentences:
-      from_to: "{$from :langName} to {$to :langNameList}"
+      from_to:
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/de-AT.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/de-AT.yml
@@ -21,57 +21,13 @@ de-AT:
       refreshed: aktualisiert
     simple_calendar:
       title: Kalender
-      ym_format: "%B %Y"
+      ym_format:
       chinese_korean:
         leap_format: Schaltmonat %{month_label}
-        leap_format_short: LM%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        leap_format_short:
+        ym_format:
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
         - Holz
         - Holz
@@ -98,18 +54,12 @@ de-AT:
         - Schwein
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         - Nisan
         - Ijjar
@@ -141,7 +91,7 @@ de-AT:
         - Ad1
         - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - Muharram
@@ -157,23 +107,10 @@ de-AT:
         - Dhu l-qaʻda
         - Dhu l-Hiddscha
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - Chaitra
@@ -191,7 +128,7 @@ de-AT:
     public_recipe_stats:
       connections: ".input {$value :number} .match $value one {{{$value :number} Verbindung}} * {{{$value :number} Verbindungen}}"
       forks: ".input {$value :number} .match $value one {{{$value :number} fork}} * {{{$value :number} forks}}"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
+      installs:
       and_more: und {$value :number} weitere
       error_keyword_title: Kein Ergebnis für “{$keyword}”.
       error_keyword_subtitle: Versuche es mit einem anderen Suchbegriff.
@@ -208,8 +145,8 @@ de-AT:
     language_learning_sentences:
       from_to: "{$from :langName} bis {$to :langNameList}"
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/de.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/de.yml
@@ -21,57 +21,13 @@ de:
       refreshed: aktualisiert
     simple_calendar:
       title: Kalender
-      ym_format: "%B %Y"
+      ym_format:
       chinese_korean:
         leap_format: Schaltmonat %{month_label}
-        leap_format_short: LM%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        leap_format_short:
+        ym_format:
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
         - Holz
         - Holz
@@ -98,18 +54,12 @@ de:
         - Schwein
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         - Nisan
         - Ijjar
@@ -141,7 +91,7 @@ de:
         - Ad1
         - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - Muharram
@@ -157,23 +107,10 @@ de:
         - Dhu l-qaʻda
         - Dhu l-Hiddscha
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - Chaitra
@@ -191,7 +128,7 @@ de:
     public_recipe_stats:
       connections: ".input {$value :number} .match $value one {{{$value :number} Verbindung}} * {{{$value :number} Verbindungen}}"
       forks: ".input {$value :number} .match $value one {{{$value :number} fork}} * {{{$value :number} forks}}"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
+      installs:
       and_more: und {$value :number} weitere
       error_keyword_title: Kein Ergebnis für “{$keyword}”.
       error_keyword_subtitle: Versuche es mit einem anderen Suchbegriff.
@@ -208,8 +145,8 @@ de:
     language_learning_sentences:
       from_to: "{$from :langName} bis {$to :langNameList}"
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/es-ES.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/es-ES.yml
@@ -21,57 +21,13 @@ es-ES:
       refreshed: Actualizado
     simple_calendar:
       title: Calendario
-      ym_format: "%B %Y"
+      ym_format:
       chinese_korean:
         leap_format: "%{month_label} (Intercalado)"
         leap_format_short: "%{alt_month}int"
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        ym_format:
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
         - Madera
         - Madera
@@ -98,18 +54,12 @@ es-ES:
         - Cerdo
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         - Nisán
         - Iyar
@@ -141,7 +91,7 @@ es-ES:
         - Ad1
         - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - Muharram
@@ -157,37 +107,11 @@ es-ES:
         - Dhul-Qadah
         - Dhul-Hijah
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Chaitra
-        - Vaisakha
-        - Jyaistha
-        - Asadha
-        - Sravana
-        - Bhadra
-        - Asvina
-        - Kartika
-        - Agrahayana
-        - Pausa
-        - Magha
-        - Phalguna
     public_recipe_stats:
       connections: ".input {$value :number} .match $value one {{{$value :number} conexión}} many {{{$value :number} conexiones}} * {{{$value :number} conexiones}}"
       forks: ".input {$value :number} .match $value one {{{$value :number} fork}} many {{{$value :number} forks}} * {{{$value :number} forks}}"
@@ -208,8 +132,8 @@ es-ES:
     language_learning_sentences:
       from_to: "{$from :langName} a {$to :langNameList}"
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/fr.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/fr.yml
@@ -11,67 +11,23 @@ fr:
       departures: Départs
       time: Heure
       line: Ligne
-      destination: Destination
+      destination:
       platform: Quai
       delay: Retard
-      train: Train
+      train:
       on_time: À l'heure
       cancelled: Annulé
       minutes: min
       refreshed: Rafraîchi
     simple_calendar:
       title: Calendrier
-      ym_format: "%B %Y"
+      ym_format:
       chinese_korean:
         leap_format: Bissextile %{month_label}
         leap_format_short: MB%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        ym_format:
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
         - Bois
         - Bois
@@ -98,18 +54,12 @@ fr:
         - Cochon
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         - nissan
         - iyar
@@ -141,7 +91,7 @@ fr:
         - ad1
         - ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - mouharram
@@ -157,7 +107,7 @@ fr:
         - dhou al qi`da
         - dhou al-hijja
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - boishakh
@@ -173,7 +123,7 @@ fr:
         - falgun
         - choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - chaitra
@@ -190,25 +140,25 @@ fr:
     public_recipe_stats:
       connections: ".input {$value :number} .match $value one {{{$value :number} connexion}} many {{{$value :number} connexions}} * {{{$value :number} connexions}}"
       forks: ".input {$value :number} .match $value one {{{$value :number} duplication}} many {{{$value :number} duplications}} * {{{$value :number} duplications}}"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
+      installs:
       and_more: et {$value :number} de plus
-      error_keyword_title: "“{$keyword}” did not match any result."
-      error_keyword_subtitle: Try searching for something else.
-      error_new_title: No new recipe is found.
-      error_new_subtitle: This shouldn’t happen.
-      error_self_title: You did not publish any recipe.
-      error_self_subtitle: Learn how to publish your first one at https://help.trmnl.com/en/articles/9510536-private-plugins
-      error_author_id_title: 'User #{$authorId} did not publish any recipe.'
-      error_author_id_subtitle: No recipe is found associated with this ID.
-      error_recipe_ids_title: No recipe ID is found.
-      error_recipe_ids_subtitle: Add a recipe ID to get started.
+      error_keyword_title:
+      error_keyword_subtitle:
+      error_new_title:
+      error_new_subtitle:
+      error_self_title:
+      error_self_subtitle:
+      error_author_id_title:
+      error_author_id_subtitle:
+      error_recipe_ids_title:
+      error_recipe_ids_subtitle:
     horizontal_world_clock:
-      name: World clock
+      name:
     language_learning_sentences:
-      from_to: "{$from :langName} to {$to :langNameList}"
+      from_to:
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/he.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/he.yml
@@ -3,113 +3,41 @@ he:
   custom_plugins:
     today: היום
     tomorrow: מחר
-    updated: Updated
-    activity: Activity
-    done: Done
-    due: Due
+    updated:
+    activity:
+    done:
+    due:
     deutsche_bahn_departures:
-      departures: Departures
-      time: Time
-      line: Line
-      destination: Destination
-      platform: Platform
-      delay: Delay
-      train: Train
-      on_time: On time
-      cancelled: Cancelled
-      minutes: m
-      refreshed: Refreshed
+      departures:
+      time:
+      line:
+      destination:
+      platform:
+      delay:
+      train:
+      on_time:
+      cancelled:
+      minutes:
+      refreshed:
     simple_calendar:
       title: לוח שנה
-      ym_format: "%B %Y"
+      ym_format:
       chinese_korean:
-        leap_format: Leap %{month_label}
-        leap_format_short: LM%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        leap_format:
+        leap_format_short:
+        ym_format:
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
-        - Wood
-        - Wood
-        - Fire
-        - Fire
-        - Earth
-        - Earth
-        - Metal
-        - Metal
-        - Water
-        - Water
         earthly_branches:
-        - Rat
-        - Ox
-        - Tiger
-        - Rabbit
-        - Dragon
-        - Snake
-        - Horse
-        - Goat
-        - Monkey
-        - Rooster
-        - Dog
-        - Pig
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         - ניסן
         - אייר
@@ -141,7 +69,7 @@ he:
         - א״א
         - א״ב
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - מוחרם
@@ -157,23 +85,10 @@ he:
         - ד׳ו אל־קעדה
         - ד׳ו אל־חיג׳ה
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - צ׳ייטרה
@@ -189,27 +104,27 @@ he:
         - מאגהה
         - פאלגונה
     public_recipe_stats:
-      connections: ".input {$value :number} .match $value zero {{No connection}} one {{{$value :number} connection}} * {{{$value :number} connections}}"
-      forks: ".input {$value :number} .match $value zero {{No fork}} one {{{$value :number} fork}} * {{{$value :number} forks}}"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
-      and_more: and {$value :number} more
-      error_keyword_title: "“{$keyword}” did not match any result."
-      error_keyword_subtitle: Try searching for something else.
-      error_new_title: No new recipe is found.
-      error_new_subtitle: This shouldn’t happen.
-      error_self_title: You did not publish any recipe.
-      error_self_subtitle: Learn how to publish your first one at https://help.trmnl.com/en/articles/9510536-private-plugins
-      error_author_id_title: 'User #{$authorId} did not publish any recipe.'
-      error_author_id_subtitle: No recipe is found associated with this ID.
-      error_recipe_ids_title: No recipe ID is found.
-      error_recipe_ids_subtitle: Add a recipe ID to get started.
+      connections:
+      forks:
+      installs:
+      and_more:
+      error_keyword_title:
+      error_keyword_subtitle:
+      error_new_title:
+      error_new_subtitle:
+      error_self_title:
+      error_self_subtitle:
+      error_author_id_title:
+      error_author_id_subtitle:
+      error_recipe_ids_title:
+      error_recipe_ids_subtitle:
     horizontal_world_clock:
-      name: World clock
+      name:
     language_learning_sentences:
-      from_to: "{$from :langName} to {$to :langNameList}"
+      from_to:
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/hu.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/hu.yml
@@ -1,215 +1,76 @@
 ---
 hu:
   custom_plugins:
-    today: today
-    tomorrow: tomorrow
-    updated: Updated
-    activity: Activity
-    done: Done
-    due: Due
+    today:
+    tomorrow:
+    updated:
+    activity:
+    done:
+    due:
     deutsche_bahn_departures:
-      departures: Departures
-      time: Time
-      line: Line
-      destination: Destination
-      platform: Platform
-      delay: Delay
-      train: Train
-      on_time: On time
-      cancelled: Cancelled
-      minutes: m
-      refreshed: Refreshed
+      departures:
+      time:
+      line:
+      destination:
+      platform:
+      delay:
+      train:
+      on_time:
+      cancelled:
+      minutes:
+      refreshed:
     simple_calendar:
-      title: Calendar
-      ym_format: "%B %Y"
+      title:
+      ym_format:
       chinese_korean:
-        leap_format: Leap %{month_label}
-        leap_format_short: LM%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        leap_format:
+        leap_format_short:
+        ym_format:
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
-        - Wood
-        - Wood
-        - Fire
-        - Fire
-        - Earth
-        - Earth
-        - Metal
-        - Metal
-        - Water
-        - Water
         earthly_branches:
-        - Rat
-        - Ox
-        - Tiger
-        - Rabbit
-        - Dragon
-        - Snake
-        - Horse
-        - Goat
-        - Monkey
-        - Rooster
-        - Dog
-        - Pig
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        - Nisan
-        - Iyar
-        - Sivan
-        - Tamuz
-        - Av
-        - Elul
-        - Tishri
-        - Heshvan
-        - Kislev
-        - Tevet
-        - Shevat
-        - Adar
-        - Adar I
-        - Adar II
         month_labels_abbr:
-        - Nis
-        - Iya
-        - Siv
-        - Tam
-        - Av
-        - Elu
-        - Tis
-        - Hes
-        - Kis
-        - Tev
-        - Shv
-        - Ada
-        - Ad1
-        - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Muharram
-        - Safar
-        - Rabiʻ I
-        - Rabiʻ II
-        - Jumada I
-        - Jumada II
-        - Rajab
-        - Shaʻban
-        - Ramadan
-        - Shawwal
-        - Dhuʻl-Qiʻdah
-        - Dhuʻl-Hijjah
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Chaitra
-        - Vaisakha
-        - Jyaistha
-        - Asadha
-        - Sravana
-        - Bhadra
-        - Asvina
-        - Kartika
-        - Agrahayana
-        - Pausa
-        - Magha
-        - Phalguna
     public_recipe_stats:
       connections: ".input {$value :number} .match $value one {{{$value :number} kapcsolat}} * {{{$value :number} kapcsolatok}}"
       forks: ".input {$value :number} .match $value one {{{$value :number} fork}} * {{{$value :number} forks}}"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
+      installs:
       and_more: és {$value :number} további
-      error_keyword_title: "“{$keyword}” did not match any result."
-      error_keyword_subtitle: Try searching for something else.
-      error_new_title: No new recipe is found.
-      error_new_subtitle: This shouldn’t happen.
-      error_self_title: You did not publish any recipe.
-      error_self_subtitle: Learn how to publish your first one at https://help.trmnl.com/en/articles/9510536-private-plugins
-      error_author_id_title: 'User #{$authorId} did not publish any recipe.'
-      error_author_id_subtitle: No recipe is found associated with this ID.
-      error_recipe_ids_title: No recipe ID is found.
-      error_recipe_ids_subtitle: Add a recipe ID to get started.
+      error_keyword_title:
+      error_keyword_subtitle:
+      error_new_title:
+      error_new_subtitle:
+      error_self_title:
+      error_self_subtitle:
+      error_author_id_title:
+      error_author_id_subtitle:
+      error_recipe_ids_title:
+      error_recipe_ids_subtitle:
     horizontal_world_clock:
-      name: World clock
+      name:
     language_learning_sentences:
-      from_to: "{$from :langName} to {$to :langNameList}"
+      from_to:
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/id.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/id.yml
@@ -1,147 +1,47 @@
 ---
 id:
   custom_plugins:
-    today: today
-    tomorrow: tomorrow
-    updated: Updated
-    activity: Activity
-    done: Done
-    due: Due
+    today:
+    tomorrow:
+    updated:
+    activity:
+    done:
+    due:
     deutsche_bahn_departures:
-      departures: Departures
-      time: Time
-      line: Line
-      destination: Destination
-      platform: Platform
-      delay: Delay
-      train: Train
-      on_time: On time
-      cancelled: Cancelled
-      minutes: m
-      refreshed: Refreshed
+      departures:
+      time:
+      line:
+      destination:
+      platform:
+      delay:
+      train:
+      on_time:
+      cancelled:
+      minutes:
+      refreshed:
     simple_calendar:
       title: Kalender
-      ym_format: "%B %Y"
+      ym_format:
       chinese_korean:
-        leap_format: Leap %{month_label}
-        leap_format_short: LM%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        leap_format:
+        leap_format_short:
+        ym_format:
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
-        - Wood
-        - Wood
-        - Fire
-        - Fire
-        - Earth
-        - Earth
-        - Metal
-        - Metal
-        - Water
-        - Water
         earthly_branches:
-        - Rat
-        - Ox
-        - Tiger
-        - Rabbit
-        - Dragon
-        - Snake
-        - Horse
-        - Goat
-        - Monkey
-        - Rooster
-        - Dog
-        - Pig
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        - Nisan
-        - Iyar
-        - Sivan
-        - Tamuz
-        - Av
-        - Elul
-        - Tishri
-        - Heshvan
-        - Kislev
-        - Tevet
-        - Shevat
-        - Adar
-        - Adar I
-        - Adar II
         month_labels_abbr:
-        - Nis
-        - Iya
-        - Siv
-        - Tam
-        - Av
-        - Elu
-        - Tis
-        - Hes
-        - Kis
-        - Tev
-        - Shv
-        - Ada
-        - Ad1
-        - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - Muharam
@@ -157,59 +57,33 @@ id:
         - Zulkaidah
         - Zulhijah
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Chaitra
-        - Vaisakha
-        - Jyaistha
-        - Asadha
-        - Sravana
-        - Bhadra
-        - Asvina
-        - Kartika
-        - Agrahayana
-        - Pausa
-        - Magha
-        - Phalguna
     public_recipe_stats:
-      connections: ".input {$value :number} .match $value zero {{No connection}} one {{{$value :number} connection}} * {{{$value :number} connections}}"
-      forks: ".input {$value :number} .match $value zero {{No fork}} one {{{$value :number} fork}} * {{{$value :number} forks}}"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
-      and_more: and {$value :number} more
-      error_keyword_title: "“{$keyword}” did not match any result."
-      error_keyword_subtitle: Try searching for something else.
-      error_new_title: No new recipe is found.
-      error_new_subtitle: This shouldn’t happen.
-      error_self_title: You did not publish any recipe.
-      error_self_subtitle: Learn how to publish your first one at https://help.trmnl.com/en/articles/9510536-private-plugins
-      error_author_id_title: 'User #{$authorId} did not publish any recipe.'
-      error_author_id_subtitle: No recipe is found associated with this ID.
-      error_recipe_ids_title: No recipe ID is found.
-      error_recipe_ids_subtitle: Add a recipe ID to get started.
+      connections:
+      forks:
+      installs:
+      and_more:
+      error_keyword_title:
+      error_keyword_subtitle:
+      error_new_title:
+      error_new_subtitle:
+      error_self_title:
+      error_self_subtitle:
+      error_author_id_title:
+      error_author_id_subtitle:
+      error_recipe_ids_title:
+      error_recipe_ids_subtitle:
     horizontal_world_clock:
-      name: World clock
+      name:
     language_learning_sentences:
-      from_to: "{$from :langName} to {$to :langNameList}"
+      from_to:
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/is.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/is.yml
@@ -17,61 +17,17 @@ is:
       train: Lest
       on_time: Á réttum tíma
       cancelled: Aflýst
-      minutes: m
+      minutes:
       refreshed: Uppfært
     simple_calendar:
       title: Dagatal
-      ym_format: "%B %Y"
+      ym_format:
       chinese_korean:
         leap_format: Hlaup %{month_label}
-        leap_format_short: LM%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        leap_format_short:
+        ym_format:
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
         - Viður
         - Viður
@@ -98,118 +54,45 @@ is:
         - Svín
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        - Nisan
-        - Iyar
-        - Sivan
-        - Tamuz
-        - Av
-        - Elul
-        - Tishri
-        - Heshvan
-        - Kislev
-        - Tevet
-        - Shevat
-        - Adar
-        - Adar I
-        - Adar II
         month_labels_abbr:
-        - Nis
-        - Iya
-        - Siv
-        - Tam
-        - Av
-        - Elu
-        - Tis
-        - Hes
-        - Kis
-        - Tev
-        - Shv
-        - Ada
-        - Ad1
-        - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Muharram
-        - Safar
-        - Rabiʻ I
-        - Rabiʻ II
-        - Jumada I
-        - Jumada II
-        - Rajab
-        - Shaʻban
-        - Ramadan
-        - Shawwal
-        - Dhuʻl-Qiʻdah
-        - Dhuʻl-Hijjah
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Chaitra
-        - Vaisakha
-        - Jyaistha
-        - Asadha
-        - Sravana
-        - Bhadra
-        - Asvina
-        - Kartika
-        - Agrahayana
-        - Pausa
-        - Magha
-        - Phalguna
     public_recipe_stats:
       connections: ".input {$value :number} .match $value one {{{$value :number} tenging}} * {{{$value :number} tengingar}}"
       forks: ".input {$value :number} .match $value one {{{$value :number} sjálfun}} * {{{$value :number} sjálfanir}}"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
+      installs:
       and_more: og {$value :number} fleiri
-      error_keyword_title: "“{$keyword}” did not match any result."
-      error_keyword_subtitle: Try searching for something else.
-      error_new_title: No new recipe is found.
-      error_new_subtitle: This shouldn’t happen.
-      error_self_title: You did not publish any recipe.
-      error_self_subtitle: Learn how to publish your first one at https://help.trmnl.com/en/articles/9510536-private-plugins
-      error_author_id_title: 'User #{$authorId} did not publish any recipe.'
-      error_author_id_subtitle: No recipe is found associated with this ID.
-      error_recipe_ids_title: No recipe ID is found.
-      error_recipe_ids_subtitle: Add a recipe ID to get started.
+      error_keyword_title:
+      error_keyword_subtitle:
+      error_new_title:
+      error_new_subtitle:
+      error_self_title:
+      error_self_subtitle:
+      error_author_id_title:
+      error_author_id_subtitle:
+      error_recipe_ids_title:
+      error_recipe_ids_subtitle:
     horizontal_world_clock:
-      name: World clock
+      name:
     language_learning_sentences:
-      from_to: "{$from :langName} to {$to :langNameList}"
+      from_to:
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/it.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/it.yml
@@ -9,7 +9,7 @@ it:
     due: Scadenza
     deutsche_bahn_departures:
       departures: Partenze
-      time: Time
+      time:
       line: Linea
       destination: Destinazione
       platform: Piattaforma
@@ -17,163 +17,37 @@ it:
       train: Treno
       on_time: In Tempo
       cancelled: Cancellato
-      minutes: m
+      minutes:
       refreshed: Aggiornato
     simple_calendar:
       title: Calendario
-      ym_format: "%B %Y"
+      ym_format:
       chinese_korean:
-        leap_format: Leap %{month_label}
-        leap_format_short: LM%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        leap_format:
+        leap_format_short:
+        ym_format:
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
-        - Wood
-        - Wood
-        - Fire
-        - Fire
-        - Earth
-        - Earth
-        - Metal
-        - Metal
-        - Water
-        - Water
         earthly_branches:
-        - Rat
-        - Ox
-        - Tiger
-        - Rabbit
-        - Dragon
-        - Snake
-        - Horse
-        - Goat
-        - Monkey
-        - Rooster
-        - Dog
-        - Pig
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        - Nisan
-        - Iyar
-        - Sivan
-        - Tamuz
-        - Av
-        - Elul
-        - Tishri
-        - Heshvan
-        - Kislev
-        - Tevet
-        - Shevat
-        - Adar
-        - Adar I
-        - Adar II
         month_labels_abbr:
-        - Nis
-        - Iya
-        - Siv
-        - Tam
-        - Av
-        - Elu
-        - Tis
-        - Hes
-        - Kis
-        - Tev
-        - Shv
-        - Ada
-        - Ad1
-        - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Muharram
-        - Safar
-        - Rabiʻ I
-        - Rabiʻ II
-        - Jumada I
-        - Jumada II
-        - Rajab
-        - Shaʻban
-        - Ramadan
-        - Shawwal
-        - Dhuʻl-Qiʻdah
-        - Dhuʻl-Hijjah
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - Chaitra
@@ -191,10 +65,10 @@ it:
     public_recipe_stats:
       connections: ".input {$value :number} .match $value one {{{$value :number} connessione}} many {{{$value :number} connessioni}} * {{{$value :number} connessioni}}"
       forks: ".input {$value :number} .match $value one {{{$value :number} fork}} many {{{$value :number} forks}} * {{{$value :number} forks}}"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
+      installs:
       and_more: e {$value :number} più
-      error_keyword_title: "“{$keyword}” did not match any result."
-      error_keyword_subtitle: Try searching for something else.
+      error_keyword_title:
+      error_keyword_subtitle:
       error_new_title: Nessuna nuova recipe è stata trovata.
       error_new_subtitle: Questo non dovrebbe accadere.
       error_self_title: Non hai pubblicato nessuna recipe.
@@ -204,12 +78,12 @@ it:
       error_recipe_ids_title: Nessun ID recipe trovato.
       error_recipe_ids_subtitle: Aggiungi l'ID di una recipe per iniziare.
     horizontal_world_clock:
-      name: World clock
+      name:
     language_learning_sentences:
-      from_to: "{$from :langName} to {$to :langNameList}"
+      from_to:
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/ja.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/ja.yml
@@ -3,28 +3,28 @@ ja:
   custom_plugins:
     today: 今日
     tomorrow: 明日
-    updated: Updated
-    activity: Activity
-    done: Done
-    due: Due
+    updated:
+    activity:
+    done:
+    due:
     deutsche_bahn_departures:
-      departures: Departures
-      time: Time
-      line: Line
-      destination: Destination
-      platform: Platform
-      delay: Delay
-      train: Train
-      on_time: On time
-      cancelled: Cancelled
-      minutes: m
-      refreshed: Refreshed
+      departures:
+      time:
+      line:
+      destination:
+      platform:
+      delay:
+      train:
+      on_time:
+      cancelled:
+      minutes:
+      refreshed:
     simple_calendar:
       title: カレンダー
       ym_format: "%Y年%-m月"
       chinese_korean:
         leap_format: 閏%{month_label}
-        leap_format_short: LM%{alt_month}
+        leap_format_short:
         ym_format: ", %{heavenly_stem}%{earthly_branch}年%{leap_month_label}"
         month_labels:
         -
@@ -41,37 +41,6 @@ ja:
         - 十一月
         - 十二月
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
         - 甲
         - 乙
@@ -98,115 +67,42 @@ ja:
         - 亥
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
           reiwa: 令和
         ym_format: "%Y年 (%{nengo}%{alt_year}年) %-m月"
         year_1: 元
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        - Nisan
-        - Iyar
-        - Sivan
-        - Tamuz
-        - Av
-        - Elul
-        - Tishri
-        - Heshvan
-        - Kislev
-        - Tevet
-        - Shevat
-        - Adar
-        - Adar I
-        - Adar II
         month_labels_abbr:
-        - Nis
-        - Iya
-        - Siv
-        - Tam
-        - Av
-        - Elu
-        - Tis
-        - Hes
-        - Kis
-        - Tev
-        - Shv
-        - Ada
-        - Ad1
-        - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Muharram
-        - Safar
-        - Rabiʻ I
-        - Rabiʻ II
-        - Jumada I
-        - Jumada II
-        - Rajab
-        - Shaʻban
-        - Ramadan
-        - Shawwal
-        - Dhuʻl-Qiʻdah
-        - Dhuʻl-Hijjah
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Chaitra
-        - Vaisakha
-        - Jyaistha
-        - Asadha
-        - Sravana
-        - Bhadra
-        - Asvina
-        - Kartika
-        - Agrahayana
-        - Pausa
-        - Magha
-        - Phalguna
     public_recipe_stats:
-      connections: ".input {$value :number} .match $value zero {{No connection}} one {{{$value :number} connection}} * {{{$value :number} connections}}"
-      forks: ".input {$value :number} .match $value zero {{No fork}} one {{{$value :number} fork}} * {{{$value :number} forks}}"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
-      and_more: and {$value :number} more
-      error_keyword_title: "“{$keyword}” did not match any result."
-      error_keyword_subtitle: Try searching for something else.
-      error_new_title: No new recipe is found.
-      error_new_subtitle: This shouldn’t happen.
-      error_self_title: You did not publish any recipe.
-      error_self_subtitle: Learn how to publish your first one at https://help.trmnl.com/en/articles/9510536-private-plugins
-      error_author_id_title: 'User #{$authorId} did not publish any recipe.'
-      error_author_id_subtitle: No recipe is found associated with this ID.
-      error_recipe_ids_title: No recipe ID is found.
-      error_recipe_ids_subtitle: Add a recipe ID to get started.
+      connections:
+      forks:
+      installs:
+      and_more:
+      error_keyword_title:
+      error_keyword_subtitle:
+      error_new_title:
+      error_new_subtitle:
+      error_self_title:
+      error_self_subtitle:
+      error_author_id_title:
+      error_author_id_subtitle:
+      error_recipe_ids_title:
+      error_recipe_ids_subtitle:
     horizontal_world_clock:
-      name: World clock
+      name:
     language_learning_sentences:
-      from_to: "{$from :langName} to {$to :langNameList}"
+      from_to:
     custom_next_holiday:
       next_holiday: 次の祝日
       today_and_next: ".input {$nextDays :number} .match $nextDays 1 {{ {#mainLabel}今日は{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}明日は{$nextName}です。{/subLabel} }} 2 {{ {#mainLabel}今日は{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}明後日は{$nextName}です。{/subLabel} }} * {{ {#mainLabel}今日は{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}次の祝日の{$nextName}まであと {$nextDays} 日です。{/subLabel} }}"

--- a/lib/trmnl/i18n/locales/custom_plugins/ko.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/ko.yml
@@ -24,7 +24,7 @@ ko:
       ym_format: "%Y년 %-m월"
       chinese_korean:
         leap_format: 윤%{month_label}
-        leap_format_short: LM%{alt_month}
+        leap_format_short:
         ym_format: ", %{heavenly_stem}%{earthly_branch}년 %{leap_month_label}"
         month_labels:
         -
@@ -41,37 +41,6 @@ ko:
         - 11월
         - 12월
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
         - 갑
         - 을
@@ -98,96 +67,23 @@ ko:
         - 해
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
           reiwa: 레이와
         ym_format: "%Y년 (%{nengo} %{alt_year}년) %-m월"
         year_1: 원
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        - Nisan
-        - Iyar
-        - Sivan
-        - Tamuz
-        - Av
-        - Elul
-        - Tishri
-        - Heshvan
-        - Kislev
-        - Tevet
-        - Shevat
-        - Adar
-        - Adar I
-        - Adar II
         month_labels_abbr:
-        - Nis
-        - Iya
-        - Siv
-        - Tam
-        - Av
-        - Elu
-        - Tis
-        - Hes
-        - Kis
-        - Tev
-        - Shv
-        - Ada
-        - Ad1
-        - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Muharram
-        - Safar
-        - Rabiʻ I
-        - Rabiʻ II
-        - Jumada I
-        - Jumada II
-        - Rajab
-        - Shaʻban
-        - Ramadan
-        - Shawwal
-        - Dhuʻl-Qiʻdah
-        - Dhuʻl-Hijjah
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Chaitra
-        - Vaisakha
-        - Jyaistha
-        - Asadha
-        - Sravana
-        - Bhadra
-        - Asvina
-        - Kartika
-        - Agrahayana
-        - Pausa
-        - Magha
-        - Phalguna
     public_recipe_stats:
       connections: "{$value :number}개 연결"
       forks: "{$value :number}개 포크"
@@ -208,8 +104,8 @@ ko:
     language_learning_sentences:
       from_to: "{$from :langName}에서 {$to :langNameList}(으)로"
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/lt.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/lt.yml
@@ -21,57 +21,13 @@ lt:
       refreshed: Atnaujinta
     simple_calendar:
       title: Kalendorius
-      ym_format: "%B %Y"
+      ym_format:
       chinese_korean:
         leap_format: Keliamasis %{month_label}
         leap_format_short: KM%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        ym_format:
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
         - Medis
         - Medis
@@ -98,18 +54,12 @@ lt:
         - Kiaulė
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         - Nisanas
         - Ijaras
@@ -141,7 +91,7 @@ lt:
         - Ad1
         - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - Muharramas
@@ -157,7 +107,7 @@ lt:
         - Zu al-Kada
         - Zu al-Hidža
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - Boišachas
@@ -173,7 +123,7 @@ lt:
         - Falgunas
         - Čoitras
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - Čaitra
@@ -208,8 +158,8 @@ lt:
     language_learning_sentences:
       from_to: iš {$from :langName} į {$to :langNameList}
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/nl.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/nl.yml
@@ -17,99 +17,27 @@ nl:
       train: Trein
       on_time: Op tijd
       cancelled: Geannuleerd
-      minutes: m
+      minutes:
       refreshed: Vernieuwd
     simple_calendar:
       title: Kalender
-      ym_format: "%B %Y"
+      ym_format:
       chinese_korean:
-        leap_format: Leap %{month_label}
-        leap_format_short: LM%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        leap_format:
+        leap_format_short:
+        ym_format:
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
-        - Wood
-        - Wood
-        - Fire
-        - Fire
-        - Earth
-        - Earth
-        - Metal
-        - Metal
-        - Water
-        - Water
         earthly_branches:
-        - Rat
-        - Ox
-        - Tiger
-        - Rabbit
-        - Dragon
-        - Snake
-        - Horse
-        - Goat
-        - Monkey
-        - Rooster
-        - Dog
-        - Pig
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         - Nisan
         - Ijar
@@ -141,7 +69,7 @@ nl:
         - AdA
         - AdB
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - Moeharram
@@ -157,23 +85,10 @@ nl:
         - Doe al kaʻaba
         - Doe al hizja
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - Chaitra
@@ -189,27 +104,27 @@ nl:
         - Maagha
         - Phaalguna
     public_recipe_stats:
-      connections: ".input {$value :number} .match $value zero {{No connection}} one {{{$value :number} connection}} * {{{$value :number} connections}}"
-      forks: ".input {$value :number} .match $value zero {{No fork}} one {{{$value :number} fork}} * {{{$value :number} forks}}"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
+      connections:
+      forks:
+      installs:
       and_more: en nog {$value :number}
-      error_keyword_title: "“{$keyword}” did not match any result."
-      error_keyword_subtitle: Try searching for something else.
-      error_new_title: No new recipe is found.
-      error_new_subtitle: This shouldn’t happen.
-      error_self_title: You did not publish any recipe.
-      error_self_subtitle: Learn how to publish your first one at https://help.trmnl.com/en/articles/9510536-private-plugins
-      error_author_id_title: 'User #{$authorId} did not publish any recipe.'
-      error_author_id_subtitle: No recipe is found associated with this ID.
-      error_recipe_ids_title: No recipe ID is found.
-      error_recipe_ids_subtitle: Add a recipe ID to get started.
+      error_keyword_title:
+      error_keyword_subtitle:
+      error_new_title:
+      error_new_subtitle:
+      error_self_title:
+      error_self_subtitle:
+      error_author_id_title:
+      error_author_id_subtitle:
+      error_recipe_ids_title:
+      error_recipe_ids_subtitle:
     horizontal_world_clock:
-      name: World clock
+      name:
     language_learning_sentences:
-      from_to: "{$from :langName} to {$to :langNameList}"
+      from_to:
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/pl.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/pl.yml
@@ -17,61 +17,17 @@ pl:
       train: Pociąg
       on_time: Na czas
       cancelled: Odwołany
-      minutes: m
+      minutes:
       refreshed: Odświeżony
     simple_calendar:
       title: Kalendarz
-      ym_format: "%B %Y"
+      ym_format:
       chinese_korean:
         leap_format: Przestępny %{month_label}
-        leap_format_short: LM%{alt_month}
+        leap_format_short:
         ym_format: ", %{leap_month_label} %{earthly_branch}, żywioł: %{heavenly_stem}"
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
         - Drewno
         - Drewno
@@ -98,96 +54,23 @@ pl:
         - Świnia
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        - Nisan
-        - Iyar
-        - Sivan
-        - Tamuz
-        - Av
-        - Elul
-        - Tishri
-        - Heshvan
-        - Kislev
-        - Tevet
-        - Shevat
-        - Adar
-        - Adar I
-        - Adar II
         month_labels_abbr:
-        - Nis
-        - Iya
-        - Siv
-        - Tam
-        - Av
-        - Elu
-        - Tis
-        - Hes
-        - Kis
-        - Tev
-        - Shv
-        - Ada
-        - Ad1
-        - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Muharram
-        - Safar
-        - Rabiʻ I
-        - Rabiʻ II
-        - Jumada I
-        - Jumada II
-        - Rajab
-        - Shaʻban
-        - Ramadan
-        - Shawwal
-        - Dhuʻl-Qiʻdah
-        - Dhuʻl-Hijjah
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Chaitra
-        - Vaisakha
-        - Jyaistha
-        - Asadha
-        - Sravana
-        - Bhadra
-        - Asvina
-        - Kartika
-        - Agrahayana
-        - Pausa
-        - Magha
-        - Phalguna
     public_recipe_stats:
       connections: ".input {$value :number} .match $value one {{{$value :number} połączenie}} few {{{$value :number} połączenia}} many {{{$value :number} połączeń}} * {{{$value :number} połączenia}}"
       forks: ".input {$value :number} .match $value one {{{$value :number} fork}} few {{{$value :number} forki}} many {{{$value :number} forków}} * {{{$value :number} forki}}"

--- a/lib/trmnl/i18n/locales/custom_plugins/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/pt-BR.yml
@@ -5,7 +5,7 @@ pt-BR:
     tomorrow: amanhã
     updated: Atualizado
     activity: Atividade
-    done: Done
+    done:
     due: Até
     deutsche_bahn_departures:
       departures: Partidas
@@ -17,61 +17,17 @@ pt-BR:
       train: Trem
       on_time: No horário
       cancelled: Cancelado
-      minutes: m
+      minutes:
       refreshed: Atualizado
     simple_calendar:
       title: Calendário
       ym_format: "%B de %Y"
       chinese_korean:
-        leap_format: Leap %{month_label}
-        leap_format_short: LM%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        leap_format:
+        leap_format_short:
+        ym_format:
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
         - Madeira
         - Madeira
@@ -98,118 +54,45 @@ pt-BR:
         - Porco
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        - Nisan
-        - Iyar
-        - Sivan
-        - Tamuz
-        - Av
-        - Elul
-        - Tishri
-        - Heshvan
-        - Kislev
-        - Tevet
-        - Shevat
-        - Adar
-        - Adar I
-        - Adar II
         month_labels_abbr:
-        - Nis
-        - Iya
-        - Siv
-        - Tam
-        - Av
-        - Elu
-        - Tis
-        - Hes
-        - Kis
-        - Tev
-        - Shv
-        - Ada
-        - Ad1
-        - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Muharram
-        - Safar
-        - Rabiʻ I
-        - Rabiʻ II
-        - Jumada I
-        - Jumada II
-        - Rajab
-        - Shaʻban
-        - Ramadan
-        - Shawwal
-        - Dhuʻl-Qiʻdah
-        - Dhuʻl-Hijjah
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Chaitra
-        - Vaisakha
-        - Jyaistha
-        - Asadha
-        - Sravana
-        - Bhadra
-        - Asvina
-        - Kartika
-        - Agrahayana
-        - Pausa
-        - Magha
-        - Phalguna
     public_recipe_stats:
       connections: ".input {$value :number} .match $value one {{{$value :number} conexão}} many {{{$value :number} conexões}} * {{{$value :number} conexões}}"
       forks: ".input {$value :number} .match $value one {{{$value :number} derivação}} many {{{$value :number} derivações}} * {{{$value :number} derivações}}"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
+      installs:
       and_more: e {$value :number} mais
-      error_keyword_title: "“{$keyword}” did not match any result."
-      error_keyword_subtitle: Try searching for something else.
-      error_new_title: No new recipe is found.
-      error_new_subtitle: This shouldn’t happen.
-      error_self_title: You did not publish any recipe.
-      error_self_subtitle: Learn how to publish your first one at https://help.trmnl.com/en/articles/9510536-private-plugins
-      error_author_id_title: 'User #{$authorId} did not publish any recipe.'
-      error_author_id_subtitle: No recipe is found associated with this ID.
-      error_recipe_ids_title: No recipe ID is found.
-      error_recipe_ids_subtitle: Add a recipe ID to get started.
+      error_keyword_title:
+      error_keyword_subtitle:
+      error_new_title:
+      error_new_subtitle:
+      error_self_title:
+      error_self_subtitle:
+      error_author_id_title:
+      error_author_id_subtitle:
+      error_recipe_ids_title:
+      error_recipe_ids_subtitle:
     horizontal_world_clock:
-      name: World clock
+      name:
     language_learning_sentences:
-      from_to: "{$from :langName} to {$to :langNameList}"
+      from_to:
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/ro.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/ro.yml
@@ -20,12 +20,12 @@ ro:
       minutes: min
       refreshed: Actualizat
     simple_calendar:
-      title: Calendar
-      ym_format: "%B %Y"
+      title:
+      ym_format:
       chinese_korean:
         leap_format: Bisect %{month_label}
         leap_format_short: LB%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        ym_format:
         month_labels:
         -
         - L1
@@ -41,37 +41,6 @@ ro:
         - L11
         - L12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
         - Lemn
         - Lemn
@@ -98,96 +67,23 @@ ro:
         - Porc
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        - Nisan
-        - Iyar
-        - Sivan
-        - Tamuz
-        - Av
-        - Elul
-        - Tishri
-        - Heshvan
-        - Kislev
-        - Tevet
-        - Shevat
-        - Adar
-        - Adar I
-        - Adar II
         month_labels_abbr:
-        - Nis
-        - Iya
-        - Siv
-        - Tam
-        - Av
-        - Elu
-        - Tis
-        - Hes
-        - Kis
-        - Tev
-        - Shv
-        - Ada
-        - Ad1
-        - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Muharram
-        - Safar
-        - Rabiʻ I
-        - Rabiʻ II
-        - Jumada I
-        - Jumada II
-        - Rajab
-        - Shaʻban
-        - Ramadan
-        - Shawwal
-        - Dhuʻl-Qiʻdah
-        - Dhuʻl-Hijjah
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Chaitra
-        - Vaisakha
-        - Jyaistha
-        - Asadha
-        - Sravana
-        - Bhadra
-        - Asvina
-        - Kartika
-        - Agrahayana
-        - Pausa
-        - Magha
-        - Phalguna
     public_recipe_stats:
       connections: ".input {$value :number} .match $value zero {{Nicio conexiune}} one {{{$value :number} conexiune}} * {{{$value :number} conexiuni}}"
       forks: ".input {$value :number} .match $value zero {{Niciun fork}} one {{{$value :number} fork}} * {{{$value :number} fork-uri}}"
@@ -208,8 +104,8 @@ ro:
     language_learning_sentences:
       from_to: "{$from :langName} în {$to :langNameList}"
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/ru.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/ru.yml
@@ -21,11 +21,11 @@ ru:
       refreshed: Обновлено
     simple_calendar:
       title: Календарь
-      ym_format: "%B %Y"
+      ym_format:
       chinese_korean:
         leap_format: Високосный %{month_label}
         leap_format_short: ВМ%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        ym_format:
         month_labels:
         -
         - М1
@@ -41,37 +41,6 @@ ru:
         - М11
         - М12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
         - Дерево
         - Дерево
@@ -98,18 +67,12 @@ ru:
         - Свинья
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
           reiwa: Рэйва
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         - Нисан
         - Ияр
@@ -141,7 +104,7 @@ ru:
         - Ад1
         - Ад2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - Мухаррам
@@ -157,7 +120,7 @@ ru:
         - Зуль-када
         - Зуль-хиджа
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - Бойшах
@@ -173,7 +136,7 @@ ru:
         - Фалгун
         - Чойтра
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - Чайтра
@@ -191,25 +154,25 @@ ru:
     public_recipe_stats:
       connections: ".input {$value :number} .match $value one {{{$value :number} подключение}} few {{{$value :number} подключения}} many {{{$value :number} подключений}} * {{{$value :number} подключения}}"
       forks: ".input {$value :number} .match $value one {{{$value :number} форк}} few {{{$value :number} форка}} many {{{$value :number} форков}} * {{{$value :number} форки}}"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
+      installs:
       and_more: и {$value :number} ещё
-      error_keyword_title: "“{$keyword}” did not match any result."
-      error_keyword_subtitle: Try searching for something else.
-      error_new_title: No new recipe is found.
-      error_new_subtitle: This shouldn’t happen.
-      error_self_title: You did not publish any recipe.
-      error_self_subtitle: Learn how to publish your first one at https://help.trmnl.com/en/articles/9510536-private-plugins
-      error_author_id_title: 'User #{$authorId} did not publish any recipe.'
-      error_author_id_subtitle: No recipe is found associated with this ID.
-      error_recipe_ids_title: No recipe ID is found.
-      error_recipe_ids_subtitle: Add a recipe ID to get started.
+      error_keyword_title:
+      error_keyword_subtitle:
+      error_new_title:
+      error_new_subtitle:
+      error_self_title:
+      error_self_subtitle:
+      error_author_id_title:
+      error_author_id_subtitle:
+      error_recipe_ids_title:
+      error_recipe_ids_subtitle:
     horizontal_world_clock:
-      name: World clock
+      name:
     language_learning_sentences:
-      from_to: "{$from :langName} to {$to :langNameList}"
+      from_to:
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/sk.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/sk.yml
@@ -1,215 +1,76 @@
 ---
 sk:
   custom_plugins:
-    today: today
-    tomorrow: tomorrow
-    updated: Updated
-    activity: Activity
-    done: Done
-    due: Due
+    today:
+    tomorrow:
+    updated:
+    activity:
+    done:
+    due:
     deutsche_bahn_departures:
-      departures: Departures
-      time: Time
-      line: Line
-      destination: Destination
-      platform: Platform
-      delay: Delay
-      train: Train
-      on_time: On time
-      cancelled: Cancelled
-      minutes: m
-      refreshed: Refreshed
+      departures:
+      time:
+      line:
+      destination:
+      platform:
+      delay:
+      train:
+      on_time:
+      cancelled:
+      minutes:
+      refreshed:
     simple_calendar:
-      title: Calendar
-      ym_format: "%B %Y"
+      title:
+      ym_format:
       chinese_korean:
-        leap_format: Leap %{month_label}
-        leap_format_short: LM%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        leap_format:
+        leap_format_short:
+        ym_format:
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
-        - Wood
-        - Wood
-        - Fire
-        - Fire
-        - Earth
-        - Earth
-        - Metal
-        - Metal
-        - Water
-        - Water
         earthly_branches:
-        - Rat
-        - Ox
-        - Tiger
-        - Rabbit
-        - Dragon
-        - Snake
-        - Horse
-        - Goat
-        - Monkey
-        - Rooster
-        - Dog
-        - Pig
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        - Nisan
-        - Iyar
-        - Sivan
-        - Tamuz
-        - Av
-        - Elul
-        - Tishri
-        - Heshvan
-        - Kislev
-        - Tevet
-        - Shevat
-        - Adar
-        - Adar I
-        - Adar II
         month_labels_abbr:
-        - Nis
-        - Iya
-        - Siv
-        - Tam
-        - Av
-        - Elu
-        - Tis
-        - Hes
-        - Kis
-        - Tev
-        - Shv
-        - Ada
-        - Ad1
-        - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Muharram
-        - Safar
-        - Rabiʻ I
-        - Rabiʻ II
-        - Jumada I
-        - Jumada II
-        - Rajab
-        - Shaʻban
-        - Ramadan
-        - Shawwal
-        - Dhuʻl-Qiʻdah
-        - Dhuʻl-Hijjah
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Chaitra
-        - Vaisakha
-        - Jyaistha
-        - Asadha
-        - Sravana
-        - Bhadra
-        - Asvina
-        - Kartika
-        - Agrahayana
-        - Pausa
-        - Magha
-        - Phalguna
     public_recipe_stats:
-      connections: ".input {$value :number} .match $value zero {{No connection}} one {{{$value :number} connection}} * {{{$value :number} connections}}"
-      forks: ".input {$value :number} .match $value zero {{No fork}} one {{{$value :number} fork}} * {{{$value :number} forks}}"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
+      connections:
+      forks:
+      installs:
       and_more: a {$value :number} ďalšie
-      error_keyword_title: "“{$keyword}” did not match any result."
-      error_keyword_subtitle: Try searching for something else.
-      error_new_title: No new recipe is found.
-      error_new_subtitle: This shouldn’t happen.
-      error_self_title: You did not publish any recipe.
-      error_self_subtitle: Learn how to publish your first one at https://help.trmnl.com/en/articles/9510536-private-plugins
-      error_author_id_title: 'User #{$authorId} did not publish any recipe.'
-      error_author_id_subtitle: No recipe is found associated with this ID.
-      error_recipe_ids_title: No recipe ID is found.
-      error_recipe_ids_subtitle: Add a recipe ID to get started.
+      error_keyword_title:
+      error_keyword_subtitle:
+      error_new_title:
+      error_new_subtitle:
+      error_self_title:
+      error_self_subtitle:
+      error_author_id_title:
+      error_author_id_subtitle:
+      error_recipe_ids_title:
+      error_recipe_ids_subtitle:
     horizontal_world_clock:
-      name: World clock
+      name:
     language_learning_sentences:
-      from_to: "{$from :langName} to {$to :langNameList}"
+      from_to:
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/sv.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/sv.yml
@@ -1,215 +1,76 @@
 ---
 sv:
   custom_plugins:
-    today: today
-    tomorrow: tomorrow
-    updated: Updated
-    activity: Activity
-    done: Done
-    due: Due
+    today:
+    tomorrow:
+    updated:
+    activity:
+    done:
+    due:
     deutsche_bahn_departures:
-      departures: Departures
-      time: Time
-      line: Line
-      destination: Destination
-      platform: Platform
-      delay: Delay
-      train: Train
-      on_time: On time
-      cancelled: Cancelled
-      minutes: m
-      refreshed: Refreshed
+      departures:
+      time:
+      line:
+      destination:
+      platform:
+      delay:
+      train:
+      on_time:
+      cancelled:
+      minutes:
+      refreshed:
     simple_calendar:
-      title: Calendar
-      ym_format: "%B %Y"
+      title:
+      ym_format:
       chinese_korean:
-        leap_format: Leap %{month_label}
-        leap_format_short: LM%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        leap_format:
+        leap_format_short:
+        ym_format:
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
-        - Wood
-        - Wood
-        - Fire
-        - Fire
-        - Earth
-        - Earth
-        - Metal
-        - Metal
-        - Water
-        - Water
         earthly_branches:
-        - Rat
-        - Ox
-        - Tiger
-        - Rabbit
-        - Dragon
-        - Snake
-        - Horse
-        - Goat
-        - Monkey
-        - Rooster
-        - Dog
-        - Pig
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
-          reiwa: Reiwa
-        ym_format: "%B %Y (%{nengo} %{alt_year})"
-        year_1: '1'
+          reiwa:
+        ym_format:
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        - Nisan
-        - Iyar
-        - Sivan
-        - Tamuz
-        - Av
-        - Elul
-        - Tishri
-        - Heshvan
-        - Kislev
-        - Tevet
-        - Shevat
-        - Adar
-        - Adar I
-        - Adar II
         month_labels_abbr:
-        - Nis
-        - Iya
-        - Siv
-        - Tam
-        - Av
-        - Elu
-        - Tis
-        - Hes
-        - Kis
-        - Tev
-        - Shv
-        - Ada
-        - Ad1
-        - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Muharram
-        - Safar
-        - Rabiʻ I
-        - Rabiʻ II
-        - Jumada I
-        - Jumada II
-        - Rajab
-        - Shaʻban
-        - Ramadan
-        - Shawwal
-        - Dhuʻl-Qiʻdah
-        - Dhuʻl-Hijjah
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Chaitra
-        - Vaisakha
-        - Jyaistha
-        - Asadha
-        - Sravana
-        - Bhadra
-        - Asvina
-        - Kartika
-        - Agrahayana
-        - Pausa
-        - Magha
-        - Phalguna
     public_recipe_stats:
-      connections: ".input {$value :number} .match $value zero {{No connection}} one {{{$value :number} connection}} * {{{$value :number} connections}}"
-      forks: ".input {$value :number} .match $value zero {{No fork}} one {{{$value :number} fork}} * {{{$value :number} forks}}"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
-      and_more: and {$value :number} more
-      error_keyword_title: "“{$keyword}” did not match any result."
-      error_keyword_subtitle: Try searching for something else.
-      error_new_title: No new recipe is found.
-      error_new_subtitle: This shouldn’t happen.
-      error_self_title: You did not publish any recipe.
-      error_self_subtitle: Learn how to publish your first one at https://help.trmnl.com/en/articles/9510536-private-plugins
-      error_author_id_title: 'User #{$authorId} did not publish any recipe.'
-      error_author_id_subtitle: No recipe is found associated with this ID.
-      error_recipe_ids_title: No recipe ID is found.
-      error_recipe_ids_subtitle: Add a recipe ID to get started.
+      connections:
+      forks:
+      installs:
+      and_more:
+      error_keyword_title:
+      error_keyword_subtitle:
+      error_new_title:
+      error_new_subtitle:
+      error_self_title:
+      error_self_subtitle:
+      error_author_id_title:
+      error_author_id_subtitle:
+      error_recipe_ids_title:
+      error_recipe_ids_subtitle:
     horizontal_world_clock:
-      name: World clock
+      name:
     language_learning_sentences:
-      from_to: "{$from :langName} to {$to :langNameList}"
+      from_to:
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/uk.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/uk.yml
@@ -1,115 +1,43 @@
 ---
 uk:
   custom_plugins:
-    today: today
-    tomorrow: tomorrow
-    updated: Updated
-    activity: Activity
-    done: Done
-    due: Due
+    today:
+    tomorrow:
+    updated:
+    activity:
+    done:
+    due:
     deutsche_bahn_departures:
-      departures: Departures
-      time: Time
-      line: Line
-      destination: Destination
-      platform: Platform
-      delay: Delay
-      train: Train
-      on_time: On time
-      cancelled: Cancelled
-      minutes: m
-      refreshed: Refreshed
+      departures:
+      time:
+      line:
+      destination:
+      platform:
+      delay:
+      train:
+      on_time:
+      cancelled:
+      minutes:
+      refreshed:
     simple_calendar:
       title: Календар
       ym_format: "%b %Y р."
       chinese_korean:
-        leap_format: Leap %{month_label}
-        leap_format_short: LM%{alt_month}
-        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        leap_format:
+        leap_format_short:
+        ym_format:
         month_labels:
-        -
-        - M1
-        - M2
-        - M3
-        - M4
-        - M5
-        - M6
-        - M7
-        - M8
-        - M9
-        - M10
-        - M11
-        - M12
         date_labels:
-        -
-        - '1'
-        - '2'
-        - '3'
-        - '4'
-        - '5'
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-        - '10'
-        - '11'
-        - '12'
-        - '13'
-        - '14'
-        - '15'
-        - '16'
-        - '17'
-        - '18'
-        - '19'
-        - '20'
-        - '21'
-        - '22'
-        - '23'
-        - '24'
-        - '25'
-        - '26'
-        - '27'
-        - '28'
-        - '29'
-        - '30'
         heavenly_stems:
-        - Wood
-        - Wood
-        - Fire
-        - Fire
-        - Earth
-        - Earth
-        - Metal
-        - Metal
-        - Water
-        - Water
         earthly_branches:
-        - Rat
-        - Ox
-        - Tiger
-        - Rabbit
-        - Dragon
-        - Snake
-        - Horse
-        - Goat
-        - Monkey
-        - Rooster
-        - Dog
-        - Pig
       japanese:
         rokuyo_terms:
-        - 先勝
-        - 友引
-        - 先負
-        - 仏滅
-        - 大安
-        - 赤口
         nengo:
           reiwa: Рейва
         ym_format: "%b %Y р. (%{nengo} %{alt_year})"
-        year_1: '1'
+        year_1:
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         - Нісан
         - Іар
@@ -141,7 +69,7 @@ uk:
         - Ад1
         - Ад2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - мухаррам
@@ -157,23 +85,10 @@ uk:
         - зу-ль-каада
         - зу-ль-хіджа
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
         -
         - чайтра
@@ -189,27 +104,27 @@ uk:
         - магха
         - фальгуна
     public_recipe_stats:
-      connections: ".input {$value :number} .match $value zero {{No connection}} one {{{$value :number} connection}} * {{{$value :number} connections}}"
-      forks: ".input {$value :number} .match $value zero {{No fork}} one {{{$value :number} fork}} * {{{$value :number} forks}}"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
-      and_more: and {$value :number} more
-      error_keyword_title: "“{$keyword}” did not match any result."
-      error_keyword_subtitle: Try searching for something else.
-      error_new_title: No new recipe is found.
-      error_new_subtitle: This shouldn’t happen.
-      error_self_title: You did not publish any recipe.
-      error_self_subtitle: Learn how to publish your first one at https://help.trmnl.com/en/articles/9510536-private-plugins
-      error_author_id_title: 'User #{$authorId} did not publish any recipe.'
-      error_author_id_subtitle: No recipe is found associated with this ID.
-      error_recipe_ids_title: No recipe ID is found.
-      error_recipe_ids_subtitle: Add a recipe ID to get started.
+      connections:
+      forks:
+      installs:
+      and_more:
+      error_keyword_title:
+      error_keyword_subtitle:
+      error_new_title:
+      error_new_subtitle:
+      error_self_title:
+      error_self_subtitle:
+      error_author_id_title:
+      error_author_id_subtitle:
+      error_recipe_ids_title:
+      error_recipe_ids_subtitle:
     horizontal_world_clock:
-      name: World clock
+      name:
     language_learning_sentences:
-      from_to: "{$from :langName} to {$to :langNameList}"
+      from_to:
     custom_next_holiday:
-      next_holiday: Next holiday
-      today_and_next: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Tomorrow is {$nextName}.{/subLabel} }}* {{ {#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}Next holiday is {$nextName} in {$nextDays} days.{/subLabel} }}"
-      today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
-      next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
-      no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+      next_holiday:
+      today_and_next:
+      today_only:
+      next_only:
+      no_holidays:

--- a/lib/trmnl/i18n/locales/custom_plugins/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/zh-CN.yml
@@ -147,85 +147,18 @@ zh-CN:
         ym_format: "%Y年 (%{nengo}%{alt_year}年) %-m月"
         year_1: 元
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        - Nisan
-        - Iyar
-        - Sivan
-        - Tamuz
-        - Av
-        - Elul
-        - Tishri
-        - Heshvan
-        - Kislev
-        - Tevet
-        - Shevat
-        - Adar
-        - Adar I
-        - Adar II
         month_labels_abbr:
-        - Nis
-        - Iya
-        - Siv
-        - Tam
-        - Av
-        - Elu
-        - Tis
-        - Hes
-        - Kis
-        - Tev
-        - Shv
-        - Ada
-        - Ad1
-        - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Muharram
-        - Safar
-        - Rabiʻ I
-        - Rabiʻ II
-        - Jumada I
-        - Jumada II
-        - Rajab
-        - Shaʻban
-        - Ramadan
-        - Shawwal
-        - Dhuʻl-Qiʻdah
-        - Dhuʻl-Hijjah
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Chaitra
-        - Vaisakha
-        - Jyaistha
-        - Asadha
-        - Sravana
-        - Bhadra
-        - Asvina
-        - Kartika
-        - Agrahayana
-        - Pausa
-        - Magha
-        - Phalguna
     public_recipe_stats:
       connections: "{$value :number} 个连接"
       forks: "{$value :number} 个分支"

--- a/lib/trmnl/i18n/locales/custom_plugins/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/zh-HK.yml
@@ -147,104 +147,37 @@ zh-HK:
         ym_format: "%Y年 (%{nengo}%{alt_year}年) %-m月"
         year_1: 元
       hebrew:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        - Nisan
-        - Iyar
-        - Sivan
-        - Tamuz
-        - Av
-        - Elul
-        - Tishri
-        - Heshvan
-        - Kislev
-        - Tevet
-        - Shevat
-        - Adar
-        - Adar I
-        - Adar II
         month_labels_abbr:
-        - Nis
-        - Iya
-        - Siv
-        - Tam
-        - Av
-        - Elu
-        - Tis
-        - Hes
-        - Kis
-        - Tev
-        - Shv
-        - Ada
-        - Ad1
-        - Ad2
       hijri:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Muharram
-        - Safar
-        - Rabiʻ I
-        - Rabiʻ II
-        - Jumada I
-        - Jumada II
-        - Rajab
-        - Shaʻban
-        - Ramadan
-        - Shawwal
-        - Dhuʻl-Qiʻdah
-        - Dhuʻl-Hijjah
       bengali:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Boishakh
-        - Joishtho
-        - Asharh
-        - Srabon
-        - Bhadro
-        - Ashwin
-        - Kartika
-        - Ogrohayon
-        - Poush
-        - Magh
-        - Falgun
-        - Choitro
       indian:
-        ym_format: ", %{month_label} %{alt_year}"
+        ym_format:
         month_labels:
-        -
-        - Chaitra
-        - Vaisakha
-        - Jyaistha
-        - Asadha
-        - Sravana
-        - Bhadra
-        - Asvina
-        - Kartika
-        - Agrahayana
-        - Pausa
-        - Magha
-        - Phalguna
     public_recipe_stats:
       connections: "{$value :number} 個連接"
       forks: "{$value :number} 個分叉"
-      installs: ".input {$value :number} .match $value zero {{No install}} one {{{$value :number} install}} * {{{$value :number} installs}}"
+      installs:
       and_more: 還有 {$value :number} 個
-      error_keyword_title: "“{$keyword}” did not match any result."
-      error_keyword_subtitle: Try searching for something else.
-      error_new_title: No new recipe is found.
-      error_new_subtitle: This shouldn’t happen.
-      error_self_title: You did not publish any recipe.
-      error_self_subtitle: Learn how to publish your first one at https://help.trmnl.com/en/articles/9510536-private-plugins
-      error_author_id_title: 'User #{$authorId} did not publish any recipe.'
-      error_author_id_subtitle: No recipe is found associated with this ID.
-      error_recipe_ids_title: No recipe ID is found.
-      error_recipe_ids_subtitle: Add a recipe ID to get started.
+      error_keyword_title:
+      error_keyword_subtitle:
+      error_new_title:
+      error_new_subtitle:
+      error_self_title:
+      error_self_subtitle:
+      error_author_id_title:
+      error_author_id_subtitle:
+      error_recipe_ids_title:
+      error_recipe_ids_subtitle:
     horizontal_world_clock:
-      name: World clock
+      name:
     language_learning_sentences:
-      from_to: "{$from :langName} to {$to :langNameList}"
+      from_to:
     custom_next_holiday:
       next_holiday: 下一個假期
       today_and_next: ".input {$nextDays :number} .match $nextDays 1 {{ {#mainLabel}今日是{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}明日是{$nextName}。{/subLabel} }} 2 {{ {#mainLabel}今日是{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}後日是{$nextName}。{/subLabel} }} * {{ {#mainLabel}今日是{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#subLabel}距離下一個假期{$nextName}還有 {$nextDays} 日。{/subLabel} }}"

--- a/lib/trmnl/i18n/locales/plugin_renders/da.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/da.yml
@@ -4,8 +4,8 @@ da:
     and_x_more_prefix: Og
     and_x_more_suffix: mere
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: Dage tilbage i år
       days_passed: Dage gået
@@ -29,49 +29,49 @@ da:
         third_quarter: Sidste kvarter
         waning_crescent: Aftagende månesegl
     netatmo_weather_station:
-      title: Netatmo Weather
-      title_short: Netatmo
-      indoor_temp: Indoor Temp.
-      indoor_temp_short: Indoor
-      indoor_humidity: Indoor Humidity
-      indoor_humidity_short: Indoor Hum.
-      outdoor_humidity: Outdoor Humidity
-      outdoor_humidity_short: Out. Hum.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
-      pressure: Pressure
-      noise: Noise
-      min_max: Min/Max
-      feels: Feels
-      rain: Rain
-      wind: Wind
-      gust: Gust
-      default_station_name: Netatmo Station
-      default_outdoor_module: Outdoor Temp.
-      default_indoor_module: Indoor
-      trends_title: "%{metric} Trends"
-      trends_title_short: Trends
-      temperature_trends: Temperature Trends
-      temperature_trends_short: Temp Trends
-      outdoor_now: Outdoor Now
-      indoor_now: Indoor Now
-      now: Now
-      low_high_24h: 24h Low / High
-      average_24h: 24h Average
-      outdoor: Outdoor
-      indoor: Indoor
-      rain_gauge_not_connected: Rain gauge not connected
-      wind_gauge_not_connected: Wind gauge not connected
-      no_rain_gauge: No rain gauge
-      no_wind_gauge: No wind gauge
-      add_module_hint: Add the optional %{module} module to see this data
-      range_24h: 24h Range
+      title:
+      title_short:
+      indoor_temp:
+      indoor_temp_short:
+      indoor_humidity:
+      indoor_humidity_short:
+      outdoor_humidity:
+      outdoor_humidity_short:
+      co2:
+      co2_ppm:
+      pressure:
+      noise:
+      min_max:
+      feels:
+      rain:
+      wind:
+      gust:
+      default_station_name:
+      default_outdoor_module:
+      default_indoor_module:
+      trends_title:
+      trends_title_short:
+      temperature_trends:
+      temperature_trends_short:
+      outdoor_now:
+      indoor_now:
+      now:
+      low_high_24h:
+      average_24h:
+      outdoor:
+      indoor:
+      rain_gauge_not_connected:
+      wind_gauge_not_connected:
+      no_rain_gauge:
+      no_wind_gauge:
+      add_module_hint:
+      range_24h:
       errors:
-        missing_access_token: Missing access token. Please reconnect your Netatmo account.
-        no_station_selected: No weather station selected. Please choose a station in settings.
-        connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
-        data_retrieval_failed: Unable to retrieve weather data. Please try again later.
-        session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        missing_access_token:
+        no_station_selected:
+        connection_failed:
+        data_retrieval_failed:
+        session_expired:
     parcel:
       delivery_by: Leveres senest
       empty: Der er ingen leveringer
@@ -106,29 +106,29 @@ da:
       humidity: Fugtighed
       low: Lav
       high: Høj
-      uv: UV
+      uv:
       right_now: Lige nu
       today: I dag
       tomorrow: I morgen
-      low_high_short: L/H
-      uv_short: UV
-      max: Max
+      low_high_short:
+      uv_short:
+      max:
       tempest:
         conditions:
-          clear: Clear
-          cloudy: Cloudy
-          foggy: Foggy
-          partly_cloudy: Partly Cloudy
-          rain_likely: Rain Likely
-          rain_possible: Rain Possible
-          snow: Snow
-          snow_possible: Snow Possible
-          thunderstorms_likely: Thunderstorms Likely
-          thunderstorms_possible: Thunderstorms Possible
-          very_light_rain: Very Light Rain
-          windy: Windy
-          wintry_mix_likely: Wintry Mix Likely
-          wintry_mix_possible: Wintry Mix Possible
+          clear:
+          cloudy:
+          foggy:
+          partly_cloudy:
+          rain_likely:
+          rain_possible:
+          snow:
+          snow_possible:
+          thunderstorms_likely:
+          thunderstorms_possible:
+          very_light_rain:
+          windy:
+          wintry_mix_likely:
+          wintry_mix_possible:
       weatherapi:
         uv:
           low: Lav

--- a/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
@@ -30,21 +30,21 @@ de-AT:
         waning_crescent: abn. Sichel
     netatmo_weather_station:
       title: Netatmo-Wetter
-      title_short: Netatmo
+      title_short:
       indoor_temp: Innen-Temp.
       indoor_temp_short: Innen
       indoor_humidity: Innen-Feuchtigkeit
       indoor_humidity_short: Innen-Feucht.
       outdoor_humidity: Außen-Feuchtigkeit
       outdoor_humidity_short: Außen-Feucht.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
+      co2:
+      co2_ppm:
       pressure: Druck
       noise: Geräuschpegel
-      min_max: Min/Max
+      min_max:
       feels: Gefühlt
       rain: Regen
-      wind: Wind
+      wind:
       gust: Böen
       default_station_name: Netatmo-Station
       default_outdoor_module: Außen-Temp.
@@ -106,13 +106,13 @@ de-AT:
       humidity: Feuchtigkeit
       low: min
       high: max
-      uv: UV
+      uv:
       right_now: jetzt
       today: heute
       tomorrow: morgen
       low_high_short: Min/Max
-      uv_short: UV
-      max: Max
+      uv_short:
+      max:
       tempest:
         conditions:
           clear: Klar

--- a/lib/trmnl/i18n/locales/plugin_renders/de.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de.yml
@@ -30,21 +30,21 @@ de:
         waning_crescent: abn. Sichel
     netatmo_weather_station:
       title: Netatmo-Wetter
-      title_short: Netatmo
+      title_short:
       indoor_temp: Innen-Temp.
       indoor_temp_short: Innen
       indoor_humidity: Innen-Feuchtigkeit
       indoor_humidity_short: Innen-Feucht.
       outdoor_humidity: Außen-Feuchtigkeit
       outdoor_humidity_short: Außen-Feucht.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
+      co2:
+      co2_ppm:
       pressure: Druck
       noise: Geräuschpegel
-      min_max: Min/Max
+      min_max:
       feels: Gefühlt
       rain: Regen
-      wind: Wind
+      wind:
       gust: Böen
       default_station_name: Netatmo-Station
       default_outdoor_module: Außen-Temp.
@@ -106,13 +106,13 @@ de:
       humidity: Feuchtigkeit
       low: min
       high: max
-      uv: UV
+      uv:
       right_now: jetzt
       today: heute
       tomorrow: morgen
       low_high_short: Min/Max
-      uv_short: UV
-      max: Max
+      uv_short:
+      max:
       tempest:
         conditions:
           clear: Klar

--- a/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
@@ -4,8 +4,8 @@ es-ES:
     and_x_more_prefix: "y"
     and_x_more_suffix: más
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: Días Restantes Este Año
       days_passed: Días Pasados
@@ -30,15 +30,15 @@ es-ES:
         waning_crescent: Luna Menguante
     netatmo_weather_station:
       title: Estación Netatmo
-      title_short: Netatmo
+      title_short:
       indoor_temp: Temp. Interior
       indoor_temp_short: Interior
       indoor_humidity: Humedad Interior
       indoor_humidity_short: Hum. Int.
       outdoor_humidity: Humedad Exterior
       outdoor_humidity_short: Hum. Ext.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
+      co2:
+      co2_ppm:
       pressure: Presión
       noise: Ruido
       min_max: Mín/Máx
@@ -106,12 +106,12 @@ es-ES:
       humidity: Humedad
       low: Mínima
       high: Máxima
-      uv: UV
+      uv:
       right_now: Ahora Mismo
       today: Hoy
       tomorrow: Mañana
       low_high_short: Mín/Máx
-      uv_short: UV
+      uv_short:
       max: Máx
       tempest:
         conditions:

--- a/lib/trmnl/i18n/locales/plugin_renders/fr.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/fr.yml
@@ -4,8 +4,8 @@ fr:
     and_x_more_prefix: Et
     and_x_more_suffix: de plus
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: Jours restants cette année
       days_passed: Jours passés
@@ -30,18 +30,18 @@ fr:
         waning_crescent: Dernier croissant
     netatmo_weather_station:
       title: Station météo Netatmo
-      title_short: Netatmo
+      title_short:
       indoor_temp: Température intérieure
       indoor_temp_short: Temp. intér.
       indoor_humidity: Humidité intérieure
       indoor_humidity_short: Hum. intér.
       outdoor_humidity: Humidité extérieure
       outdoor_humidity_short: Hum. extér.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
+      co2:
+      co2_ppm:
       pressure: Pression
       noise: Bruit
-      min_max: Min/Max
+      min_max:
       feels: Ressenti
       rain: Pluie
       wind: Vent
@@ -106,13 +106,13 @@ fr:
       humidity: Humidité
       low: Min
       high: Max
-      uv: UV
+      uv:
       right_now: Maintenant
       today: Aujourd'hui
       tomorrow: Demain
       low_high_short: Min/Max
-      uv_short: UV
-      max: Max
+      uv_short:
+      max:
       tempest:
         conditions:
           clear: Clair

--- a/lib/trmnl/i18n/locales/plugin_renders/he.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/he.yml
@@ -1,104 +1,104 @@
 ---
 he:
   renders:
-    and_x_more_prefix: And
-    and_x_more_suffix: more
+    and_x_more_prefix:
+    and_x_more_suffix:
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: ימים שנותרו עד לסוף השנה
       days_passed: ימים שחלפו
       days_left: ימים שנותרו
     lunar_calendar:
-      title: Lunar Calendar
-      age: Lunar Age
-      current_phase: Current Phase
-      illumination: Moon Illumination
-      next_full_moon: Next Full Moon
-      next_new_moon: Next New Moon
-      next_phase: Next Phase
-      next_phase_short: Next
+      title:
+      age:
+      current_phase:
+      illumination:
+      next_full_moon:
+      next_new_moon:
+      next_phase:
+      next_phase_short:
       moon_phases:
-        new_moon: New Moon
-        waxing_crescent: Waxing Crescent
-        first_quarter: First Quarter
-        waxing_gibbous: Waxing Gibbous
-        full_moon: Full Moon
-        waning_gibbous: Waning Gibbous
-        third_quarter: Third Quarter
-        waning_crescent: Waning Crescent
+        new_moon:
+        waxing_crescent:
+        first_quarter:
+        waxing_gibbous:
+        full_moon:
+        waning_gibbous:
+        third_quarter:
+        waning_crescent:
     netatmo_weather_station:
-      title: Netatmo Weather
-      title_short: Netatmo
-      indoor_temp: Indoor Temp.
-      indoor_temp_short: Indoor
-      indoor_humidity: Indoor Humidity
-      indoor_humidity_short: Indoor Hum.
-      outdoor_humidity: Outdoor Humidity
-      outdoor_humidity_short: Out. Hum.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
-      pressure: Pressure
-      noise: Noise
-      min_max: Min/Max
-      feels: Feels
-      rain: Rain
-      wind: Wind
-      gust: Gust
-      default_station_name: Netatmo Station
-      default_outdoor_module: Outdoor Temp.
-      default_indoor_module: Indoor
-      trends_title: "%{metric} Trends"
-      trends_title_short: Trends
-      temperature_trends: Temperature Trends
-      temperature_trends_short: Temp Trends
-      outdoor_now: Outdoor Now
-      indoor_now: Indoor Now
-      now: Now
-      low_high_24h: 24h Low / High
-      average_24h: 24h Average
-      outdoor: Outdoor
-      indoor: Indoor
-      rain_gauge_not_connected: Rain gauge not connected
-      wind_gauge_not_connected: Wind gauge not connected
-      no_rain_gauge: No rain gauge
-      no_wind_gauge: No wind gauge
-      add_module_hint: Add the optional %{module} module to see this data
-      range_24h: 24h Range
+      title:
+      title_short:
+      indoor_temp:
+      indoor_temp_short:
+      indoor_humidity:
+      indoor_humidity_short:
+      outdoor_humidity:
+      outdoor_humidity_short:
+      co2:
+      co2_ppm:
+      pressure:
+      noise:
+      min_max:
+      feels:
+      rain:
+      wind:
+      gust:
+      default_station_name:
+      default_outdoor_module:
+      default_indoor_module:
+      trends_title:
+      trends_title_short:
+      temperature_trends:
+      temperature_trends_short:
+      outdoor_now:
+      indoor_now:
+      now:
+      low_high_24h:
+      average_24h:
+      outdoor:
+      indoor:
+      rain_gauge_not_connected:
+      wind_gauge_not_connected:
+      no_rain_gauge:
+      no_wind_gauge:
+      add_module_hint:
+      range_24h:
       errors:
-        missing_access_token: Missing access token. Please reconnect your Netatmo account.
-        no_station_selected: No weather station selected. Please choose a station in settings.
-        connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
-        data_retrieval_failed: Unable to retrieve weather data. Please try again later.
-        session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        missing_access_token:
+        no_station_selected:
+        connection_failed:
+        data_retrieval_failed:
+        session_expired:
     parcel:
-      delivery_by: Delivery by
-      empty: There are no deliveries
+      delivery_by:
+      empty:
       errors:
-        api: Parcel API error
-        http: HTTP error %{code}
-        internal: Internal error
+        api:
+        http:
+        internal:
       filter_modes:
         active:
-          one: Active Delivery
-          other: Active Deliveries
+          one:
+          other:
         recent:
-          one: Recent Delivery
-          other: Recent Deliveries
+          one:
+          other:
       status:
-        delivered: Delivered
-        delivery_exception: Delivery Exception
-        expecting_pickup: Expecting Pickup
-        failed_delivery_attempt: Failed Delivery Attempt
-        frozen: Frozen
-        in_transit: In Transit
-        information_received: Information Received
-        not_found: Not Found
-        out_for_delivery: Out For Delivery
-        unknown: Unknown
-      today: Today
-      tomorrow: Tomorrow
+        delivered:
+        delivery_exception:
+        expecting_pickup:
+        failed_delivery_attempt:
+        frozen:
+        in_transit:
+        information_received:
+        not_found:
+        out_for_delivery:
+        unknown:
+      today:
+      tomorrow:
     weather:
       title: מזג אויר
       temperature: טמפרטורה
@@ -110,174 +110,30 @@ he:
       right_now: כעת
       today: היום
       tomorrow: מחר
-      low_high_short: L/H
-      uv_short: UV
-      max: Max
+      low_high_short:
+      uv_short:
+      max:
       tempest:
         conditions:
-          clear: Clear
-          cloudy: Cloudy
-          foggy: Foggy
-          partly_cloudy: Partly Cloudy
-          rain_likely: Rain Likely
-          rain_possible: Rain Possible
-          snow: Snow
-          snow_possible: Snow Possible
-          thunderstorms_likely: Thunderstorms Likely
-          thunderstorms_possible: Thunderstorms Possible
-          very_light_rain: Very Light Rain
-          windy: Windy
-          wintry_mix_likely: Wintry Mix Likely
-          wintry_mix_possible: Wintry Mix Possible
+          clear:
+          cloudy:
+          foggy:
+          partly_cloudy:
+          rain_likely:
+          rain_possible:
+          snow:
+          snow_possible:
+          thunderstorms_likely:
+          thunderstorms_possible:
+          very_light_rain:
+          windy:
+          wintry_mix_likely:
+          wintry_mix_possible:
       weatherapi:
         uv:
-          low: Low
-          moderate: Moderate
-          high: High
-          very_high: Very High
-          extreme: Extreme
+          low:
+          moderate:
+          high:
+          very_high:
+          extreme:
         conditions:
-        - code: 1000
-          day: Sunny
-          night: Clear
-        - code: 1003
-          day: Partly Cloudy
-          night: Partly Cloudy
-        - code: 1006
-          day: Cloudy
-          night: Cloudy
-        - code: 1009
-          day: Overcast
-          night: Overcast
-        - code: 1030
-          day: Mist
-          night: Mist
-        - code: 1063
-          day: Light Rain
-          night: Light Rain
-        - code: 1066
-          day: Light Snow
-          night: Light Snow
-        - code: 1069
-          day: Sleet
-          night: Sleet
-        - code: 1072
-          day: Freeze Drizzle
-          night: Freeze Drizzle
-        - code: 1087
-          day: Thunder
-          night: Thunder
-        - code: 1114
-          day: Blowing Snow
-          night: Blowing Snow
-        - code: 1117
-          day: Blizzard
-          night: Blizzard
-        - code: 1135
-          day: Fog
-          night: Fog
-        - code: 1147
-          day: Freezing Fog
-          night: Freezing Fog
-        - code: 1150
-          day: Light Drizzle
-          night: Light Drizzle
-        - code: 1153
-          day: Drizzle
-          night: Drizzle
-        - code: 1168
-          day: Freeze Drizzle
-          night: Freeze Drizzle
-        - code: 1171
-          day: Heavy Freeze
-          night: Heavy Freeze
-        - code: 1180
-          day: Light Rain
-          night: Light Rain
-        - code: 1183
-          day: Light Rain
-          night: Light Rain
-        - code: 1186
-          day: Moderate Rain
-          night: Moderate Rain
-        - code: 1189
-          day: Moderate Rain
-          night: Moderate Rain
-        - code: 1192
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1195
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1198
-          day: Light Freeze
-          night: Light Freeze
-        - code: 1201
-          day: Heavy Freeze
-          night: Heavy Freeze
-        - code: 1204
-          day: Light Sleet
-          night: Light Sleet
-        - code: 1207
-          day: Heavy Sleet
-          night: Heavy Sleet
-        - code: 1210
-          day: Light Snow
-          night: Light Snow
-        - code: 1213
-          day: Light Snow
-          night: Light Snow
-        - code: 1216
-          day: Moderate Snow
-          night: Moderate Snow
-        - code: 1219
-          day: Moderate Snow
-          night: Moderate Snow
-        - code: 1222
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1225
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1237
-          day: Ice Pellets
-          night: Ice Pellets
-        - code: 1240
-          day: Light Rain
-          night: Light Rain
-        - code: 1243
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1246
-          day: Torrential Rain
-          night: Torrential Rain
-        - code: 1249
-          day: Light Sleet
-          night: Light Sleet
-        - code: 1252
-          day: Heavy Sleet
-          night: Heavy Sleet
-        - code: 1255
-          day: Light Snow
-          night: Light Snow
-        - code: 1258
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1261
-          day: Light Ice
-          night: Light Ice
-        - code: 1264
-          day: Heavy Ice
-          night: Heavy Ice
-        - code: 1273
-          day: Thunder & Rain
-          night: Thunder & Rain
-        - code: 1276
-          day: Thunder & Rain
-          night: Thunder & Rain
-        - code: 1279
-          day: Thunder & Snow
-          night: Thunder & Snow
-        - code: 1282
-          day: Thunder & Snow
-          night: Thunder & Snow

--- a/lib/trmnl/i18n/locales/plugin_renders/hu.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/hu.yml
@@ -4,8 +4,8 @@ hu:
     and_x_more_prefix: És
     and_x_more_suffix: további
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: Hátralévő napok az évben
       days_passed: Eltelt napok
@@ -29,49 +29,49 @@ hu:
         third_quarter: Utolsó negyed
         waning_crescent: Fogyó holdsarló
     netatmo_weather_station:
-      title: Netatmo Weather
-      title_short: Netatmo
-      indoor_temp: Indoor Temp.
-      indoor_temp_short: Indoor
-      indoor_humidity: Indoor Humidity
-      indoor_humidity_short: Indoor Hum.
-      outdoor_humidity: Outdoor Humidity
-      outdoor_humidity_short: Out. Hum.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
-      pressure: Pressure
-      noise: Noise
-      min_max: Min/Max
-      feels: Feels
-      rain: Rain
-      wind: Wind
-      gust: Gust
-      default_station_name: Netatmo Station
-      default_outdoor_module: Outdoor Temp.
-      default_indoor_module: Indoor
-      trends_title: "%{metric} Trends"
-      trends_title_short: Trends
-      temperature_trends: Temperature Trends
-      temperature_trends_short: Temp Trends
-      outdoor_now: Outdoor Now
-      indoor_now: Indoor Now
-      now: Now
-      low_high_24h: 24h Low / High
-      average_24h: 24h Average
-      outdoor: Outdoor
-      indoor: Indoor
-      rain_gauge_not_connected: Rain gauge not connected
-      wind_gauge_not_connected: Wind gauge not connected
-      no_rain_gauge: No rain gauge
-      no_wind_gauge: No wind gauge
-      add_module_hint: Add the optional %{module} module to see this data
-      range_24h: 24h Range
+      title:
+      title_short:
+      indoor_temp:
+      indoor_temp_short:
+      indoor_humidity:
+      indoor_humidity_short:
+      outdoor_humidity:
+      outdoor_humidity_short:
+      co2:
+      co2_ppm:
+      pressure:
+      noise:
+      min_max:
+      feels:
+      rain:
+      wind:
+      gust:
+      default_station_name:
+      default_outdoor_module:
+      default_indoor_module:
+      trends_title:
+      trends_title_short:
+      temperature_trends:
+      temperature_trends_short:
+      outdoor_now:
+      indoor_now:
+      now:
+      low_high_24h:
+      average_24h:
+      outdoor:
+      indoor:
+      rain_gauge_not_connected:
+      wind_gauge_not_connected:
+      no_rain_gauge:
+      no_wind_gauge:
+      add_module_hint:
+      range_24h:
       errors:
-        missing_access_token: Missing access token. Please reconnect your Netatmo account.
-        no_station_selected: No weather station selected. Please choose a station in settings.
-        connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
-        data_retrieval_failed: Unable to retrieve weather data. Please try again later.
-        session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        missing_access_token:
+        no_station_selected:
+        connection_failed:
+        data_retrieval_failed:
+        session_expired:
     parcel:
       delivery_by: Kézbesítés ekkorra
       empty: Nincsenek kézbesítések
@@ -106,29 +106,29 @@ hu:
       humidity: Páratartalom
       low: Minimum
       high: Maximum
-      uv: UV
+      uv:
       right_now: Jelenleg
       today: Ma
       tomorrow: Holnap
-      low_high_short: L/H
-      uv_short: UV
-      max: Max
+      low_high_short:
+      uv_short:
+      max:
       tempest:
         conditions:
-          clear: Clear
-          cloudy: Cloudy
-          foggy: Foggy
-          partly_cloudy: Partly Cloudy
-          rain_likely: Rain Likely
-          rain_possible: Rain Possible
-          snow: Snow
-          snow_possible: Snow Possible
-          thunderstorms_likely: Thunderstorms Likely
-          thunderstorms_possible: Thunderstorms Possible
-          very_light_rain: Very Light Rain
-          windy: Windy
-          wintry_mix_likely: Wintry Mix Likely
-          wintry_mix_possible: Wintry Mix Possible
+          clear:
+          cloudy:
+          foggy:
+          partly_cloudy:
+          rain_likely:
+          rain_possible:
+          snow:
+          snow_possible:
+          thunderstorms_likely:
+          thunderstorms_possible:
+          very_light_rain:
+          windy:
+          wintry_mix_likely:
+          wintry_mix_possible:
       weatherapi:
         uv:
           low: Alacsony

--- a/lib/trmnl/i18n/locales/plugin_renders/id.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/id.yml
@@ -1,283 +1,139 @@
 ---
 id:
   renders:
-    and_x_more_prefix: And
-    and_x_more_suffix: more
+    and_x_more_prefix:
+    and_x_more_suffix:
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
-      title: Days Left This Year
-      days_passed: Days Passed
-      days_left: Days Left
+      title:
+      days_passed:
+      days_left:
     lunar_calendar:
-      title: Lunar Calendar
-      age: Lunar Age
-      current_phase: Current Phase
-      illumination: Moon Illumination
-      next_full_moon: Next Full Moon
-      next_new_moon: Next New Moon
-      next_phase: Next Phase
-      next_phase_short: Next
+      title:
+      age:
+      current_phase:
+      illumination:
+      next_full_moon:
+      next_new_moon:
+      next_phase:
+      next_phase_short:
       moon_phases:
-        new_moon: New Moon
-        waxing_crescent: Waxing Crescent
-        first_quarter: First Quarter
-        waxing_gibbous: Waxing Gibbous
-        full_moon: Full Moon
-        waning_gibbous: Waning Gibbous
-        third_quarter: Third Quarter
-        waning_crescent: Waning Crescent
+        new_moon:
+        waxing_crescent:
+        first_quarter:
+        waxing_gibbous:
+        full_moon:
+        waning_gibbous:
+        third_quarter:
+        waning_crescent:
     netatmo_weather_station:
-      title: Netatmo Weather
-      title_short: Netatmo
-      indoor_temp: Indoor Temp.
-      indoor_temp_short: Indoor
-      indoor_humidity: Indoor Humidity
-      indoor_humidity_short: Indoor Hum.
-      outdoor_humidity: Outdoor Humidity
-      outdoor_humidity_short: Out. Hum.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
-      pressure: Pressure
-      noise: Noise
-      min_max: Min/Max
-      feels: Feels
-      rain: Rain
-      wind: Wind
-      gust: Gust
-      default_station_name: Netatmo Station
-      default_outdoor_module: Outdoor Temp.
-      default_indoor_module: Indoor
-      trends_title: "%{metric} Trends"
-      trends_title_short: Trends
-      temperature_trends: Temperature Trends
-      temperature_trends_short: Temp Trends
-      outdoor_now: Outdoor Now
-      indoor_now: Indoor Now
-      now: Now
-      low_high_24h: 24h Low / High
-      average_24h: 24h Average
-      outdoor: Outdoor
-      indoor: Indoor
-      rain_gauge_not_connected: Rain gauge not connected
-      wind_gauge_not_connected: Wind gauge not connected
-      no_rain_gauge: No rain gauge
-      no_wind_gauge: No wind gauge
-      add_module_hint: Add the optional %{module} module to see this data
-      range_24h: 24h Range
+      title:
+      title_short:
+      indoor_temp:
+      indoor_temp_short:
+      indoor_humidity:
+      indoor_humidity_short:
+      outdoor_humidity:
+      outdoor_humidity_short:
+      co2:
+      co2_ppm:
+      pressure:
+      noise:
+      min_max:
+      feels:
+      rain:
+      wind:
+      gust:
+      default_station_name:
+      default_outdoor_module:
+      default_indoor_module:
+      trends_title:
+      trends_title_short:
+      temperature_trends:
+      temperature_trends_short:
+      outdoor_now:
+      indoor_now:
+      now:
+      low_high_24h:
+      average_24h:
+      outdoor:
+      indoor:
+      rain_gauge_not_connected:
+      wind_gauge_not_connected:
+      no_rain_gauge:
+      no_wind_gauge:
+      add_module_hint:
+      range_24h:
       errors:
-        missing_access_token: Missing access token. Please reconnect your Netatmo account.
-        no_station_selected: No weather station selected. Please choose a station in settings.
-        connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
-        data_retrieval_failed: Unable to retrieve weather data. Please try again later.
-        session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        missing_access_token:
+        no_station_selected:
+        connection_failed:
+        data_retrieval_failed:
+        session_expired:
     parcel:
-      delivery_by: Delivery by
-      empty: There are no deliveries
+      delivery_by:
+      empty:
       errors:
-        api: Parcel API error
-        http: HTTP error %{code}
-        internal: Internal error
+        api:
+        http:
+        internal:
       filter_modes:
         active:
-          one: Active Delivery
-          other: Active Deliveries
+          one:
+          other:
         recent:
-          one: Recent Delivery
-          other: Recent Deliveries
+          one:
+          other:
       status:
-        delivered: Delivered
-        delivery_exception: Delivery Exception
-        expecting_pickup: Expecting Pickup
-        failed_delivery_attempt: Failed Delivery Attempt
-        frozen: Frozen
-        in_transit: In Transit
-        information_received: Information Received
-        not_found: Not Found
-        out_for_delivery: Out For Delivery
-        unknown: Unknown
-      today: Today
-      tomorrow: Tomorrow
+        delivered:
+        delivery_exception:
+        expecting_pickup:
+        failed_delivery_attempt:
+        frozen:
+        in_transit:
+        information_received:
+        not_found:
+        out_for_delivery:
+        unknown:
+      today:
+      tomorrow:
     weather:
-      title: Weather
-      temperature: Temperature
-      feels_like: Feels Like
-      humidity: Humidity
-      low: Low
-      high: High
-      uv: UV
-      right_now: Right Now
-      today: Today
-      tomorrow: Tomorrow
-      low_high_short: L/H
-      uv_short: UV
-      max: Max
+      title:
+      temperature:
+      feels_like:
+      humidity:
+      low:
+      high:
+      uv:
+      right_now:
+      today:
+      tomorrow:
+      low_high_short:
+      uv_short:
+      max:
       tempest:
         conditions:
-          clear: Clear
-          cloudy: Cloudy
-          foggy: Foggy
-          partly_cloudy: Partly Cloudy
-          rain_likely: Rain Likely
-          rain_possible: Rain Possible
-          snow: Snow
-          snow_possible: Snow Possible
-          thunderstorms_likely: Thunderstorms Likely
-          thunderstorms_possible: Thunderstorms Possible
-          very_light_rain: Very Light Rain
-          windy: Windy
-          wintry_mix_likely: Wintry Mix Likely
-          wintry_mix_possible: Wintry Mix Possible
+          clear:
+          cloudy:
+          foggy:
+          partly_cloudy:
+          rain_likely:
+          rain_possible:
+          snow:
+          snow_possible:
+          thunderstorms_likely:
+          thunderstorms_possible:
+          very_light_rain:
+          windy:
+          wintry_mix_likely:
+          wintry_mix_possible:
       weatherapi:
         uv:
-          low: Low
-          moderate: Moderate
-          high: High
-          very_high: Very High
-          extreme: Extreme
+          low:
+          moderate:
+          high:
+          very_high:
+          extreme:
         conditions:
-        - code: 1000
-          day: Sunny
-          night: Clear
-        - code: 1003
-          day: Partly Cloudy
-          night: Partly Cloudy
-        - code: 1006
-          day: Cloudy
-          night: Cloudy
-        - code: 1009
-          day: Overcast
-          night: Overcast
-        - code: 1030
-          day: Mist
-          night: Mist
-        - code: 1063
-          day: Light Rain
-          night: Light Rain
-        - code: 1066
-          day: Light Snow
-          night: Light Snow
-        - code: 1069
-          day: Sleet
-          night: Sleet
-        - code: 1072
-          day: Freeze Drizzle
-          night: Freeze Drizzle
-        - code: 1087
-          day: Thunder
-          night: Thunder
-        - code: 1114
-          day: Blowing Snow
-          night: Blowing Snow
-        - code: 1117
-          day: Blizzard
-          night: Blizzard
-        - code: 1135
-          day: Fog
-          night: Fog
-        - code: 1147
-          day: Freezing Fog
-          night: Freezing Fog
-        - code: 1150
-          day: Light Drizzle
-          night: Light Drizzle
-        - code: 1153
-          day: Drizzle
-          night: Drizzle
-        - code: 1168
-          day: Freeze Drizzle
-          night: Freeze Drizzle
-        - code: 1171
-          day: Heavy Freeze
-          night: Heavy Freeze
-        - code: 1180
-          day: Light Rain
-          night: Light Rain
-        - code: 1183
-          day: Light Rain
-          night: Light Rain
-        - code: 1186
-          day: Moderate Rain
-          night: Moderate Rain
-        - code: 1189
-          day: Moderate Rain
-          night: Moderate Rain
-        - code: 1192
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1195
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1198
-          day: Light Freeze
-          night: Light Freeze
-        - code: 1201
-          day: Heavy Freeze
-          night: Heavy Freeze
-        - code: 1204
-          day: Light Sleet
-          night: Light Sleet
-        - code: 1207
-          day: Heavy Sleet
-          night: Heavy Sleet
-        - code: 1210
-          day: Light Snow
-          night: Light Snow
-        - code: 1213
-          day: Light Snow
-          night: Light Snow
-        - code: 1216
-          day: Moderate Snow
-          night: Moderate Snow
-        - code: 1219
-          day: Moderate Snow
-          night: Moderate Snow
-        - code: 1222
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1225
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1237
-          day: Ice Pellets
-          night: Ice Pellets
-        - code: 1240
-          day: Light Rain
-          night: Light Rain
-        - code: 1243
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1246
-          day: Torrential Rain
-          night: Torrential Rain
-        - code: 1249
-          day: Light Sleet
-          night: Light Sleet
-        - code: 1252
-          day: Heavy Sleet
-          night: Heavy Sleet
-        - code: 1255
-          day: Light Snow
-          night: Light Snow
-        - code: 1258
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1261
-          day: Light Ice
-          night: Light Ice
-        - code: 1264
-          day: Heavy Ice
-          night: Heavy Ice
-        - code: 1273
-          day: Thunder & Rain
-          night: Thunder & Rain
-        - code: 1276
-          day: Thunder & Rain
-          night: Thunder & Rain
-        - code: 1279
-          day: Thunder & Snow
-          night: Thunder & Snow
-        - code: 1282
-          day: Thunder & Snow
-          night: Thunder & Snow

--- a/lib/trmnl/i18n/locales/plugin_renders/is.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/is.yml
@@ -4,8 +4,8 @@ is:
     and_x_more_prefix: Og
     and_x_more_suffix: fleiri
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: Dagar eftir á þessu ári
       days_passed: Dagar liðnir
@@ -29,49 +29,49 @@ is:
         third_quarter: Þriðja kvartil
         waning_crescent: Minnkandi sigð
     netatmo_weather_station:
-      title: Netatmo Weather
-      title_short: Netatmo
-      indoor_temp: Indoor Temp.
-      indoor_temp_short: Indoor
-      indoor_humidity: Indoor Humidity
-      indoor_humidity_short: Indoor Hum.
-      outdoor_humidity: Outdoor Humidity
-      outdoor_humidity_short: Out. Hum.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
-      pressure: Pressure
-      noise: Noise
-      min_max: Min/Max
-      feels: Feels
-      rain: Rain
-      wind: Wind
-      gust: Gust
-      default_station_name: Netatmo Station
-      default_outdoor_module: Outdoor Temp.
-      default_indoor_module: Indoor
-      trends_title: "%{metric} Trends"
-      trends_title_short: Trends
-      temperature_trends: Temperature Trends
-      temperature_trends_short: Temp Trends
-      outdoor_now: Outdoor Now
-      indoor_now: Indoor Now
-      now: Now
-      low_high_24h: 24h Low / High
-      average_24h: 24h Average
-      outdoor: Outdoor
-      indoor: Indoor
-      rain_gauge_not_connected: Rain gauge not connected
-      wind_gauge_not_connected: Wind gauge not connected
-      no_rain_gauge: No rain gauge
-      no_wind_gauge: No wind gauge
-      add_module_hint: Add the optional %{module} module to see this data
-      range_24h: 24h Range
+      title:
+      title_short:
+      indoor_temp:
+      indoor_temp_short:
+      indoor_humidity:
+      indoor_humidity_short:
+      outdoor_humidity:
+      outdoor_humidity_short:
+      co2:
+      co2_ppm:
+      pressure:
+      noise:
+      min_max:
+      feels:
+      rain:
+      wind:
+      gust:
+      default_station_name:
+      default_outdoor_module:
+      default_indoor_module:
+      trends_title:
+      trends_title_short:
+      temperature_trends:
+      temperature_trends_short:
+      outdoor_now:
+      indoor_now:
+      now:
+      low_high_24h:
+      average_24h:
+      outdoor:
+      indoor:
+      rain_gauge_not_connected:
+      wind_gauge_not_connected:
+      no_rain_gauge:
+      no_wind_gauge:
+      add_module_hint:
+      range_24h:
       errors:
-        missing_access_token: Missing access token. Please reconnect your Netatmo account.
-        no_station_selected: No weather station selected. Please choose a station in settings.
-        connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
-        data_retrieval_failed: Unable to retrieve weather data. Please try again later.
-        session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        missing_access_token:
+        no_station_selected:
+        connection_failed:
+        data_retrieval_failed:
+        session_expired:
     parcel:
       delivery_by: Afhending fyrir
       empty: Engar sendingar
@@ -110,25 +110,25 @@ is:
       right_now: Núna
       today: Í dag
       tomorrow: Á morgun
-      low_high_short: L/H
-      uv_short: UV
-      max: Max
+      low_high_short:
+      uv_short:
+      max:
       tempest:
         conditions:
-          clear: Clear
-          cloudy: Cloudy
-          foggy: Foggy
-          partly_cloudy: Partly Cloudy
-          rain_likely: Rain Likely
-          rain_possible: Rain Possible
-          snow: Snow
-          snow_possible: Snow Possible
-          thunderstorms_likely: Thunderstorms Likely
-          thunderstorms_possible: Thunderstorms Possible
-          very_light_rain: Very Light Rain
-          windy: Windy
-          wintry_mix_likely: Wintry Mix Likely
-          wintry_mix_possible: Wintry Mix Possible
+          clear:
+          cloudy:
+          foggy:
+          partly_cloudy:
+          rain_likely:
+          rain_possible:
+          snow:
+          snow_possible:
+          thunderstorms_likely:
+          thunderstorms_possible:
+          very_light_rain:
+          windy:
+          wintry_mix_likely:
+          wintry_mix_possible:
       weatherapi:
         uv:
           low: Lágt

--- a/lib/trmnl/i18n/locales/plugin_renders/it.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/it.yml
@@ -4,8 +4,8 @@ it:
     and_x_more_prefix: e
     and_x_more_suffix: più
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: Giorni rimasti quest'anno
       days_passed: Giorni Passati
@@ -29,55 +29,55 @@ it:
         third_quarter: Terzo Quarto
         waning_crescent: Luna Calante
     netatmo_weather_station:
-      title: Netatmo Weather
-      title_short: Netatmo
-      indoor_temp: Indoor Temp.
-      indoor_temp_short: Indoor
-      indoor_humidity: Indoor Humidity
-      indoor_humidity_short: Indoor Hum.
-      outdoor_humidity: Outdoor Humidity
-      outdoor_humidity_short: Out. Hum.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
-      pressure: Pressure
-      noise: Noise
-      min_max: Min/Max
-      feels: Feels
-      rain: Rain
-      wind: Wind
-      gust: Gust
-      default_station_name: Netatmo Station
-      default_outdoor_module: Outdoor Temp.
-      default_indoor_module: Indoor
-      trends_title: "%{metric} Trends"
-      trends_title_short: Trends
-      temperature_trends: Temperature Trends
-      temperature_trends_short: Temp Trends
-      outdoor_now: Outdoor Now
-      indoor_now: Indoor Now
-      now: Now
-      low_high_24h: 24h Low / High
-      average_24h: 24h Average
-      outdoor: Outdoor
-      indoor: Indoor
-      rain_gauge_not_connected: Rain gauge not connected
-      wind_gauge_not_connected: Wind gauge not connected
-      no_rain_gauge: No rain gauge
-      no_wind_gauge: No wind gauge
-      add_module_hint: Add the optional %{module} module to see this data
-      range_24h: 24h Range
+      title:
+      title_short:
+      indoor_temp:
+      indoor_temp_short:
+      indoor_humidity:
+      indoor_humidity_short:
+      outdoor_humidity:
+      outdoor_humidity_short:
+      co2:
+      co2_ppm:
+      pressure:
+      noise:
+      min_max:
+      feels:
+      rain:
+      wind:
+      gust:
+      default_station_name:
+      default_outdoor_module:
+      default_indoor_module:
+      trends_title:
+      trends_title_short:
+      temperature_trends:
+      temperature_trends_short:
+      outdoor_now:
+      indoor_now:
+      now:
+      low_high_24h:
+      average_24h:
+      outdoor:
+      indoor:
+      rain_gauge_not_connected:
+      wind_gauge_not_connected:
+      no_rain_gauge:
+      no_wind_gauge:
+      add_module_hint:
+      range_24h:
       errors:
-        missing_access_token: Missing access token. Please reconnect your Netatmo account.
-        no_station_selected: No weather station selected. Please choose a station in settings.
-        connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
-        data_retrieval_failed: Unable to retrieve weather data. Please try again later.
-        session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        missing_access_token:
+        no_station_selected:
+        connection_failed:
+        data_retrieval_failed:
+        session_expired:
     parcel:
       delivery_by: Consegna da
       empty: Non ci sono spedizioni
       errors:
         api: Errore Parcel API
-        http: HTTP error %{code}
+        http:
         internal: Errore interno
       filter_modes:
         active:
@@ -106,178 +106,34 @@ it:
       humidity: Umidità
       low: Minima
       high: Massima
-      uv: UV
+      uv:
       right_now: Adesso
       today: Oggi
       tomorrow: Domani
-      low_high_short: L/H
-      uv_short: UV
-      max: Max
+      low_high_short:
+      uv_short:
+      max:
       tempest:
         conditions:
-          clear: Clear
-          cloudy: Cloudy
-          foggy: Foggy
-          partly_cloudy: Partly Cloudy
-          rain_likely: Rain Likely
-          rain_possible: Rain Possible
-          snow: Snow
-          snow_possible: Snow Possible
-          thunderstorms_likely: Thunderstorms Likely
-          thunderstorms_possible: Thunderstorms Possible
-          very_light_rain: Very Light Rain
-          windy: Windy
-          wintry_mix_likely: Wintry Mix Likely
-          wintry_mix_possible: Wintry Mix Possible
+          clear:
+          cloudy:
+          foggy:
+          partly_cloudy:
+          rain_likely:
+          rain_possible:
+          snow:
+          snow_possible:
+          thunderstorms_likely:
+          thunderstorms_possible:
+          very_light_rain:
+          windy:
+          wintry_mix_likely:
+          wintry_mix_possible:
       weatherapi:
         uv:
-          low: Low
-          moderate: Moderate
-          high: High
-          very_high: Very High
-          extreme: Extreme
+          low:
+          moderate:
+          high:
+          very_high:
+          extreme:
         conditions:
-        - code: 1000
-          day: Sunny
-          night: Clear
-        - code: 1003
-          day: Partly Cloudy
-          night: Partly Cloudy
-        - code: 1006
-          day: Cloudy
-          night: Cloudy
-        - code: 1009
-          day: Overcast
-          night: Overcast
-        - code: 1030
-          day: Mist
-          night: Mist
-        - code: 1063
-          day: Light Rain
-          night: Light Rain
-        - code: 1066
-          day: Light Snow
-          night: Light Snow
-        - code: 1069
-          day: Sleet
-          night: Sleet
-        - code: 1072
-          day: Freeze Drizzle
-          night: Freeze Drizzle
-        - code: 1087
-          day: Thunder
-          night: Thunder
-        - code: 1114
-          day: Blowing Snow
-          night: Blowing Snow
-        - code: 1117
-          day: Blizzard
-          night: Blizzard
-        - code: 1135
-          day: Fog
-          night: Fog
-        - code: 1147
-          day: Freezing Fog
-          night: Freezing Fog
-        - code: 1150
-          day: Light Drizzle
-          night: Light Drizzle
-        - code: 1153
-          day: Drizzle
-          night: Drizzle
-        - code: 1168
-          day: Freeze Drizzle
-          night: Freeze Drizzle
-        - code: 1171
-          day: Heavy Freeze
-          night: Heavy Freeze
-        - code: 1180
-          day: Light Rain
-          night: Light Rain
-        - code: 1183
-          day: Light Rain
-          night: Light Rain
-        - code: 1186
-          day: Moderate Rain
-          night: Moderate Rain
-        - code: 1189
-          day: Moderate Rain
-          night: Moderate Rain
-        - code: 1192
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1195
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1198
-          day: Light Freeze
-          night: Light Freeze
-        - code: 1201
-          day: Heavy Freeze
-          night: Heavy Freeze
-        - code: 1204
-          day: Light Sleet
-          night: Light Sleet
-        - code: 1207
-          day: Heavy Sleet
-          night: Heavy Sleet
-        - code: 1210
-          day: Light Snow
-          night: Light Snow
-        - code: 1213
-          day: Light Snow
-          night: Light Snow
-        - code: 1216
-          day: Moderate Snow
-          night: Moderate Snow
-        - code: 1219
-          day: Moderate Snow
-          night: Moderate Snow
-        - code: 1222
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1225
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1237
-          day: Ice Pellets
-          night: Ice Pellets
-        - code: 1240
-          day: Light Rain
-          night: Light Rain
-        - code: 1243
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1246
-          day: Torrential Rain
-          night: Torrential Rain
-        - code: 1249
-          day: Light Sleet
-          night: Light Sleet
-        - code: 1252
-          day: Heavy Sleet
-          night: Heavy Sleet
-        - code: 1255
-          day: Light Snow
-          night: Light Snow
-        - code: 1258
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1261
-          day: Light Ice
-          night: Light Ice
-        - code: 1264
-          day: Heavy Ice
-          night: Heavy Ice
-        - code: 1273
-          day: Thunder & Rain
-          night: Thunder & Rain
-        - code: 1276
-          day: Thunder & Rain
-          night: Thunder & Rain
-        - code: 1279
-          day: Thunder & Snow
-          night: Thunder & Snow
-        - code: 1282
-          day: Thunder & Snow
-          night: Thunder & Snow

--- a/lib/trmnl/i18n/locales/plugin_renders/ja.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ja.yml
@@ -1,104 +1,104 @@
 ---
 ja:
   renders:
-    and_x_more_prefix: And
-    and_x_more_suffix: more
+    and_x_more_prefix:
+    and_x_more_suffix:
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: 今年の残り日数
       days_passed: 経過日数
       days_left: 残り日数
     lunar_calendar:
-      title: Lunar Calendar
-      age: Lunar Age
-      current_phase: Current Phase
-      illumination: Moon Illumination
-      next_full_moon: Next Full Moon
-      next_new_moon: Next New Moon
-      next_phase: Next Phase
-      next_phase_short: Next
+      title:
+      age:
+      current_phase:
+      illumination:
+      next_full_moon:
+      next_new_moon:
+      next_phase:
+      next_phase_short:
       moon_phases:
-        new_moon: New Moon
-        waxing_crescent: Waxing Crescent
-        first_quarter: First Quarter
-        waxing_gibbous: Waxing Gibbous
-        full_moon: Full Moon
-        waning_gibbous: Waning Gibbous
-        third_quarter: Third Quarter
-        waning_crescent: Waning Crescent
+        new_moon:
+        waxing_crescent:
+        first_quarter:
+        waxing_gibbous:
+        full_moon:
+        waning_gibbous:
+        third_quarter:
+        waning_crescent:
     netatmo_weather_station:
-      title: Netatmo Weather
-      title_short: Netatmo
-      indoor_temp: Indoor Temp.
-      indoor_temp_short: Indoor
-      indoor_humidity: Indoor Humidity
-      indoor_humidity_short: Indoor Hum.
-      outdoor_humidity: Outdoor Humidity
-      outdoor_humidity_short: Out. Hum.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
-      pressure: Pressure
-      noise: Noise
-      min_max: Min/Max
-      feels: Feels
-      rain: Rain
-      wind: Wind
-      gust: Gust
-      default_station_name: Netatmo Station
-      default_outdoor_module: Outdoor Temp.
-      default_indoor_module: Indoor
-      trends_title: "%{metric} Trends"
-      trends_title_short: Trends
-      temperature_trends: Temperature Trends
-      temperature_trends_short: Temp Trends
-      outdoor_now: Outdoor Now
-      indoor_now: Indoor Now
-      now: Now
-      low_high_24h: 24h Low / High
-      average_24h: 24h Average
-      outdoor: Outdoor
-      indoor: Indoor
-      rain_gauge_not_connected: Rain gauge not connected
-      wind_gauge_not_connected: Wind gauge not connected
-      no_rain_gauge: No rain gauge
-      no_wind_gauge: No wind gauge
-      add_module_hint: Add the optional %{module} module to see this data
-      range_24h: 24h Range
+      title:
+      title_short:
+      indoor_temp:
+      indoor_temp_short:
+      indoor_humidity:
+      indoor_humidity_short:
+      outdoor_humidity:
+      outdoor_humidity_short:
+      co2:
+      co2_ppm:
+      pressure:
+      noise:
+      min_max:
+      feels:
+      rain:
+      wind:
+      gust:
+      default_station_name:
+      default_outdoor_module:
+      default_indoor_module:
+      trends_title:
+      trends_title_short:
+      temperature_trends:
+      temperature_trends_short:
+      outdoor_now:
+      indoor_now:
+      now:
+      low_high_24h:
+      average_24h:
+      outdoor:
+      indoor:
+      rain_gauge_not_connected:
+      wind_gauge_not_connected:
+      no_rain_gauge:
+      no_wind_gauge:
+      add_module_hint:
+      range_24h:
       errors:
-        missing_access_token: Missing access token. Please reconnect your Netatmo account.
-        no_station_selected: No weather station selected. Please choose a station in settings.
-        connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
-        data_retrieval_failed: Unable to retrieve weather data. Please try again later.
-        session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        missing_access_token:
+        no_station_selected:
+        connection_failed:
+        data_retrieval_failed:
+        session_expired:
     parcel:
-      delivery_by: Delivery by
-      empty: There are no deliveries
+      delivery_by:
+      empty:
       errors:
-        api: Parcel API error
-        http: HTTP error %{code}
-        internal: Internal error
+        api:
+        http:
+        internal:
       filter_modes:
         active:
-          one: Active Delivery
-          other: Active Deliveries
+          one:
+          other:
         recent:
-          one: Recent Delivery
-          other: Recent Deliveries
+          one:
+          other:
       status:
-        delivered: Delivered
-        delivery_exception: Delivery Exception
-        expecting_pickup: Expecting Pickup
-        failed_delivery_attempt: Failed Delivery Attempt
-        frozen: Frozen
-        in_transit: In Transit
-        information_received: Information Received
-        not_found: Not Found
-        out_for_delivery: Out For Delivery
-        unknown: Unknown
-      today: Today
-      tomorrow: Tomorrow
+        delivered:
+        delivery_exception:
+        expecting_pickup:
+        failed_delivery_attempt:
+        frozen:
+        in_transit:
+        information_received:
+        not_found:
+        out_for_delivery:
+        unknown:
+      today:
+      tomorrow:
     weather:
       title: 天気
       temperature: 温度
@@ -110,174 +110,30 @@ ja:
       right_now: 現在
       today: 今日
       tomorrow: 明日
-      low_high_short: L/H
-      uv_short: UV
-      max: Max
+      low_high_short:
+      uv_short:
+      max:
       tempest:
         conditions:
-          clear: Clear
-          cloudy: Cloudy
-          foggy: Foggy
-          partly_cloudy: Partly Cloudy
-          rain_likely: Rain Likely
-          rain_possible: Rain Possible
-          snow: Snow
-          snow_possible: Snow Possible
-          thunderstorms_likely: Thunderstorms Likely
-          thunderstorms_possible: Thunderstorms Possible
-          very_light_rain: Very Light Rain
-          windy: Windy
-          wintry_mix_likely: Wintry Mix Likely
-          wintry_mix_possible: Wintry Mix Possible
+          clear:
+          cloudy:
+          foggy:
+          partly_cloudy:
+          rain_likely:
+          rain_possible:
+          snow:
+          snow_possible:
+          thunderstorms_likely:
+          thunderstorms_possible:
+          very_light_rain:
+          windy:
+          wintry_mix_likely:
+          wintry_mix_possible:
       weatherapi:
         uv:
-          low: Low
-          moderate: Moderate
-          high: High
-          very_high: Very High
-          extreme: Extreme
+          low:
+          moderate:
+          high:
+          very_high:
+          extreme:
         conditions:
-        - code: 1000
-          day: Sunny
-          night: Clear
-        - code: 1003
-          day: Partly Cloudy
-          night: Partly Cloudy
-        - code: 1006
-          day: Cloudy
-          night: Cloudy
-        - code: 1009
-          day: Overcast
-          night: Overcast
-        - code: 1030
-          day: Mist
-          night: Mist
-        - code: 1063
-          day: Light Rain
-          night: Light Rain
-        - code: 1066
-          day: Light Snow
-          night: Light Snow
-        - code: 1069
-          day: Sleet
-          night: Sleet
-        - code: 1072
-          day: Freeze Drizzle
-          night: Freeze Drizzle
-        - code: 1087
-          day: Thunder
-          night: Thunder
-        - code: 1114
-          day: Blowing Snow
-          night: Blowing Snow
-        - code: 1117
-          day: Blizzard
-          night: Blizzard
-        - code: 1135
-          day: Fog
-          night: Fog
-        - code: 1147
-          day: Freezing Fog
-          night: Freezing Fog
-        - code: 1150
-          day: Light Drizzle
-          night: Light Drizzle
-        - code: 1153
-          day: Drizzle
-          night: Drizzle
-        - code: 1168
-          day: Freeze Drizzle
-          night: Freeze Drizzle
-        - code: 1171
-          day: Heavy Freeze
-          night: Heavy Freeze
-        - code: 1180
-          day: Light Rain
-          night: Light Rain
-        - code: 1183
-          day: Light Rain
-          night: Light Rain
-        - code: 1186
-          day: Moderate Rain
-          night: Moderate Rain
-        - code: 1189
-          day: Moderate Rain
-          night: Moderate Rain
-        - code: 1192
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1195
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1198
-          day: Light Freeze
-          night: Light Freeze
-        - code: 1201
-          day: Heavy Freeze
-          night: Heavy Freeze
-        - code: 1204
-          day: Light Sleet
-          night: Light Sleet
-        - code: 1207
-          day: Heavy Sleet
-          night: Heavy Sleet
-        - code: 1210
-          day: Light Snow
-          night: Light Snow
-        - code: 1213
-          day: Light Snow
-          night: Light Snow
-        - code: 1216
-          day: Moderate Snow
-          night: Moderate Snow
-        - code: 1219
-          day: Moderate Snow
-          night: Moderate Snow
-        - code: 1222
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1225
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1237
-          day: Ice Pellets
-          night: Ice Pellets
-        - code: 1240
-          day: Light Rain
-          night: Light Rain
-        - code: 1243
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1246
-          day: Torrential Rain
-          night: Torrential Rain
-        - code: 1249
-          day: Light Sleet
-          night: Light Sleet
-        - code: 1252
-          day: Heavy Sleet
-          night: Heavy Sleet
-        - code: 1255
-          day: Light Snow
-          night: Light Snow
-        - code: 1258
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1261
-          day: Light Ice
-          night: Light Ice
-        - code: 1264
-          day: Heavy Ice
-          night: Heavy Ice
-        - code: 1273
-          day: Thunder & Rain
-          night: Thunder & Rain
-        - code: 1276
-          day: Thunder & Rain
-          night: Thunder & Rain
-        - code: 1279
-          day: Thunder & Snow
-          night: Thunder & Snow
-        - code: 1282
-          day: Thunder & Snow
-          night: Thunder & Snow

--- a/lib/trmnl/i18n/locales/plugin_renders/ko.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ko.yml
@@ -4,8 +4,8 @@ ko:
     and_x_more_prefix: ''
     and_x_more_suffix: 개 더
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: 올해 남은 날
       days_passed: 지난 날
@@ -30,15 +30,15 @@ ko:
         waning_crescent: 그믐달
     netatmo_weather_station:
       title: Netatmo 날씨
-      title_short: Netatmo
+      title_short:
       indoor_temp: 실내 온도
       indoor_temp_short: 실내
       indoor_humidity: 실내 습도
       indoor_humidity_short: 실내 습도
       outdoor_humidity: 실외 습도
       outdoor_humidity_short: 실외 습도
-      co2: CO₂
-      co2_ppm: CO₂ ppm
+      co2:
+      co2_ppm:
       pressure: 기압
       noise: 소음
       min_max: 최저/최고
@@ -111,7 +111,7 @@ ko:
       today: 오늘
       tomorrow: 내일
       low_high_short: 최저/최고
-      uv_short: UV
+      uv_short:
       max: 최대
       tempest:
         conditions:

--- a/lib/trmnl/i18n/locales/plugin_renders/lt.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/lt.yml
@@ -4,8 +4,8 @@ lt:
     and_x_more_prefix: Ir dar
     and_x_more_suffix: daugiau
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: Dienų liko šiais metais
       days_passed: Praėjo dienų
@@ -30,15 +30,15 @@ lt:
         waning_crescent: Senas mėnulis
     netatmo_weather_station:
       title: Netatmo orai
-      title_short: Netatmo
+      title_short:
       indoor_temp: Vidaus temp.
       indoor_temp_short: Viduje
       indoor_humidity: Vidaus drėgmė
       indoor_humidity_short: Vidaus drėgn.
       outdoor_humidity: Lauko drėgmė
       outdoor_humidity_short: Lauko drėgn.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
+      co2:
+      co2_ppm:
       pressure: Slėgis
       noise: Triukšmas
       min_max: Min/Maks
@@ -106,12 +106,12 @@ lt:
       humidity: Drėgmė
       low: Žemiausia
       high: Aukščiausia
-      uv: UV
+      uv:
       right_now: Šiuo metu
       today: Šiandien
       tomorrow: Rytoj
       low_high_short: Ž/A
-      uv_short: UV
+      uv_short:
       max: Maks.
       tempest:
         conditions:

--- a/lib/trmnl/i18n/locales/plugin_renders/nl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/nl.yml
@@ -4,8 +4,8 @@ nl:
     and_x_more_prefix: En nog
     and_x_more_suffix:
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: Dagen over dit jaar
       days_passed: Verstreken dagen
@@ -29,56 +29,56 @@ nl:
         third_quarter: Laatste Kwartier
         waning_crescent: Asgrauwe Maan
     netatmo_weather_station:
-      title: Netatmo Weather
-      title_short: Netatmo
-      indoor_temp: Indoor Temp.
-      indoor_temp_short: Indoor
-      indoor_humidity: Indoor Humidity
-      indoor_humidity_short: Indoor Hum.
-      outdoor_humidity: Outdoor Humidity
-      outdoor_humidity_short: Out. Hum.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
-      pressure: Pressure
-      noise: Noise
-      min_max: Min/Max
-      feels: Feels
-      rain: Rain
-      wind: Wind
-      gust: Gust
-      default_station_name: Netatmo Station
-      default_outdoor_module: Outdoor Temp.
-      default_indoor_module: Indoor
-      trends_title: "%{metric} Trends"
-      trends_title_short: Trends
-      temperature_trends: Temperature Trends
-      temperature_trends_short: Temp Trends
-      outdoor_now: Outdoor Now
-      indoor_now: Indoor Now
-      now: Now
-      low_high_24h: 24h Low / High
-      average_24h: 24h Average
-      outdoor: Outdoor
-      indoor: Indoor
-      rain_gauge_not_connected: Rain gauge not connected
-      wind_gauge_not_connected: Wind gauge not connected
-      no_rain_gauge: No rain gauge
-      no_wind_gauge: No wind gauge
-      add_module_hint: Add the optional %{module} module to see this data
-      range_24h: 24h Range
+      title:
+      title_short:
+      indoor_temp:
+      indoor_temp_short:
+      indoor_humidity:
+      indoor_humidity_short:
+      outdoor_humidity:
+      outdoor_humidity_short:
+      co2:
+      co2_ppm:
+      pressure:
+      noise:
+      min_max:
+      feels:
+      rain:
+      wind:
+      gust:
+      default_station_name:
+      default_outdoor_module:
+      default_indoor_module:
+      trends_title:
+      trends_title_short:
+      temperature_trends:
+      temperature_trends_short:
+      outdoor_now:
+      indoor_now:
+      now:
+      low_high_24h:
+      average_24h:
+      outdoor:
+      indoor:
+      rain_gauge_not_connected:
+      wind_gauge_not_connected:
+      no_rain_gauge:
+      no_wind_gauge:
+      add_module_hint:
+      range_24h:
       errors:
-        missing_access_token: Missing access token. Please reconnect your Netatmo account.
-        no_station_selected: No weather station selected. Please choose a station in settings.
-        connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
-        data_retrieval_failed: Unable to retrieve weather data. Please try again later.
-        session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        missing_access_token:
+        no_station_selected:
+        connection_failed:
+        data_retrieval_failed:
+        session_expired:
     parcel:
       delivery_by: Levering door
       empty: Er zijn geen leveringen
       errors:
-        api: Parcel API error
-        http: HTTP error %{code}
-        internal: Internal error
+        api:
+        http:
+        internal:
       filter_modes:
         active:
           one: Actieve Levering
@@ -106,29 +106,29 @@ nl:
       humidity: Vochtigheid
       low: Min
       high: Max
-      uv: UV
+      uv:
       right_now: Op dit moment
       today: Vandaag
       tomorrow: Morgen
-      low_high_short: L/H
-      uv_short: UV
-      max: Max
+      low_high_short:
+      uv_short:
+      max:
       tempest:
         conditions:
-          clear: Clear
-          cloudy: Cloudy
-          foggy: Foggy
-          partly_cloudy: Partly Cloudy
-          rain_likely: Rain Likely
-          rain_possible: Rain Possible
-          snow: Snow
-          snow_possible: Snow Possible
-          thunderstorms_likely: Thunderstorms Likely
-          thunderstorms_possible: Thunderstorms Possible
-          very_light_rain: Very Light Rain
-          windy: Windy
-          wintry_mix_likely: Wintry Mix Likely
-          wintry_mix_possible: Wintry Mix Possible
+          clear:
+          cloudy:
+          foggy:
+          partly_cloudy:
+          rain_likely:
+          rain_possible:
+          snow:
+          snow_possible:
+          thunderstorms_likely:
+          thunderstorms_possible:
+          very_light_rain:
+          windy:
+          wintry_mix_likely:
+          wintry_mix_possible:
       weatherapi:
         uv:
           low: Zwak

--- a/lib/trmnl/i18n/locales/plugin_renders/no.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/no.yml
@@ -1,104 +1,104 @@
 ---
 'no':
   renders:
-    and_x_more_prefix: And
-    and_x_more_suffix: more
+    and_x_more_prefix:
+    and_x_more_suffix:
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: Dager igjen i år
       days_passed: Dager som har gått
       days_left: Gjenstående dager
     lunar_calendar:
-      title: Lunar Calendar
-      age: Lunar Age
-      current_phase: Current Phase
-      illumination: Moon Illumination
-      next_full_moon: Next Full Moon
-      next_new_moon: Next New Moon
-      next_phase: Next Phase
-      next_phase_short: Next
+      title:
+      age:
+      current_phase:
+      illumination:
+      next_full_moon:
+      next_new_moon:
+      next_phase:
+      next_phase_short:
       moon_phases:
-        new_moon: New Moon
-        waxing_crescent: Waxing Crescent
-        first_quarter: First Quarter
-        waxing_gibbous: Waxing Gibbous
-        full_moon: Full Moon
-        waning_gibbous: Waning Gibbous
-        third_quarter: Third Quarter
-        waning_crescent: Waning Crescent
+        new_moon:
+        waxing_crescent:
+        first_quarter:
+        waxing_gibbous:
+        full_moon:
+        waning_gibbous:
+        third_quarter:
+        waning_crescent:
     netatmo_weather_station:
-      title: Netatmo Weather
-      title_short: Netatmo
-      indoor_temp: Indoor Temp.
-      indoor_temp_short: Indoor
-      indoor_humidity: Indoor Humidity
-      indoor_humidity_short: Indoor Hum.
-      outdoor_humidity: Outdoor Humidity
-      outdoor_humidity_short: Out. Hum.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
-      pressure: Pressure
-      noise: Noise
-      min_max: Min/Max
-      feels: Feels
-      rain: Rain
-      wind: Wind
-      gust: Gust
-      default_station_name: Netatmo Station
-      default_outdoor_module: Outdoor Temp.
-      default_indoor_module: Indoor
-      trends_title: "%{metric} Trends"
-      trends_title_short: Trends
-      temperature_trends: Temperature Trends
-      temperature_trends_short: Temp Trends
-      outdoor_now: Outdoor Now
-      indoor_now: Indoor Now
-      now: Now
-      low_high_24h: 24h Low / High
-      average_24h: 24h Average
-      outdoor: Outdoor
-      indoor: Indoor
-      rain_gauge_not_connected: Rain gauge not connected
-      wind_gauge_not_connected: Wind gauge not connected
-      no_rain_gauge: No rain gauge
-      no_wind_gauge: No wind gauge
-      add_module_hint: Add the optional %{module} module to see this data
-      range_24h: 24h Range
+      title:
+      title_short:
+      indoor_temp:
+      indoor_temp_short:
+      indoor_humidity:
+      indoor_humidity_short:
+      outdoor_humidity:
+      outdoor_humidity_short:
+      co2:
+      co2_ppm:
+      pressure:
+      noise:
+      min_max:
+      feels:
+      rain:
+      wind:
+      gust:
+      default_station_name:
+      default_outdoor_module:
+      default_indoor_module:
+      trends_title:
+      trends_title_short:
+      temperature_trends:
+      temperature_trends_short:
+      outdoor_now:
+      indoor_now:
+      now:
+      low_high_24h:
+      average_24h:
+      outdoor:
+      indoor:
+      rain_gauge_not_connected:
+      wind_gauge_not_connected:
+      no_rain_gauge:
+      no_wind_gauge:
+      add_module_hint:
+      range_24h:
       errors:
-        missing_access_token: Missing access token. Please reconnect your Netatmo account.
-        no_station_selected: No weather station selected. Please choose a station in settings.
-        connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
-        data_retrieval_failed: Unable to retrieve weather data. Please try again later.
-        session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        missing_access_token:
+        no_station_selected:
+        connection_failed:
+        data_retrieval_failed:
+        session_expired:
     parcel:
-      delivery_by: Delivery by
-      empty: There are no deliveries
+      delivery_by:
+      empty:
       errors:
-        api: Parcel API error
-        http: HTTP error %{code}
-        internal: Internal error
+        api:
+        http:
+        internal:
       filter_modes:
         active:
-          one: Active Delivery
-          other: Active Deliveries
+          one:
+          other:
         recent:
-          one: Recent Delivery
-          other: Recent Deliveries
+          one:
+          other:
       status:
-        delivered: Delivered
-        delivery_exception: Delivery Exception
-        expecting_pickup: Expecting Pickup
-        failed_delivery_attempt: Failed Delivery Attempt
-        frozen: Frozen
-        in_transit: In Transit
-        information_received: Information Received
-        not_found: Not Found
-        out_for_delivery: Out For Delivery
-        unknown: Unknown
-      today: Today
-      tomorrow: Tomorrow
+        delivered:
+        delivery_exception:
+        expecting_pickup:
+        failed_delivery_attempt:
+        frozen:
+        in_transit:
+        information_received:
+        not_found:
+        out_for_delivery:
+        unknown:
+      today:
+      tomorrow:
     weather:
       title: Vær
       temperature: Temperatur
@@ -106,178 +106,34 @@
       humidity: Fuktighet
       low: Lav
       high: Høy
-      uv: UV
+      uv:
       right_now: Akkurat nå
       today: I dag
       tomorrow: I morgen
-      low_high_short: L/H
-      uv_short: UV
-      max: Max
+      low_high_short:
+      uv_short:
+      max:
       tempest:
         conditions:
-          clear: Clear
-          cloudy: Cloudy
-          foggy: Foggy
-          partly_cloudy: Partly Cloudy
-          rain_likely: Rain Likely
-          rain_possible: Rain Possible
-          snow: Snow
-          snow_possible: Snow Possible
-          thunderstorms_likely: Thunderstorms Likely
-          thunderstorms_possible: Thunderstorms Possible
-          very_light_rain: Very Light Rain
-          windy: Windy
-          wintry_mix_likely: Wintry Mix Likely
-          wintry_mix_possible: Wintry Mix Possible
+          clear:
+          cloudy:
+          foggy:
+          partly_cloudy:
+          rain_likely:
+          rain_possible:
+          snow:
+          snow_possible:
+          thunderstorms_likely:
+          thunderstorms_possible:
+          very_light_rain:
+          windy:
+          wintry_mix_likely:
+          wintry_mix_possible:
       weatherapi:
         uv:
-          low: Low
-          moderate: Moderate
-          high: High
-          very_high: Very High
-          extreme: Extreme
+          low:
+          moderate:
+          high:
+          very_high:
+          extreme:
         conditions:
-        - code: 1000
-          day: Sunny
-          night: Clear
-        - code: 1003
-          day: Partly Cloudy
-          night: Partly Cloudy
-        - code: 1006
-          day: Cloudy
-          night: Cloudy
-        - code: 1009
-          day: Overcast
-          night: Overcast
-        - code: 1030
-          day: Mist
-          night: Mist
-        - code: 1063
-          day: Light Rain
-          night: Light Rain
-        - code: 1066
-          day: Light Snow
-          night: Light Snow
-        - code: 1069
-          day: Sleet
-          night: Sleet
-        - code: 1072
-          day: Freeze Drizzle
-          night: Freeze Drizzle
-        - code: 1087
-          day: Thunder
-          night: Thunder
-        - code: 1114
-          day: Blowing Snow
-          night: Blowing Snow
-        - code: 1117
-          day: Blizzard
-          night: Blizzard
-        - code: 1135
-          day: Fog
-          night: Fog
-        - code: 1147
-          day: Freezing Fog
-          night: Freezing Fog
-        - code: 1150
-          day: Light Drizzle
-          night: Light Drizzle
-        - code: 1153
-          day: Drizzle
-          night: Drizzle
-        - code: 1168
-          day: Freeze Drizzle
-          night: Freeze Drizzle
-        - code: 1171
-          day: Heavy Freeze
-          night: Heavy Freeze
-        - code: 1180
-          day: Light Rain
-          night: Light Rain
-        - code: 1183
-          day: Light Rain
-          night: Light Rain
-        - code: 1186
-          day: Moderate Rain
-          night: Moderate Rain
-        - code: 1189
-          day: Moderate Rain
-          night: Moderate Rain
-        - code: 1192
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1195
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1198
-          day: Light Freeze
-          night: Light Freeze
-        - code: 1201
-          day: Heavy Freeze
-          night: Heavy Freeze
-        - code: 1204
-          day: Light Sleet
-          night: Light Sleet
-        - code: 1207
-          day: Heavy Sleet
-          night: Heavy Sleet
-        - code: 1210
-          day: Light Snow
-          night: Light Snow
-        - code: 1213
-          day: Light Snow
-          night: Light Snow
-        - code: 1216
-          day: Moderate Snow
-          night: Moderate Snow
-        - code: 1219
-          day: Moderate Snow
-          night: Moderate Snow
-        - code: 1222
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1225
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1237
-          day: Ice Pellets
-          night: Ice Pellets
-        - code: 1240
-          day: Light Rain
-          night: Light Rain
-        - code: 1243
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1246
-          day: Torrential Rain
-          night: Torrential Rain
-        - code: 1249
-          day: Light Sleet
-          night: Light Sleet
-        - code: 1252
-          day: Heavy Sleet
-          night: Heavy Sleet
-        - code: 1255
-          day: Light Snow
-          night: Light Snow
-        - code: 1258
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1261
-          day: Light Ice
-          night: Light Ice
-        - code: 1264
-          day: Heavy Ice
-          night: Heavy Ice
-        - code: 1273
-          day: Thunder & Rain
-          night: Thunder & Rain
-        - code: 1276
-          day: Thunder & Rain
-          night: Thunder & Rain
-        - code: 1279
-          day: Thunder & Snow
-          night: Thunder & Snow
-        - code: 1282
-          day: Thunder & Snow
-          night: Thunder & Snow

--- a/lib/trmnl/i18n/locales/plugin_renders/pl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pl.yml
@@ -29,16 +29,16 @@ pl:
         third_quarter: Trzecia kwadra
         waning_crescent: Znikający sierp
     netatmo_weather_station:
-      title: Netatmo Weather
-      title_short: Netatmo
+      title:
+      title_short:
       indoor_temp: Temperatura wew.
       indoor_temp_short: Wewnątrz
       indoor_humidity: Wilgotność wewnętrzna
       indoor_humidity_short: Wilg. wew.
       outdoor_humidity: Wilgotność zewnętrzna
       outdoor_humidity_short: Wilg. zew.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
+      co2:
+      co2_ppm:
       pressure: Ciśnienie
       noise: Hałas
       min_max: Min/Maks
@@ -111,8 +111,8 @@ pl:
       right_now: Obecnie
       today: Dziś
       tomorrow: Jutro
-      low_high_short: L/H
-      uv_short: UV
+      low_high_short:
+      uv_short:
       max: Maks.
       tempest:
         conditions:

--- a/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
@@ -4,8 +4,8 @@ pt-BR:
     and_x_more_prefix: E
     and_x_more_suffix: mais
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: Dias Restantes Neste Ano
       days_passed: Dias Corridos
@@ -29,49 +29,49 @@ pt-BR:
         third_quarter: Quarto Minguante
         waning_crescent: Lua Minguante
     netatmo_weather_station:
-      title: Netatmo Weather
-      title_short: Netatmo
-      indoor_temp: Indoor Temp.
-      indoor_temp_short: Indoor
-      indoor_humidity: Indoor Humidity
-      indoor_humidity_short: Indoor Hum.
-      outdoor_humidity: Outdoor Humidity
-      outdoor_humidity_short: Out. Hum.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
-      pressure: Pressure
-      noise: Noise
-      min_max: Min/Max
-      feels: Feels
-      rain: Rain
-      wind: Wind
-      gust: Gust
-      default_station_name: Netatmo Station
-      default_outdoor_module: Outdoor Temp.
-      default_indoor_module: Indoor
-      trends_title: "%{metric} Trends"
-      trends_title_short: Trends
-      temperature_trends: Temperature Trends
-      temperature_trends_short: Temp Trends
-      outdoor_now: Outdoor Now
-      indoor_now: Indoor Now
-      now: Now
-      low_high_24h: 24h Low / High
-      average_24h: 24h Average
-      outdoor: Outdoor
-      indoor: Indoor
-      rain_gauge_not_connected: Rain gauge not connected
-      wind_gauge_not_connected: Wind gauge not connected
-      no_rain_gauge: No rain gauge
-      no_wind_gauge: No wind gauge
-      add_module_hint: Add the optional %{module} module to see this data
-      range_24h: 24h Range
+      title:
+      title_short:
+      indoor_temp:
+      indoor_temp_short:
+      indoor_humidity:
+      indoor_humidity_short:
+      outdoor_humidity:
+      outdoor_humidity_short:
+      co2:
+      co2_ppm:
+      pressure:
+      noise:
+      min_max:
+      feels:
+      rain:
+      wind:
+      gust:
+      default_station_name:
+      default_outdoor_module:
+      default_indoor_module:
+      trends_title:
+      trends_title_short:
+      temperature_trends:
+      temperature_trends_short:
+      outdoor_now:
+      indoor_now:
+      now:
+      low_high_24h:
+      average_24h:
+      outdoor:
+      indoor:
+      rain_gauge_not_connected:
+      wind_gauge_not_connected:
+      no_rain_gauge:
+      no_wind_gauge:
+      add_module_hint:
+      range_24h:
       errors:
-        missing_access_token: Missing access token. Please reconnect your Netatmo account.
-        no_station_selected: No weather station selected. Please choose a station in settings.
-        connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
-        data_retrieval_failed: Unable to retrieve weather data. Please try again later.
-        session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        missing_access_token:
+        no_station_selected:
+        connection_failed:
+        data_retrieval_failed:
+        session_expired:
     parcel:
       delivery_by: Entregue por
       empty: Não há entregas
@@ -106,29 +106,29 @@ pt-BR:
       humidity: Umidade
       low: Mínima
       high: Máxima
-      uv: UV
+      uv:
       right_now: Agora
       today: Hoje
       tomorrow: Amanhã
-      low_high_short: L/H
-      uv_short: UV
-      max: Max
+      low_high_short:
+      uv_short:
+      max:
       tempest:
         conditions:
-          clear: Clear
-          cloudy: Cloudy
-          foggy: Foggy
-          partly_cloudy: Partly Cloudy
-          rain_likely: Rain Likely
-          rain_possible: Rain Possible
-          snow: Snow
-          snow_possible: Snow Possible
-          thunderstorms_likely: Thunderstorms Likely
-          thunderstorms_possible: Thunderstorms Possible
-          very_light_rain: Very Light Rain
-          windy: Windy
-          wintry_mix_likely: Wintry Mix Likely
-          wintry_mix_possible: Wintry Mix Possible
+          clear:
+          cloudy:
+          foggy:
+          partly_cloudy:
+          rain_likely:
+          rain_possible:
+          snow:
+          snow_possible:
+          thunderstorms_likely:
+          thunderstorms_possible:
+          very_light_rain:
+          windy:
+          wintry_mix_likely:
+          wintry_mix_possible:
       weatherapi:
         uv:
           low: Baixo

--- a/lib/trmnl/i18n/locales/plugin_renders/ro.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ro.yml
@@ -4,8 +4,8 @@ ro:
     and_x_more_prefix: Și
     and_x_more_suffix: mai mult
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: Zile rămase în an
       days_passed: Zile trecute
@@ -30,18 +30,18 @@ ro:
         waning_crescent: Semilună în descreștere
     netatmo_weather_station:
       title: Meteo Netatmo
-      title_short: Netatmo
+      title_short:
       indoor_temp: Temp. interior
       indoor_temp_short: Interior
       indoor_humidity: Umiditate interior
       indoor_humidity_short: Um. int.
       outdoor_humidity: Umiditate exterior
       outdoor_humidity_short: Um. ext.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
+      co2:
+      co2_ppm:
       pressure: Presiune
       noise: Zgomot
-      min_max: Min/Max
+      min_max:
       feels: Resimțit
       rain: Ploaie
       wind: Vânt
@@ -106,13 +106,13 @@ ro:
       humidity: Umiditate
       low: Min
       high: Max
-      uv: UV
+      uv:
       right_now: Chiar acum
       today: Astăzi
       tomorrow: Mâine
       low_high_short: Min/Max
-      uv_short: UV
-      max: Max
+      uv_short:
+      max:
       tempest:
         conditions:
           clear: Senin

--- a/lib/trmnl/i18n/locales/plugin_renders/ru.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ru.yml
@@ -4,8 +4,8 @@ ru:
     and_x_more_prefix: И
     and_x_more_suffix: ещё
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: Осталось дней в этом году
       days_passed: Прошло дней
@@ -29,49 +29,49 @@ ru:
         third_quarter: Третья четверть
         waning_crescent: Убывающий полумесяц
     netatmo_weather_station:
-      title: Netatmo Weather
-      title_short: Netatmo
-      indoor_temp: Indoor Temp.
-      indoor_temp_short: Indoor
-      indoor_humidity: Indoor Humidity
-      indoor_humidity_short: Indoor Hum.
-      outdoor_humidity: Outdoor Humidity
-      outdoor_humidity_short: Out. Hum.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
-      pressure: Pressure
-      noise: Noise
-      min_max: Min/Max
-      feels: Feels
-      rain: Rain
-      wind: Wind
-      gust: Gust
-      default_station_name: Netatmo Station
-      default_outdoor_module: Outdoor Temp.
-      default_indoor_module: Indoor
-      trends_title: "%{metric} Trends"
-      trends_title_short: Trends
-      temperature_trends: Temperature Trends
-      temperature_trends_short: Temp Trends
-      outdoor_now: Outdoor Now
-      indoor_now: Indoor Now
-      now: Now
-      low_high_24h: 24h Low / High
-      average_24h: 24h Average
-      outdoor: Outdoor
-      indoor: Indoor
-      rain_gauge_not_connected: Rain gauge not connected
-      wind_gauge_not_connected: Wind gauge not connected
-      no_rain_gauge: No rain gauge
-      no_wind_gauge: No wind gauge
-      add_module_hint: Add the optional %{module} module to see this data
-      range_24h: 24h Range
+      title:
+      title_short:
+      indoor_temp:
+      indoor_temp_short:
+      indoor_humidity:
+      indoor_humidity_short:
+      outdoor_humidity:
+      outdoor_humidity_short:
+      co2:
+      co2_ppm:
+      pressure:
+      noise:
+      min_max:
+      feels:
+      rain:
+      wind:
+      gust:
+      default_station_name:
+      default_outdoor_module:
+      default_indoor_module:
+      trends_title:
+      trends_title_short:
+      temperature_trends:
+      temperature_trends_short:
+      outdoor_now:
+      indoor_now:
+      now:
+      low_high_24h:
+      average_24h:
+      outdoor:
+      indoor:
+      rain_gauge_not_connected:
+      wind_gauge_not_connected:
+      no_rain_gauge:
+      no_wind_gauge:
+      add_module_hint:
+      range_24h:
       errors:
-        missing_access_token: Missing access token. Please reconnect your Netatmo account.
-        no_station_selected: No weather station selected. Please choose a station in settings.
-        connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
-        data_retrieval_failed: Unable to retrieve weather data. Please try again later.
-        session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        missing_access_token:
+        no_station_selected:
+        connection_failed:
+        data_retrieval_failed:
+        session_expired:
     parcel:
       delivery_by: Доставка до
       empty: Нет доставок
@@ -110,25 +110,25 @@ ru:
       right_now: Прямо сейчас
       today: Сегодня
       tomorrow: Завтра
-      low_high_short: L/H
-      uv_short: UV
-      max: Max
+      low_high_short:
+      uv_short:
+      max:
       tempest:
         conditions:
-          clear: Clear
-          cloudy: Cloudy
-          foggy: Foggy
-          partly_cloudy: Partly Cloudy
-          rain_likely: Rain Likely
-          rain_possible: Rain Possible
-          snow: Snow
-          snow_possible: Snow Possible
-          thunderstorms_likely: Thunderstorms Likely
-          thunderstorms_possible: Thunderstorms Possible
-          very_light_rain: Very Light Rain
-          windy: Windy
-          wintry_mix_likely: Wintry Mix Likely
-          wintry_mix_possible: Wintry Mix Possible
+          clear:
+          cloudy:
+          foggy:
+          partly_cloudy:
+          rain_likely:
+          rain_possible:
+          snow:
+          snow_possible:
+          thunderstorms_likely:
+          thunderstorms_possible:
+          very_light_rain:
+          windy:
+          wintry_mix_likely:
+          wintry_mix_possible:
       weatherapi:
         uv:
           low: Низкий

--- a/lib/trmnl/i18n/locales/plugin_renders/sk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sk.yml
@@ -4,8 +4,8 @@ sk:
     and_x_more_prefix: A
     and_x_more_suffix: ďalšie
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: Zostávajúce dni v roku
       days_passed: Uplynuté dni
@@ -29,49 +29,49 @@ sk:
         third_quarter: Posledná štvrť
         waning_crescent: Ubúdajúci polmesiac
     netatmo_weather_station:
-      title: Netatmo Weather
-      title_short: Netatmo
-      indoor_temp: Indoor Temp.
-      indoor_temp_short: Indoor
-      indoor_humidity: Indoor Humidity
-      indoor_humidity_short: Indoor Hum.
-      outdoor_humidity: Outdoor Humidity
-      outdoor_humidity_short: Out. Hum.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
-      pressure: Pressure
-      noise: Noise
-      min_max: Min/Max
-      feels: Feels
-      rain: Rain
-      wind: Wind
-      gust: Gust
-      default_station_name: Netatmo Station
-      default_outdoor_module: Outdoor Temp.
-      default_indoor_module: Indoor
-      trends_title: "%{metric} Trends"
-      trends_title_short: Trends
-      temperature_trends: Temperature Trends
-      temperature_trends_short: Temp Trends
-      outdoor_now: Outdoor Now
-      indoor_now: Indoor Now
-      now: Now
-      low_high_24h: 24h Low / High
-      average_24h: 24h Average
-      outdoor: Outdoor
-      indoor: Indoor
-      rain_gauge_not_connected: Rain gauge not connected
-      wind_gauge_not_connected: Wind gauge not connected
-      no_rain_gauge: No rain gauge
-      no_wind_gauge: No wind gauge
-      add_module_hint: Add the optional %{module} module to see this data
-      range_24h: 24h Range
+      title:
+      title_short:
+      indoor_temp:
+      indoor_temp_short:
+      indoor_humidity:
+      indoor_humidity_short:
+      outdoor_humidity:
+      outdoor_humidity_short:
+      co2:
+      co2_ppm:
+      pressure:
+      noise:
+      min_max:
+      feels:
+      rain:
+      wind:
+      gust:
+      default_station_name:
+      default_outdoor_module:
+      default_indoor_module:
+      trends_title:
+      trends_title_short:
+      temperature_trends:
+      temperature_trends_short:
+      outdoor_now:
+      indoor_now:
+      now:
+      low_high_24h:
+      average_24h:
+      outdoor:
+      indoor:
+      rain_gauge_not_connected:
+      wind_gauge_not_connected:
+      no_rain_gauge:
+      no_wind_gauge:
+      add_module_hint:
+      range_24h:
       errors:
-        missing_access_token: Missing access token. Please reconnect your Netatmo account.
-        no_station_selected: No weather station selected. Please choose a station in settings.
-        connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
-        data_retrieval_failed: Unable to retrieve weather data. Please try again later.
-        session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        missing_access_token:
+        no_station_selected:
+        connection_failed:
+        data_retrieval_failed:
+        session_expired:
     parcel:
       delivery_by: Doručenie do
       empty: Žiadne zásielky
@@ -111,8 +111,8 @@ sk:
       today: Dnes
       tomorrow: Zajtra
       low_high_short: Min/Max
-      uv_short: UV
-      max: Max
+      uv_short:
+      max:
       tempest:
         conditions:
           clear: Jasno

--- a/lib/trmnl/i18n/locales/plugin_renders/sv.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sv.yml
@@ -1,283 +1,139 @@
 ---
 sv:
   renders:
-    and_x_more_prefix: And
-    and_x_more_suffix: more
+    and_x_more_prefix:
+    and_x_more_suffix:
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
-      title: Days Left This Year
-      days_passed: Days Passed
-      days_left: Days Left
+      title:
+      days_passed:
+      days_left:
     lunar_calendar:
-      title: Lunar Calendar
-      age: Lunar Age
-      current_phase: Current Phase
-      illumination: Moon Illumination
-      next_full_moon: Next Full Moon
-      next_new_moon: Next New Moon
-      next_phase: Next Phase
-      next_phase_short: Next
+      title:
+      age:
+      current_phase:
+      illumination:
+      next_full_moon:
+      next_new_moon:
+      next_phase:
+      next_phase_short:
       moon_phases:
-        new_moon: New Moon
-        waxing_crescent: Waxing Crescent
-        first_quarter: First Quarter
-        waxing_gibbous: Waxing Gibbous
-        full_moon: Full Moon
-        waning_gibbous: Waning Gibbous
-        third_quarter: Third Quarter
-        waning_crescent: Waning Crescent
+        new_moon:
+        waxing_crescent:
+        first_quarter:
+        waxing_gibbous:
+        full_moon:
+        waning_gibbous:
+        third_quarter:
+        waning_crescent:
     netatmo_weather_station:
-      title: Netatmo Weather
-      title_short: Netatmo
-      indoor_temp: Indoor Temp.
-      indoor_temp_short: Indoor
-      indoor_humidity: Indoor Humidity
-      indoor_humidity_short: Indoor Hum.
-      outdoor_humidity: Outdoor Humidity
-      outdoor_humidity_short: Out. Hum.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
-      pressure: Pressure
-      noise: Noise
-      min_max: Min/Max
-      feels: Feels
-      rain: Rain
-      wind: Wind
-      gust: Gust
-      default_station_name: Netatmo Station
-      default_outdoor_module: Outdoor Temp.
-      default_indoor_module: Indoor
-      trends_title: "%{metric} Trends"
-      trends_title_short: Trends
-      temperature_trends: Temperature Trends
-      temperature_trends_short: Temp Trends
-      outdoor_now: Outdoor Now
-      indoor_now: Indoor Now
-      now: Now
-      low_high_24h: 24h Low / High
-      average_24h: 24h Average
-      outdoor: Outdoor
-      indoor: Indoor
-      rain_gauge_not_connected: Rain gauge not connected
-      wind_gauge_not_connected: Wind gauge not connected
-      no_rain_gauge: No rain gauge
-      no_wind_gauge: No wind gauge
-      add_module_hint: Add the optional %{module} module to see this data
-      range_24h: 24h Range
+      title:
+      title_short:
+      indoor_temp:
+      indoor_temp_short:
+      indoor_humidity:
+      indoor_humidity_short:
+      outdoor_humidity:
+      outdoor_humidity_short:
+      co2:
+      co2_ppm:
+      pressure:
+      noise:
+      min_max:
+      feels:
+      rain:
+      wind:
+      gust:
+      default_station_name:
+      default_outdoor_module:
+      default_indoor_module:
+      trends_title:
+      trends_title_short:
+      temperature_trends:
+      temperature_trends_short:
+      outdoor_now:
+      indoor_now:
+      now:
+      low_high_24h:
+      average_24h:
+      outdoor:
+      indoor:
+      rain_gauge_not_connected:
+      wind_gauge_not_connected:
+      no_rain_gauge:
+      no_wind_gauge:
+      add_module_hint:
+      range_24h:
       errors:
-        missing_access_token: Missing access token. Please reconnect your Netatmo account.
-        no_station_selected: No weather station selected. Please choose a station in settings.
-        connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
-        data_retrieval_failed: Unable to retrieve weather data. Please try again later.
-        session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        missing_access_token:
+        no_station_selected:
+        connection_failed:
+        data_retrieval_failed:
+        session_expired:
     parcel:
-      delivery_by: Delivery by
-      empty: There are no deliveries
+      delivery_by:
+      empty:
       errors:
-        api: Parcel API error
-        http: HTTP error %{code}
-        internal: Internal error
+        api:
+        http:
+        internal:
       filter_modes:
         active:
-          one: Active Delivery
-          other: Active Deliveries
+          one:
+          other:
         recent:
-          one: Recent Delivery
-          other: Recent Deliveries
+          one:
+          other:
       status:
-        delivered: Delivered
-        delivery_exception: Delivery Exception
-        expecting_pickup: Expecting Pickup
-        failed_delivery_attempt: Failed Delivery Attempt
-        frozen: Frozen
-        in_transit: In Transit
-        information_received: Information Received
-        not_found: Not Found
-        out_for_delivery: Out For Delivery
-        unknown: Unknown
-      today: Today
-      tomorrow: Tomorrow
+        delivered:
+        delivery_exception:
+        expecting_pickup:
+        failed_delivery_attempt:
+        frozen:
+        in_transit:
+        information_received:
+        not_found:
+        out_for_delivery:
+        unknown:
+      today:
+      tomorrow:
     weather:
-      title: Weather
-      temperature: Temperature
-      feels_like: Feels Like
-      humidity: Humidity
-      low: Low
-      high: High
-      uv: UV
-      right_now: Right Now
-      today: Today
-      tomorrow: Tomorrow
-      low_high_short: L/H
-      uv_short: UV
-      max: Max
+      title:
+      temperature:
+      feels_like:
+      humidity:
+      low:
+      high:
+      uv:
+      right_now:
+      today:
+      tomorrow:
+      low_high_short:
+      uv_short:
+      max:
       tempest:
         conditions:
-          clear: Clear
-          cloudy: Cloudy
-          foggy: Foggy
-          partly_cloudy: Partly Cloudy
-          rain_likely: Rain Likely
-          rain_possible: Rain Possible
-          snow: Snow
-          snow_possible: Snow Possible
-          thunderstorms_likely: Thunderstorms Likely
-          thunderstorms_possible: Thunderstorms Possible
-          very_light_rain: Very Light Rain
-          windy: Windy
-          wintry_mix_likely: Wintry Mix Likely
-          wintry_mix_possible: Wintry Mix Possible
+          clear:
+          cloudy:
+          foggy:
+          partly_cloudy:
+          rain_likely:
+          rain_possible:
+          snow:
+          snow_possible:
+          thunderstorms_likely:
+          thunderstorms_possible:
+          very_light_rain:
+          windy:
+          wintry_mix_likely:
+          wintry_mix_possible:
       weatherapi:
         uv:
-          low: Low
-          moderate: Moderate
-          high: High
-          very_high: Very High
-          extreme: Extreme
+          low:
+          moderate:
+          high:
+          very_high:
+          extreme:
         conditions:
-        - code: 1000
-          day: Sunny
-          night: Clear
-        - code: 1003
-          day: Partly Cloudy
-          night: Partly Cloudy
-        - code: 1006
-          day: Cloudy
-          night: Cloudy
-        - code: 1009
-          day: Overcast
-          night: Overcast
-        - code: 1030
-          day: Mist
-          night: Mist
-        - code: 1063
-          day: Light Rain
-          night: Light Rain
-        - code: 1066
-          day: Light Snow
-          night: Light Snow
-        - code: 1069
-          day: Sleet
-          night: Sleet
-        - code: 1072
-          day: Freeze Drizzle
-          night: Freeze Drizzle
-        - code: 1087
-          day: Thunder
-          night: Thunder
-        - code: 1114
-          day: Blowing Snow
-          night: Blowing Snow
-        - code: 1117
-          day: Blizzard
-          night: Blizzard
-        - code: 1135
-          day: Fog
-          night: Fog
-        - code: 1147
-          day: Freezing Fog
-          night: Freezing Fog
-        - code: 1150
-          day: Light Drizzle
-          night: Light Drizzle
-        - code: 1153
-          day: Drizzle
-          night: Drizzle
-        - code: 1168
-          day: Freeze Drizzle
-          night: Freeze Drizzle
-        - code: 1171
-          day: Heavy Freeze
-          night: Heavy Freeze
-        - code: 1180
-          day: Light Rain
-          night: Light Rain
-        - code: 1183
-          day: Light Rain
-          night: Light Rain
-        - code: 1186
-          day: Moderate Rain
-          night: Moderate Rain
-        - code: 1189
-          day: Moderate Rain
-          night: Moderate Rain
-        - code: 1192
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1195
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1198
-          day: Light Freeze
-          night: Light Freeze
-        - code: 1201
-          day: Heavy Freeze
-          night: Heavy Freeze
-        - code: 1204
-          day: Light Sleet
-          night: Light Sleet
-        - code: 1207
-          day: Heavy Sleet
-          night: Heavy Sleet
-        - code: 1210
-          day: Light Snow
-          night: Light Snow
-        - code: 1213
-          day: Light Snow
-          night: Light Snow
-        - code: 1216
-          day: Moderate Snow
-          night: Moderate Snow
-        - code: 1219
-          day: Moderate Snow
-          night: Moderate Snow
-        - code: 1222
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1225
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1237
-          day: Ice Pellets
-          night: Ice Pellets
-        - code: 1240
-          day: Light Rain
-          night: Light Rain
-        - code: 1243
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1246
-          day: Torrential Rain
-          night: Torrential Rain
-        - code: 1249
-          day: Light Sleet
-          night: Light Sleet
-        - code: 1252
-          day: Heavy Sleet
-          night: Heavy Sleet
-        - code: 1255
-          day: Light Snow
-          night: Light Snow
-        - code: 1258
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1261
-          day: Light Ice
-          night: Light Ice
-        - code: 1264
-          day: Heavy Ice
-          night: Heavy Ice
-        - code: 1273
-          day: Thunder & Rain
-          night: Thunder & Rain
-        - code: 1276
-          day: Thunder & Rain
-          night: Thunder & Rain
-        - code: 1279
-          day: Thunder & Snow
-          night: Thunder & Snow
-        - code: 1282
-          day: Thunder & Snow
-          night: Thunder & Snow

--- a/lib/trmnl/i18n/locales/plugin_renders/uk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/uk.yml
@@ -1,283 +1,139 @@
 ---
 uk:
   renders:
-    and_x_more_prefix: And
-    and_x_more_suffix: more
+    and_x_more_prefix:
+    and_x_more_suffix:
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
-      title: Days Left This Year
-      days_passed: Days Passed
-      days_left: Days Left
+      title:
+      days_passed:
+      days_left:
     lunar_calendar:
-      title: Lunar Calendar
-      age: Lunar Age
-      current_phase: Current Phase
-      illumination: Moon Illumination
-      next_full_moon: Next Full Moon
-      next_new_moon: Next New Moon
-      next_phase: Next Phase
-      next_phase_short: Next
+      title:
+      age:
+      current_phase:
+      illumination:
+      next_full_moon:
+      next_new_moon:
+      next_phase:
+      next_phase_short:
       moon_phases:
-        new_moon: New Moon
-        waxing_crescent: Waxing Crescent
-        first_quarter: First Quarter
-        waxing_gibbous: Waxing Gibbous
-        full_moon: Full Moon
-        waning_gibbous: Waning Gibbous
-        third_quarter: Third Quarter
-        waning_crescent: Waning Crescent
+        new_moon:
+        waxing_crescent:
+        first_quarter:
+        waxing_gibbous:
+        full_moon:
+        waning_gibbous:
+        third_quarter:
+        waning_crescent:
     netatmo_weather_station:
-      title: Netatmo Weather
-      title_short: Netatmo
-      indoor_temp: Indoor Temp.
-      indoor_temp_short: Indoor
-      indoor_humidity: Indoor Humidity
-      indoor_humidity_short: Indoor Hum.
-      outdoor_humidity: Outdoor Humidity
-      outdoor_humidity_short: Out. Hum.
-      co2: CO₂
-      co2_ppm: CO₂ ppm
-      pressure: Pressure
-      noise: Noise
-      min_max: Min/Max
-      feels: Feels
-      rain: Rain
-      wind: Wind
-      gust: Gust
-      default_station_name: Netatmo Station
-      default_outdoor_module: Outdoor Temp.
-      default_indoor_module: Indoor
-      trends_title: "%{metric} Trends"
-      trends_title_short: Trends
-      temperature_trends: Temperature Trends
-      temperature_trends_short: Temp Trends
-      outdoor_now: Outdoor Now
-      indoor_now: Indoor Now
-      now: Now
-      low_high_24h: 24h Low / High
-      average_24h: 24h Average
-      outdoor: Outdoor
-      indoor: Indoor
-      rain_gauge_not_connected: Rain gauge not connected
-      wind_gauge_not_connected: Wind gauge not connected
-      no_rain_gauge: No rain gauge
-      no_wind_gauge: No wind gauge
-      add_module_hint: Add the optional %{module} module to see this data
-      range_24h: 24h Range
+      title:
+      title_short:
+      indoor_temp:
+      indoor_temp_short:
+      indoor_humidity:
+      indoor_humidity_short:
+      outdoor_humidity:
+      outdoor_humidity_short:
+      co2:
+      co2_ppm:
+      pressure:
+      noise:
+      min_max:
+      feels:
+      rain:
+      wind:
+      gust:
+      default_station_name:
+      default_outdoor_module:
+      default_indoor_module:
+      trends_title:
+      trends_title_short:
+      temperature_trends:
+      temperature_trends_short:
+      outdoor_now:
+      indoor_now:
+      now:
+      low_high_24h:
+      average_24h:
+      outdoor:
+      indoor:
+      rain_gauge_not_connected:
+      wind_gauge_not_connected:
+      no_rain_gauge:
+      no_wind_gauge:
+      add_module_hint:
+      range_24h:
       errors:
-        missing_access_token: Missing access token. Please reconnect your Netatmo account.
-        no_station_selected: No weather station selected. Please choose a station in settings.
-        connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
-        data_retrieval_failed: Unable to retrieve weather data. Please try again later.
-        session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        missing_access_token:
+        no_station_selected:
+        connection_failed:
+        data_retrieval_failed:
+        session_expired:
     parcel:
-      delivery_by: Delivery by
-      empty: There are no deliveries
+      delivery_by:
+      empty:
       errors:
-        api: Parcel API error
-        http: HTTP error %{code}
-        internal: Internal error
+        api:
+        http:
+        internal:
       filter_modes:
         active:
-          one: Active Delivery
-          other: Active Deliveries
+          one:
+          other:
         recent:
-          one: Recent Delivery
-          other: Recent Deliveries
+          one:
+          other:
       status:
-        delivered: Delivered
-        delivery_exception: Delivery Exception
-        expecting_pickup: Expecting Pickup
-        failed_delivery_attempt: Failed Delivery Attempt
-        frozen: Frozen
-        in_transit: In Transit
-        information_received: Information Received
-        not_found: Not Found
-        out_for_delivery: Out For Delivery
-        unknown: Unknown
-      today: Today
-      tomorrow: Tomorrow
+        delivered:
+        delivery_exception:
+        expecting_pickup:
+        failed_delivery_attempt:
+        frozen:
+        in_transit:
+        information_received:
+        not_found:
+        out_for_delivery:
+        unknown:
+      today:
+      tomorrow:
     weather:
-      title: Weather
-      temperature: Temperature
-      feels_like: Feels Like
-      humidity: Humidity
-      low: Low
-      high: High
-      uv: UV
-      right_now: Right Now
-      today: Today
-      tomorrow: Tomorrow
-      low_high_short: L/H
-      uv_short: UV
-      max: Max
+      title:
+      temperature:
+      feels_like:
+      humidity:
+      low:
+      high:
+      uv:
+      right_now:
+      today:
+      tomorrow:
+      low_high_short:
+      uv_short:
+      max:
       tempest:
         conditions:
-          clear: Clear
-          cloudy: Cloudy
-          foggy: Foggy
-          partly_cloudy: Partly Cloudy
-          rain_likely: Rain Likely
-          rain_possible: Rain Possible
-          snow: Snow
-          snow_possible: Snow Possible
-          thunderstorms_likely: Thunderstorms Likely
-          thunderstorms_possible: Thunderstorms Possible
-          very_light_rain: Very Light Rain
-          windy: Windy
-          wintry_mix_likely: Wintry Mix Likely
-          wintry_mix_possible: Wintry Mix Possible
+          clear:
+          cloudy:
+          foggy:
+          partly_cloudy:
+          rain_likely:
+          rain_possible:
+          snow:
+          snow_possible:
+          thunderstorms_likely:
+          thunderstorms_possible:
+          very_light_rain:
+          windy:
+          wintry_mix_likely:
+          wintry_mix_possible:
       weatherapi:
         uv:
-          low: Low
-          moderate: Moderate
-          high: High
-          very_high: Very High
-          extreme: Extreme
+          low:
+          moderate:
+          high:
+          very_high:
+          extreme:
         conditions:
-        - code: 1000
-          day: Sunny
-          night: Clear
-        - code: 1003
-          day: Partly Cloudy
-          night: Partly Cloudy
-        - code: 1006
-          day: Cloudy
-          night: Cloudy
-        - code: 1009
-          day: Overcast
-          night: Overcast
-        - code: 1030
-          day: Mist
-          night: Mist
-        - code: 1063
-          day: Light Rain
-          night: Light Rain
-        - code: 1066
-          day: Light Snow
-          night: Light Snow
-        - code: 1069
-          day: Sleet
-          night: Sleet
-        - code: 1072
-          day: Freeze Drizzle
-          night: Freeze Drizzle
-        - code: 1087
-          day: Thunder
-          night: Thunder
-        - code: 1114
-          day: Blowing Snow
-          night: Blowing Snow
-        - code: 1117
-          day: Blizzard
-          night: Blizzard
-        - code: 1135
-          day: Fog
-          night: Fog
-        - code: 1147
-          day: Freezing Fog
-          night: Freezing Fog
-        - code: 1150
-          day: Light Drizzle
-          night: Light Drizzle
-        - code: 1153
-          day: Drizzle
-          night: Drizzle
-        - code: 1168
-          day: Freeze Drizzle
-          night: Freeze Drizzle
-        - code: 1171
-          day: Heavy Freeze
-          night: Heavy Freeze
-        - code: 1180
-          day: Light Rain
-          night: Light Rain
-        - code: 1183
-          day: Light Rain
-          night: Light Rain
-        - code: 1186
-          day: Moderate Rain
-          night: Moderate Rain
-        - code: 1189
-          day: Moderate Rain
-          night: Moderate Rain
-        - code: 1192
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1195
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1198
-          day: Light Freeze
-          night: Light Freeze
-        - code: 1201
-          day: Heavy Freeze
-          night: Heavy Freeze
-        - code: 1204
-          day: Light Sleet
-          night: Light Sleet
-        - code: 1207
-          day: Heavy Sleet
-          night: Heavy Sleet
-        - code: 1210
-          day: Light Snow
-          night: Light Snow
-        - code: 1213
-          day: Light Snow
-          night: Light Snow
-        - code: 1216
-          day: Moderate Snow
-          night: Moderate Snow
-        - code: 1219
-          day: Moderate Snow
-          night: Moderate Snow
-        - code: 1222
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1225
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1237
-          day: Ice Pellets
-          night: Ice Pellets
-        - code: 1240
-          day: Light Rain
-          night: Light Rain
-        - code: 1243
-          day: Heavy Rain
-          night: Heavy Rain
-        - code: 1246
-          day: Torrential Rain
-          night: Torrential Rain
-        - code: 1249
-          day: Light Sleet
-          night: Light Sleet
-        - code: 1252
-          day: Heavy Sleet
-          night: Heavy Sleet
-        - code: 1255
-          day: Light Snow
-          night: Light Snow
-        - code: 1258
-          day: Heavy Snow
-          night: Heavy Snow
-        - code: 1261
-          day: Light Ice
-          night: Light Ice
-        - code: 1264
-          day: Heavy Ice
-          night: Heavy Ice
-        - code: 1273
-          day: Thunder & Rain
-          night: Thunder & Rain
-        - code: 1276
-          day: Thunder & Rain
-          night: Thunder & Rain
-        - code: 1279
-          day: Thunder & Snow
-          night: Thunder & Snow
-        - code: 1282
-          day: Thunder & Snow
-          night: Thunder & Snow

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
@@ -4,8 +4,8 @@ zh-CN:
     and_x_more_prefix: 及其他
     and_x_more_suffix: 项
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: 今年还剩多少天
       days_passed: 已过天数
@@ -30,15 +30,15 @@ zh-CN:
         waning_crescent: 残月
     netatmo_weather_station:
       title: Netatmo 天气
-      title_short: Netatmo
+      title_short:
       indoor_temp: 室内温度
       indoor_temp_short: 室内
       indoor_humidity: 室内湿度
       indoor_humidity_short: 室内湿度
       outdoor_humidity: 室外湿度
       outdoor_humidity_short: 室外湿度
-      co2: CO₂
-      co2_ppm: CO₂ ppm
+      co2:
+      co2_ppm:
       pressure: 气压
       noise: 噪音
       min_max: 最低/最高
@@ -110,8 +110,8 @@ zh-CN:
       right_now: 现在
       today: 今天
       tomorrow: 明天
-      low_high_short: L/H
-      uv_short: UV
+      low_high_short:
+      uv_short:
       max: 最高
       tempest:
         conditions:

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
@@ -4,8 +4,8 @@ zh-HK:
     and_x_more_prefix: 還有
     and_x_more_suffix: 個
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events:
+      no_events_today:
     days_left_year:
       title: 今年剩餘日數
       days_passed: 經過日數
@@ -30,7 +30,7 @@ zh-HK:
         waning_crescent: 殘月
     netatmo_weather_station:
       title: Netatmo天氣
-      title_short: Netatmo
+      title_short:
       indoor_temp: 室內氣溫
       indoor_temp_short: 室內
       indoor_humidity: 室內濕度

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -1,25 +1,25 @@
 ---
 da:
   locale_name: Dansk
-  about: About
-  actions: Actions
+  about:
+  actions:
   add: Tilføj
   add_new: Tilføj ny
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: Jeg har allerede en konto
-  are_you_sure: Are you sure?
+  are_you_sure:
   back: Tilbage
   back_to_all_blog_posts: Tilbage til alle indlæg
-  blog: Blog
-  brand: Brand
+  blog:
+  brand:
   buy_now: Køb nu
   cancel: Annuller
   change_password: Skift adgangskode
   charge_level: Opladningsniveau
   charged: Opladet
   charging: Oplader
-  claim_plus_trial: Claim 6 Months Free
+  claim_plus_trial:
   close: Luk
   confirm_change_password: Bekræft ændring af adgangskode
   confirm_password: Bekræft ny adgangskode
@@ -31,11 +31,11 @@ da:
   current_device: Nuværende enhed
   days: dage
   delete: Slet
-  developers: Developers
+  developers:
   developer_edition_required: Udviklerudgave kræves for at aktivere denne funktion.
   device_id: Enheds-ID
   device: Enhed
-  discard: Discard
+  discard:
   edit: Rediger
   email_address: Mailadresse
   export: Eksporter
@@ -43,9 +43,9 @@ da:
   first_name: Fornavn
   forgot_password: Jeg har glemt min adgangskode
   forgot_password_title: Her går vi igen
-  friendly_id: Friendly ID
+  friendly_id:
   get_started: Lad os få dig i gang!
-  hidden: hidden
+  hidden:
   identify: Identificer
   import: Importer
   import_new: Importer ny
@@ -65,30 +65,30 @@ da:
   password: Adgangskode
   please_wait: Vent venligst...
   plugin_not_found: Plugin ikke fundet
-  preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
+  preview:
+  privacy:
+  refresh_rate:
   refresh_rates_hint: Lær hvordan opdateringshastigheder fungerer __her__.
   reset_password: Nulstil min adgangskode
-  reset_to_defaults: Reset to defaults
-  required: Required
+  reset_to_defaults:
+  required:
   save: Gem
-  shown: shown
+  shown:
   section: Sektion
   settings: Indstillinger
   sign_in: Log ind
   sign_up: Tilmeld
   something_went_wrong: Noget gik galt
-  status: Status
+  status:
   subscribe: Abonner
-  help_center: Support
-  terms: Terms
-  unsaved_changes: You have unsaved changes
+  help_center:
+  terms:
+  unsaved_changes:
   update: Opdater
   view: Vis
-  collaboration_request: Wanna collaborate?
-  collaboration_request_hint: Partnerships, group sales, special projects, your call.
-  collaboration_request_cta: Let's talk
+  collaboration_request:
+  collaboration_request_hint:
+  collaboration_request_cta:
   welcome: Velkommen
   time:
     formats:
@@ -145,7 +145,7 @@ da:
       api_key: API-nøgle
       beta_features: Beta-funktioner
       beta_features_hint: Prøv nye funktioner her. Muligheder kan forsvinde når som helst.
-      discord_community: Discord Community
+      discord_community:
       discord_username: Hvad er dit Discord-brugernavn?
       discord_username_hint: Kan bruges til support, attribution på publicerede opskrifter osv.
       email_address: Mailadresse
@@ -159,21 +159,21 @@ da:
       email_address_hint: Bruges til at logge ind på TRMNL og modtage systembeskeder.
       first_name_hint: Vi bruger dit navn til at gøre TRMNL-grænsefladen mere personlig.
       last_name_hint: Vi bruger dit navn til at gøre TRMNL-grænsefladen mere personlig.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: Bruges til at beskytte din TRMNL-konto.
       enable_2fa: Aktivér 2FA?
       enable_2fa_hint: __Klik her__ for at aktivere OTP.
       disable_2fa: Deaktiver 2FA
       disable_2fa_hint: Indtast gyldig OTP og nuværende adgangskode ovenfor for at deaktivere denne funktion.
       plus_subscription: TRMNL+ Abonnement
-      plus_subscription_trial_until: You're on a free trial until %{plus_trial_end_at}.
+      plus_subscription_trial_until:
       plus_subscription_hint: Lås op for hurtigere opdateringshastigheder og højere grænser. __Læs mere__.
       plus_subscription_modify: Vil du opdatere betalingsmetoden eller annullere?
-      session: Session
+      session:
       session_hint: Du er logget ind som %{user}
       show_title_bar: Vis titelbjælke
       show_title_bar_hint: Hvis deaktiveret, vil native (ikke globale) og tredjeparts-plugins være mere minimalistiske.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
+      theme_hint:
       time_zone: Tidszone
       time_zone_hint: Bestemmer opdateringshastigheder og enhedens sovetid.
       locale: Lokalitet
@@ -184,7 +184,7 @@ da:
       success: API-nøgle blev regenereret med succes
   dashboard:
     index:
-      title: Dashboard
+      title:
       last_7_days: Sidste 7 dage
       last_30_days: Sidste 30 dage
       last_90_days: Sidste 90 dage
@@ -202,7 +202,7 @@ da:
       cta: Rediger playliste
       pieces_of_content_displayed: Indholdselementer vist
     plugins:
-      title: Plugins
+      title:
       cta: Gå til Plugins
       connected: Forbundet
       new_and_popular: Nye og populære
@@ -213,10 +213,10 @@ da:
       title: Tid sparet
       cta: Læs om
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: Godmorgen
       afternoon_salutation: God eftermiddag
@@ -226,14 +226,14 @@ da:
       accepts_beta_firmware: Firmware Tidlig Udgivelse
       accepts_beta_firmware_hint: Slå til for at få de nyeste firmwareforbedringer før andre brugere.
       back_to_devices: Tilbage til enheder
-      battery_and_sleep: Battery & Sleep
+      battery_and_sleep:
       battery_consumption: Batteriforbrug
       battery_consumption_hint: Spar strøm og forlæng batterilevetiden ved at aktivere dvaletilstand.
       battery_learn_more: Læs mere om opladning af batteri __her__.
-      battery_refresh: Refresh
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      battery_refresh:
+      click:
+      click_action:
+      controls:
       developer_perks: Udviklerfordele
       developer_perks_hint: Nogle muligheder kræver __Udviklerudgave-tilføjelse__.
       device_credentials: Enhedsoplysninger
@@ -243,23 +243,23 @@ da:
       device_model: Enhedsmodel
       device_model_hint: Din hardwaremodel
       device_model_switch_warning: Dette er en risikabel handling, læs mere __her__
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
-      display_calibration: Display Calibration
-      display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
-      display_calibration_pixel_ratio: Pixel Ratio
-      display_calibration_pixel_ratio_hint: 'Image zoom level (0.5–3.0). Default:'
-      display_calibration_ui_scale: UI Scale
-      display_calibration_ui_scale_hint: 'Text and element sizes (0.5–2.0). Default:'
+      device_info:
+      current_firmware:
+      last_ping:
+      unknown:
+      never:
+      display_calibration:
+      display_calibration_hint:
+      display_calibration_pixel_ratio:
+      display_calibration_pixel_ratio_hint:
+      display_calibration_ui_scale:
+      display_calibration_ui_scale_hint:
       edit_device: Rediger enhed
-      firmware: Firmware
-      firmware_updates_enabled: Updates enabled
-      firmware_updates_disabled: Updates disabled
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
+      firmware:
+      firmware_updates_enabled:
+      firmware_updates_disabled:
+      font_family:
+      font_family_hint:
       guest_mode: Gæstetilstand
       guest_mode_hint: Vælg hvad der skal vises (og i hvor lang tid), når gæstetilstand er aktiveret.
       guest_mode_item_placeholder: Vælg et element
@@ -269,21 +269,21 @@ da:
       identify_device_hint: Klik på knappen nedenfor for at generere en skærm på denne enhed, der hjælper med identifikation.
       logs: Logfiler
       logs_hint: Fejlret din enhed og plugins med en live feed af rå logfiler.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
       low_battery_email_notification: Lavt batteri e-mail notifikation
       low_battery_email_notification_hint: Få besked via e-mail, når din enheds batteri er lavt.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: Spejl
       mirror_device: Spejl en anden enhed
       mirror_device_hint: Angiv et (delbart) enheds-ID for at spejle dens playliste. Din playliste vises stadig.
-      mirror_disabled: Mirroring disabled
-      mirror_enabled: Mirroring
+      mirror_disabled:
+      mirror_enabled:
       mirror_stop: Stop spejling
       mirror_sync: Synkroniser skærme
       ota_enabled: OTA-opdateringer aktiveret
@@ -292,12 +292,12 @@ da:
       maximum_compatibility: Aktivér maksimal kompatibilitet
       maximum_compatibility_hint: Løser visningsproblemer forårsaget af visse ePaper driverchips. Deaktiverer hurtig opdatering. Firmware 1.6.0+ kræves.
       color_and_rotation: Farve og rotation
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Skærmrotation
       screen_rotation_not_supported: Skærmrotation er ikke understøttet på din enhed.
-      palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
-      presentation: Presentation
+      palette:
+      palette_hint:
+      presentation:
       sleep_mode: Dvaletilstand
       sleep_mode_hint: Juster opdateringshastigheden for at optimere fokus og batterilevetid.
       sleep_screen: Dvaleskærm
@@ -308,16 +308,16 @@ da:
       special_function_learn_more: Læs mere om specialfunktioner __her__.
       temperature_profile: Temperaturprofil
       temperature_profile_hint: Ændr ikke medmindre instrueret. Til displays med udvaskede billeder.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
-      tidbyt_credentials: Tidbyt Credentials
-      tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
-      tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
-      tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
+      touchbar_mode:
+      touchbar_mode_hint:
+      tidbyt_credentials:
+      tidbyt_credentials_hint:
+      tidbyt_api_key:
+      tidbyt_credentials_invalid:
+      tidbyt_device_id:
+      tidbyt_device_api_key:
       unlink: Fjern tilknytning
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm:
       unlink_device: Fjern tilknytning til enhed
       unlink_device_hint: At fjerne tilknytning gør det sikkert at sælge eller give TRMNL-enheden til en anden.
       unlink_device_learn_more: Følg den fulde guide __her__.
@@ -331,41 +331,41 @@ da:
         warning_2: Jeg forstår, at dette er en <strong>farlig</strong> handling og kan beskadige min enhed.
         cta: Opgrader til TRMNL OG (2-bit)
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Enheder
       tagline: Dine TRMNL-enheder
       add_device_modal_title: Tilføj en ny enhed
       add_first_device: Start med at tilføje din første enhed!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: Tilføj en ny enhed
       description: Indtast dit enheds-ID for at tilføje en ny TRMNL-enhed til din konto.
@@ -377,8 +377,8 @@ da:
       error: Fejl ved frakobling af enhed
       success: Enhed frakoblet med succes
     external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
+      error:
+      success:
     identify:
       error: Fejl ved opdatering af enhed
       success: Enhedsidentifikation anmodet
@@ -391,32 +391,32 @@ da:
     switch:
       error: Fejl ved skift af enhed
       success: Enhed skiftet med succes
-      title: Switch to device
+      title:
     update:
       error: Fejl ved opdatering af enhed
       success: "%{device} enhedsindstillinger opdateret med succes"
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: For mange forsøg, vent venligst og prøv igen
     invoice_not_found: Faktura ikke fundet
@@ -424,21 +424,21 @@ da:
     index:
       title: Logfiler
       all: Alle
-      bulk_destroy: Bulk Destroy
-      dump: Dump
-      id: ID
-      private_plugins: Private Plugins
+      bulk_destroy:
+      dump:
+      id:
+      private_plugins:
       source: Kilde
       time: Tid
   markups:
     console_logs:
-      js_logs: JS Logs
+      js_logs:
     form:
       back_to_plugin_settings: Tilbage til plugin-indstillinger
       design_system: Udnyt vores indbyggede designsystem
       design_system_docs: Designsystem dokumentation
       dirty_confirm: Du har ikke-gemte ændringer. Er du sikker på, at du vil forlade siden?
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: Rediger markup
       edit_markup_for_plugin: Rediger markup for %{plugin_setting_name}
       edit_markup_please_save_first: Gem venligst før redigering af markup
@@ -463,7 +463,7 @@ da:
       no_variables_detected: Ingen variabler registreret.
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: 2FA deaktiveret
@@ -512,18 +512,18 @@ da:
       remove_from_playlist: Fjern fra playliste
       hide_playlist: Skjul dette element
       show_playlist: Vis dette element
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default:
+        external:
+        global:
+        mashup:
+        readonly:
     create:
       error: Fejl ved opdatering af playliste
       success: Playliste opdateret
@@ -542,11 +542,11 @@ da:
       success: Playlistens rækkefølge opdateret
   plugins:
     index:
-      title: Plugins
+      title:
       tagline: Hvad vil du sætte på din TRMNL?
       available: Tilgængelig
       connected: Forbundet
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: Opskrifter
       recipes_hint: Private plugins fra fællesskabsmedlemmer, som kan installeres med 1 klik. __Læs mere__.
     search:
@@ -578,7 +578,7 @@ da:
       knowledge_base_url: Vidensbase-URL
       management_url: Plugin-administrations-URL
       management_url_hint: Læs mere om administrationsflowet __her__.
-      markup_url: Plugin Markup URL
+      markup_url:
       markup_url_hint: Læs mere om skærmgenerering __her__.
       no_screen_padding: Ingen skærmpadding
       no_screen_padding_hint: Fjerner yderste padding i fuldskærmsvisning.
@@ -594,29 +594,29 @@ da:
       one: Forbindelse
       other: Forbindelser
     forks:
-      one: Fork
-      other: Forks
-    forked: Recipe forked
+      one:
+      other:
+    forked:
     new:
       error: Opskrift ikke fundet
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: Aktiv
     copy_are_you_sure: Er du sikker på, at du vil kopiere denne indstilling?
     delete_are_you_sure: Er du sikker på, at du vil slette denne indstilling?
     delete: Dette vil fuldstændigt fjerne pluginets indstillinger. For blot at skjule pluginet fra din enhed, skal du slette det fra din playliste i stedet.
     inactive: Inaktiv
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: Ingen plugin-indstillinger fundet.
-    not_supported: Not supported on current device
+    not_supported:
     refreshing_now_please_wait: Opdaterer nu, genindlæs siden om et par sekunder.
     reset_credentials: "%{plugin_name} konto nulstillet med succes"
     form:
       active_hint: Vis eller skjul denne plugin-instans på din enhed
       advanced_settings: Avancerede indstillinger
-      back_to_playlist: Back to Playlist
+      back_to_playlist:
       back_to_plugin: Tilbage til %{plugin}
       back_to_plugins: Tilbage til Plugins
       connect_with: Forbind med %{plugin}
@@ -631,66 +631,66 @@ da:
       force_refresh_hint: Denne funktion er tiltænkt testbrug - misbrug den venligst ikke.
       force_refresh_click_here: Klik her
       force_refresh_click_here_hint: for at generere en ny skærm med det samme
-      force_refresh_not_possible: This plugin cannot be force-refreshed because the TRMNL server does not perform image processing. Learn how to test your instance __here__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      force_refresh_not_possible:
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: Læs om dette plugin i vores vidensbase
       learn_more_fork: Dette plugin blev forgrenet fra en opskrift.
       learn_more_fork_original: Se original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long:
+      learn_more_native_short:
       learn_more_recipe_author: Brug for hjælp? Kontakt %{recipe_author} på Discord.
       learn_more_recipe_long: Dette plugin er en community-opskrift og vedligeholdes ikke af TRMNL.
       learn_more_recipe_short: 'Bemærk: dette plugin er en opskrift.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long:
+      learn_more_third_party_short:
       linked_account: Tilknyttet konto
       linked_account_success: Succesfuldt tilknyttet med %{plugin_name}
       link_oauth: Link konto
       link_oauth_hint: Følg den sikre autorisationsproces leveret af %{plugin}
-      mirrored: Mirrored
+      mirrored:
       multiple_instances_hint: Dette plugin understøtter flere instanser.
       name: Navn
       name_hint: Giv det et navn til nem reference
-      parse: Parse
+      parse:
       parse_save_first: Parse (gem plugin først)
-      parsed: Parsed
-      plugin_uuid: Plugin UUID
+      parsed:
+      plugin_uuid:
       plugin_uuid_hint: Bruges til Webhook API-anmodninger.
       preview: Forhåndsvisning - din enhed vil viser faktiske data
       recipe_cta_heading_published: Dette plugin er en opskrift
-      recipe_cta_heading_unlisted: This plugin is unlisted
+      recipe_cta_heading_unlisted:
       recipe_cta_heading_in_review: Opskrift under gennemgang
       recipe_cta_heading_not_published: Udgiv som opskrift?
       recipe_cta_body_published: Ændringer vil blive afspejlet på eksisterende og fremtidige installationer/forks.
       recipe_cta_body_in_review: Dette plugin er sendt til vores team. Vent venligst.
       recipe_cta_body_not_published: Indsend dette plugin, så andre kan installere det. __Læs mere__.
       recipe_cta_confirm: Er du sikker? Vores team vil gennemgå det og vende tilbage inden for få dage. Du kan fortsætte med at foretage ændringer.
-      recipe_mirrored: This screen is mirrored from the recipe.
-      recipe_visibility_title: How would you like to publish?
-      recipe_visibility_edit_title: Edit Submission
-      recipe_visibility_public: Public
-      recipe_visibility_public_hint: Anyone can find and install.
-      recipe_visibility_private: Private
-      recipe_visibility_private_hint: Breaks external installs.
-      recipe_visibility_unlisted: Unlisted
-      recipe_visibility_unlisted_hint: Anyone with the link can install.
+      recipe_mirrored:
+      recipe_visibility_title:
+      recipe_visibility_edit_title:
+      recipe_visibility_public:
+      recipe_visibility_public_hint:
+      recipe_visibility_private:
+      recipe_visibility_private_hint:
+      recipe_visibility_unlisted:
+      recipe_visibility_unlisted_hint:
       refresh_rate: Opdateringshastighed
       refresh_rate_hint: Definer hvor ofte denne plugin-instans henter friske data
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
-      refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
+      refresh_rate_jit_hint:
+      refresh_rate_not_configurable:
       refreshed: Opdateret
       remove_plugin: Fjern plugin
       remove_plugin_hint: Fjernelse af et plugin vil også fjerne det fra din playliste
       synced: Synkroniseret
       refresh_paused: Opdatering sat på pause
       refresh_paused_hint: Auto-opdatering er sat på pause. Tilføj til en playliste for at starte igen.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
+      refresh_paused_hidden_hint:
       refresh_paused_mashup: Opdaterer Mashups
       refresh_paused_mashup_hint: Auto-opdatering af fuldskærmsvisning er på pause. Mashups opdaterer.
       refresh_stopped: Auto-opdatering stoppet. Ret pluginfejl for at fortsætte.
-      view_recipe: View Recipe
+      view_recipe:
       visit_docs: Besøg dokumentation
     import:
       archive_too_large: ZIP-fil er for stor (%{max_mb} MB maksimum)
@@ -725,7 +725,7 @@ da:
       some_schedule: Vis kun denne skærm under…
       to: til
       copy_prompt: Kopiér tidsplan fra…
-      no_days_error: Please select at least one day.
+      no_days_error:
   upgrade:
     index:
       title: 'Opgradering af enhed:'

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -5,13 +5,13 @@ de-AT:
   actions: Aktionen
   add: Hinzufügen
   add_new: Neu hinzufügen
-  ai_assistant: Agent
+  ai_assistant:
   ai_assistant_hint: Aktiviere den Agent für die Markup-Bearbeitung im Plugin-Editor.
   already_have_account: Ich besitze bereits ein Konto
   are_you_sure: Bist du sicher?
   back: Zurück
   back_to_all_blog_posts: Zurück zu allen Posts
-  blog: Blog
+  blog:
   brand: Marke
   buy_now: Jetzt kaufen
   cancel: Abbrechen
@@ -43,7 +43,7 @@ de-AT:
   first_name: Vorname
   forgot_password: Passwort vergessen
   forgot_password_title: Neues Passwort vergeben
-  friendly_id: Friendly ID
+  friendly_id:
   get_started: Lass uns loslegen!
   hidden: versteckt
   identify: Identifizieren
@@ -79,7 +79,7 @@ de-AT:
   sign_in: Anmelden
   sign_up: Registrieren
   something_went_wrong: Etwas ist schiefgegangen
-  status: Status
+  status:
   subscribe: Abonnieren
   help_center: Hilfe
   terms: AGB
@@ -97,7 +97,7 @@ de-AT:
   datetime:
     relative:
       past: vor %{time}
-      future: in %{time}
+      future:
       distance_in_words:
         half_a_minute: einer halben Minute
         less_than_x_seconds:
@@ -207,7 +207,7 @@ de-AT:
       connected: Verbunden
       new_and_popular: Neu und beliebt
     shop:
-      title: Shop
+      title:
       need_another: Brauchst du noch einen TRMNL?
     time_saved:
       title: Eingesparte Zeit
@@ -255,7 +255,7 @@ de-AT:
       display_calibration_ui_scale: UI-Skalierung
       display_calibration_ui_scale_hint: 'Text- und Elementgröße (0,5–2,0). Standard:'
       edit_device: Gerät bearbeiten
-      firmware: Firmware
+      firmware:
       firmware_updates_enabled: Updates aktiviert
       firmware_updates_disabled: Updates deaktiviert
       font_family: Schriftfamilie
@@ -292,7 +292,7 @@ de-AT:
       maximum_compatibility: Maximale Kompatibilität aktivieren
       maximum_compatibility_hint: Behebt Anzeigefehler aufgrund bestimmter ePaper-Treiber-Chips. Deaktiviert schnelles Rendern. Benötigt Firmware 1.6.0+.
       color_and_rotation: Farbe & Rotation
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Bildschirmrotation
       screen_rotation_not_supported: Bildschirmrotation ist derzeit nicht auf deinem Gerät unterstützt.
       palette: Farbpalette
@@ -312,7 +312,7 @@ de-AT:
       touchbar_mode_hint: Auf welche Art von Gesten soll dein Gerät reagieren?
       tidbyt_credentials: Tidbyt-Anmeldedaten
       tidbyt_credentials_hint: Gib hier die API-Zugangsdaten deines Tidbyt-Geräts ein (Einstellungen → Entwickler → API-Schlüssel in der Tidbyt-App).
-      tidbyt_api_key: Tidbyt API Key
+      tidbyt_api_key:
       tidbyt_credentials_invalid: Ungültige Tidbyt-API-Zugangsdaten. Bitte prüfen und erneut versuchen.
       tidbyt_device_id: Geräte-ID
       tidbyt_device_api_key: API-Schlüssel
@@ -331,22 +331,22 @@ de-AT:
         warning_2: Mir ist bewusst, dass dies ein <strong>gefährlicher</strong> Vorgang ist, der mein Gerät dauerhaft beschädigen kann.
         cta: Auf TRMNL OG (2-bit) upgraden
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Geräte
       tagline: Deine TRMNL-Geräte
@@ -425,7 +425,7 @@ de-AT:
       all: Alle
       bulk_destroy: Stapel-Löschen
       dump: Ausgabe
-      id: ID
+      id:
       private_plugins: Private Erweiterungen
       source: Quelle
       time: Zeit
@@ -437,7 +437,7 @@ de-AT:
       design_system: Nutze unser natives Design-System
       design_system_docs: Dokumentation anzeigen
       dirty_confirm: Es gibt ungespeicherte Änderungen. Möchtest Du diese Seite wirklich verlassen?
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: Markup bearbeiten
       edit_markup_for_plugin: Markup von %{plugin_setting_name} bearbeiten
       edit_markup_please_save_first: Bitte vor dem Bearbeiten des Markups speichern
@@ -513,7 +513,7 @@ de-AT:
       show_playlist: Eintrag anzeigen
       duplicate: Duplizieren
       duplicate_confirm: Es wird eine Kopie dieses Eintrags erstellt und am Ende der Wiedergabeliste hinzugefügt. Fortfahren?
-      presentation: Presentation
+      presentation:
       color_palette: Farbpalette
       device_default: Geräte-Standard (%{name})
       palette_unavailable: Nur verfügbar für Geräte mit mehreren Farbpaletten
@@ -545,7 +545,7 @@ de-AT:
       tagline: Was soll auf dem TRMNL angezeigt werden?
       available: Verfügbar
       connected: Verbunden
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: Blaupausen
       recipes_hint: Private Erweiterungen aus der Community können mit einem Klick installiert werden. __Mehr erfahren__
     search:
@@ -562,7 +562,7 @@ de-AT:
     new:
       title: Neue Erweiterung erstellen
       tagline: Ermögliche anderen Benutzern, deine Erweiterung zu installieren.
-      name: Name
+      name:
       category: Kategorie
       category_hint: Cmd oder Strg gedrückt halten, um bis zu 3 Einträge auszuwählen
       refresh_every: Unterstütztes Intervall für Aktualisierungen
@@ -585,7 +585,7 @@ de-AT:
     edit:
       title: Erweiterung bearbeiten
       tagline: Aktualisiere Details deiner Erweiterung.
-      name: Name
+      name:
       description: Beschreibung
   plugin_recipes:
     connected: Blaupause verbunden
@@ -593,8 +593,8 @@ de-AT:
       one: Verbindung
       other: Verbindungen
     forks:
-      one: Fork
-      other: Forks
+      one:
+      other:
     forked: Blaupause geforkt
     new:
       error: Blaupause nicht gefunden
@@ -650,7 +650,7 @@ de-AT:
       link_oauth_hint: Um fortzufahren, muss eine Kontoverknüpfung mit %{plugin} hergestellt werden
       mirrored: gespiegelt
       multiple_instances_hint: Diese Erweiterung unterstützt mehrere Instanzen.
-      name: Name
+      name:
       name_hint: Vergib einen Namen zur einfachen Unterscheidung
       parse: Parsen
       parse_save_first: Parsen (Erweiterung zuerst speichern)

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -5,13 +5,13 @@ de:
   actions: Aktionen
   add: Hinzufügen
   add_new: Neu hinzufügen
-  ai_assistant: Agent
+  ai_assistant:
   ai_assistant_hint: Aktiviere den Agent für die Markup-Bearbeitung im Plugin-Editor.
   already_have_account: Ich besitze bereits ein Konto
   are_you_sure: Bist du sicher?
   back: Zurück
   back_to_all_blog_posts: Zurück zu allen Posts
-  blog: Blog
+  blog:
   brand: Marke
   buy_now: Jetzt kaufen
   cancel: Abbrechen
@@ -43,7 +43,7 @@ de:
   first_name: Vorname
   forgot_password: Passwort vergessen
   forgot_password_title: Neues Passwort vergeben
-  friendly_id: Friendly ID
+  friendly_id:
   get_started: Lass uns loslegen!
   hidden: versteckt
   identify: Identifizieren
@@ -79,7 +79,7 @@ de:
   sign_in: Anmelden
   sign_up: Registrieren
   something_went_wrong: Etwas ist schiefgegangen
-  status: Status
+  status:
   subscribe: Abonnieren
   help_center: Hilfe
   terms: AGB
@@ -97,7 +97,7 @@ de:
   datetime:
     relative:
       past: vor %{time}
-      future: in %{time}
+      future:
       distance_in_words:
         half_a_minute: einer halben Minute
         less_than_x_seconds:
@@ -207,7 +207,7 @@ de:
       connected: Verbunden
       new_and_popular: Neu und beliebt
     shop:
-      title: Shop
+      title:
       need_another: Brauchst du noch einen TRMNL?
     time_saved:
       title: Eingesparte Zeit
@@ -255,7 +255,7 @@ de:
       display_calibration_ui_scale: UI-Skalierung
       display_calibration_ui_scale_hint: 'Text- und Elementgröße (0,5–2,0). Standard:'
       edit_device: Gerät bearbeiten
-      firmware: Firmware
+      firmware:
       firmware_updates_enabled: Updates aktiviert
       firmware_updates_disabled: Updates deaktiviert
       font_family: Schriftfamilie
@@ -292,7 +292,7 @@ de:
       maximum_compatibility: Maximale Kompatibilität aktivieren
       maximum_compatibility_hint: Behebt Anzeigefehler aufgrund bestimmter ePaper-Treiber-Chips. Deaktiviert schnelles Rendern. Benötigt Firmware 1.6.0+.
       color_and_rotation: Farbe & Rotation
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Bildschirmrotation
       screen_rotation_not_supported: Bildschirmrotation ist derzeit nicht auf deinem Gerät unterstützt.
       palette: Farbpalette
@@ -312,7 +312,7 @@ de:
       touchbar_mode_hint: Auf welche Art von Gesten soll dein Gerät reagieren?
       tidbyt_credentials: Tidbyt-Anmeldedaten
       tidbyt_credentials_hint: Gib hier die API-Zugangsdaten deines Tidbyt-Geräts ein (Einstellungen → Entwickler → API-Schlüssel in der Tidbyt-App).
-      tidbyt_api_key: Tidbyt API Key
+      tidbyt_api_key:
       tidbyt_credentials_invalid: Ungültige Tidbyt-API-Zugangsdaten. Bitte prüfen und erneut versuchen.
       tidbyt_device_id: Geräte-ID
       tidbyt_device_api_key: API-Schlüssel
@@ -331,22 +331,22 @@ de:
         warning_2: Mir ist bewusst, dass dies ein <strong>gefährlicher</strong> Vorgang ist, der mein Gerät dauerhaft beschädigen kann.
         cta: Auf TRMNL OG (2-bit) upgraden
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Geräte
       tagline: Deine TRMNL-Geräte
@@ -425,7 +425,7 @@ de:
       all: Alle
       bulk_destroy: Stapel-Löschen
       dump: Ausgabe
-      id: ID
+      id:
       private_plugins: Private Erweiterungen
       source: Quelle
       time: Zeit
@@ -437,7 +437,7 @@ de:
       design_system: Nutze unser natives Design-System
       design_system_docs: Dokumentation anzeigen
       dirty_confirm: Es gibt ungespeicherte Änderungen. Möchtest Du diese Seite wirklich verlassen?
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: Markup bearbeiten
       edit_markup_for_plugin: Markup von %{plugin_setting_name} bearbeiten
       edit_markup_please_save_first: Bitte vor dem Bearbeiten des Markups speichern
@@ -513,7 +513,7 @@ de:
       show_playlist: Eintrag anzeigen
       duplicate: Duplizieren
       duplicate_confirm: Es wird eine Kopie dieses Eintrags erstellt und am Ende der Wiedergabeliste hinzugefügt. Fortfahren?
-      presentation: Presentation
+      presentation:
       color_palette: Farbpalette
       device_default: Geräte-Standard (%{name})
       palette_unavailable: Nur verfügbar für Geräte mit mehreren Farbpaletten
@@ -545,7 +545,7 @@ de:
       tagline: Was soll auf dem TRMNL angezeigt werden?
       available: Verfügbar
       connected: Verbunden
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: Blaupausen
       recipes_hint: Private Erweiterungen aus der Community können mit einem Klick installiert werden. __Mehr erfahren__
     search:
@@ -562,7 +562,7 @@ de:
     new:
       title: Neue Erweiterung erstellen
       tagline: Ermögliche anderen Benutzern, deine Erweiterung zu installieren.
-      name: Name
+      name:
       category: Kategorie
       category_hint: Cmd oder Strg gedrückt halten, um bis zu 3 Einträge auszuwählen
       refresh_every: Unterstütztes Intervall für Aktualisierungen
@@ -585,7 +585,7 @@ de:
     edit:
       title: Erweiterung bearbeiten
       tagline: Aktualisiere Details deiner Erweiterung.
-      name: Name
+      name:
       description: Beschreibung
   plugin_recipes:
     connected: Blaupause verbunden
@@ -593,8 +593,8 @@ de:
       one: Verbindung
       other: Verbindungen
     forks:
-      one: Fork
-      other: Forks
+      one:
+      other:
     forked: Blaupause geforkt
     new:
       error: Blaupause nicht gefunden
@@ -650,7 +650,7 @@ de:
       link_oauth_hint: Um fortzufahren, muss eine Kontoverknüpfung mit %{plugin} hergestellt werden
       mirrored: gespiegelt
       multiple_instances_hint: Diese Erweiterung unterstützt mehrere Instanzen.
-      name: Name
+      name:
       name_hint: Vergib einen Namen zur einfachen Unterscheidung
       parse: Parsen
       parse_save_first: Parsen (Erweiterung zuerst speichern)

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -1,736 +1,736 @@
 ---
 en-GB:
   locale_name: English (United Kingdom)
-  about: About
-  actions: Actions
-  add: Add
-  add_new: Add new
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
-  already_have_account: I already have an account
-  are_you_sure: Are you sure?
-  back: Back
-  back_to_all_blog_posts: Back to all posts
-  blog: Blog
-  brand: Brand
-  buy_now: Buy Now
-  cancel: Cancel
-  change_password: Change Password
-  charge_level: Charge Level
-  charged: charged
-  charging: Charging
-  claim_plus_trial: Claim 6 Months Free
-  close: Close
-  confirm_change_password: Change my password
-  confirm_password: Confirm new password
-  copy: Copy
-  copied_to_clipboard: Copied!
-  copy_to_clipboard: Copy to clipboard
-  created: Created
-  create_an_account: Create an account
-  current_device: Current device
-  days: days
-  delete: Delete
-  developers: Developers
-  developer_edition_required: Developer edition is required to enable this feature.
-  device_id: Device ID
-  device: Device
-  discard: Discard
-  edit: Edit
-  email_address: Email address
-  export: Export
-  fetching: Fetching
-  first_name: First Name
-  forgot_password: I forgot my password
-  forgot_password_title: Here we go again
-  friendly_id: Friendly ID
-  get_started: Let's get you started!
-  hidden: hidden
-  identify: Identify
-  import: Import
-  import_new: Import new
-  integrations: Integrations
-  keep_me_signed_in: Keep me signed in
-  knowledge_base: Knowledge base
-  last_name: Last Name
-  learn_more: Learn more
-  loading: Loading
-  login: Login
-  log_out: Log out
-  manage: Manage
-  minimum_characters: characters minimum
-  mins: mins
-  my_playlist: My Playlist
-  new_password: New password
-  password: Password
-  please_wait: Please Wait...
-  plugin_not_found: Plugin not found
-  preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
-  refresh_rates_hint: Learn how refresh rates work __here__.
-  reset_password: Reset my password
-  reset_to_defaults: Reset to defaults
-  required: Required
-  save: Save
-  shown: shown
-  section: Section
-  settings: Settings
-  sign_in: Sign in
-  sign_up: Sign up
-  something_went_wrong: Something went wrong
-  status: Status
-  subscribe: Subscribe
-  help_center: Support
-  terms: Terms
-  unsaved_changes: You have unsaved changes
-  update: Update
-  view: View
-  collaboration_request: Wanna collaborate?
-  collaboration_request_hint: Partnerships, group sales, special projects, your call.
-  collaboration_request_cta: Let's talk
-  welcome: Welcome
+  about:
+  actions:
+  add:
+  add_new:
+  ai_assistant:
+  ai_assistant_hint:
+  already_have_account:
+  are_you_sure:
+  back:
+  back_to_all_blog_posts:
+  blog:
+  brand:
+  buy_now:
+  cancel:
+  change_password:
+  charge_level:
+  charged:
+  charging:
+  claim_plus_trial:
+  close:
+  confirm_change_password:
+  confirm_password:
+  copy:
+  copied_to_clipboard:
+  copy_to_clipboard:
+  created:
+  create_an_account:
+  current_device:
+  days:
+  delete:
+  developers:
+  developer_edition_required:
+  device_id:
+  device:
+  discard:
+  edit:
+  email_address:
+  export:
+  fetching:
+  first_name:
+  forgot_password:
+  forgot_password_title:
+  friendly_id:
+  get_started:
+  hidden:
+  identify:
+  import:
+  import_new:
+  integrations:
+  keep_me_signed_in:
+  knowledge_base:
+  last_name:
+  learn_more:
+  loading:
+  login:
+  log_out:
+  manage:
+  minimum_characters:
+  mins:
+  my_playlist:
+  new_password:
+  password:
+  please_wait:
+  plugin_not_found:
+  preview:
+  privacy:
+  refresh_rate:
+  refresh_rates_hint:
+  reset_password:
+  reset_to_defaults:
+  required:
+  save:
+  shown:
+  section:
+  settings:
+  sign_in:
+  sign_up:
+  something_went_wrong:
+  status:
+  subscribe:
+  help_center:
+  terms:
+  unsaved_changes:
+  update:
+  view:
+  collaboration_request:
+  collaboration_request_hint:
+  collaboration_request_cta:
+  welcome:
   time:
     formats:
       shorter: "%-H:%M"
     start_of_week: 1
   datetime:
     relative:
-      past: "%{time} ago"
-      future: in %{time}
+      past:
+      future:
       distance_in_words:
-        half_a_minute: half a minute
+        half_a_minute:
         less_than_x_seconds:
-          one: less than %{count} second
-          other: less than %{count} seconds
+          one:
+          other:
         less_than_x_minutes:
-          one: less than a minute
-          other: less than %{count} minutes
+          one:
+          other:
         x_seconds:
-          one: "%{count} second"
-          other: "%{count} seconds"
+          one:
+          other:
         x_minutes:
-          one: "%{count} minute"
-          other: "%{count} minutes"
+          one:
+          other:
         about_x_hours:
-          one: about %{count} hour
-          other: about %{count} hours
+          one:
+          other:
         x_days:
-          one: "%{count} day"
-          other: "%{count} days"
+          one:
+          other:
         about_x_months:
-          one: about %{count} month
-          other: about %{count} months
+          one:
+          other:
         x_months:
-          one: "%{count} month"
-          other: "%{count} months"
+          one:
+          other:
         about_x_years:
-          one: about %{count} year
-          other: about %{count} years
+          one:
+          other:
         over_x_years:
-          one: over %{count} year
-          other: over %{count} years
+          one:
+          other:
         almost_x_years:
-          one: almost %{count} year
-          other: almost %{count} years
+          one:
+          other:
   account:
     index:
-      title: Account
-      tagline: Manage your account settings
-      api_key_confirm: Are you sure you want to regenerate your API Key? The old key will be invalidated.
-      api_key_hint: See __the docs__ to learn how to configure your local environment.
-      api_key_label: The credential for authenticating local development tools
-      api_key_not_generated: "(none yet)"
-      api_key_reset: Regenerate
+      title:
+      tagline:
+      api_key_confirm:
+      api_key_hint:
+      api_key_label:
+      api_key_not_generated:
+      api_key_reset:
       api_key: API Key
-      beta_features: Beta Features
-      beta_features_hint: Try out new stuff here. Options may disappear at any time.
-      discord_community: Discord Community
-      discord_username: What's your Discord username?
-      discord_username_hint: May be used for support, attribution on published Recipes, etc.
-      email_address: Email Address
-      refer_and_earn: Refer and Earn
-      refer_and_earn_hint: Give the gift of TRMNL with a personalized coupon. Earn per use, paid monthly.
-      refer_and_earn_redemptions: Redemptions
-      refer_and_earn_request_code: Request a Code
-      device_invoice: Device Invoice
-      device_invoice_label: Download commercial documents for your accountant or (weird) PDF collection.
-      device_invoice_hint: Find this on your package tracking page or shipment notification email.
-      email_address_hint: Used to sign into TRMNL and receive system messages.
-      first_name_hint: We use your name to make the TRMNL interface more comfortable.
-      last_name_hint: We use your name to make the TRMNL interface more comfortable.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
-      password_hint: Used to protect your TRMNL account.
-      enable_2fa: Enable 2FA?
-      enable_2fa_hint: __Click here__ to enable OTP.
-      disable_2fa: Disable 2FA
-      disable_2fa_hint: Provide valid OTP and current password above to disable this feature.
-      plus_subscription: TRMNL+ Subscription
-      plus_subscription_trial_until: You're on a free trial until %{plus_trial_end_at}.
-      plus_subscription_hint: Unlock faster refresh rates and higher rate limits. __Learn more__.
-      plus_subscription_modify: Want to update your payment method or cancel?
-      session: Session
-      session_hint: You're logged in as %{user}
-      show_title_bar: Show title bar
-      show_title_bar_hint: If disabled, native (non global) and third party plugins will be more minimal.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
-      time_zone: Time Zone
-      time_zone_hint: Determines refresh rates and device sleep time.
-      locale: Locale
-      locale_hint: What language and localization do you prefer? __Go here__.
+      beta_features:
+      beta_features_hint:
+      discord_community:
+      discord_username:
+      discord_username_hint:
+      email_address:
+      refer_and_earn:
+      refer_and_earn_hint:
+      refer_and_earn_redemptions:
+      refer_and_earn_request_code:
+      device_invoice:
+      device_invoice_label:
+      device_invoice_hint:
+      email_address_hint:
+      first_name_hint:
+      last_name_hint:
+      github_username_hint:
+      password_hint:
+      enable_2fa:
+      enable_2fa_hint:
+      disable_2fa:
+      disable_2fa_hint:
+      plus_subscription:
+      plus_subscription_trial_until:
+      plus_subscription_hint:
+      plus_subscription_modify:
+      session:
+      session_hint:
+      show_title_bar:
+      show_title_bar_hint:
+      theme_hint:
+      time_zone:
+      time_zone_hint:
+      locale:
+      locale_hint:
     update:
-      success: Profile updated successfully
+      success:
     reset_api_key:
-      success: API key was regenerated successfully
+      success:
   dashboard:
     index:
-      title: Dashboard
-      last_7_days: Last 7 days
-      last_30_days: Last 30 days
-      last_90_days: Last 90 days
-      today: Today
-      yesterday: Yesterday
+      title:
+      last_7_days:
+      last_30_days:
+      last_90_days:
+      today:
+      yesterday:
     health:
-      bad: Plugins are experiencing issues
-      good: Plugins are healthy
-      next_steps: We will inform you if anything changes
+      bad:
+      good:
+      next_steps:
     news:
-      title: News
-      cta: View All
+      title:
+      cta:
     playlist_items:
-      title: Playlist
-      cta: Edit Playlist
-      pieces_of_content_displayed: Pieces of content displayed
+      title:
+      cta:
+      pieces_of_content_displayed:
     plugins:
-      title: Plugins
-      cta: Go to Plugins
-      connected: Connected
-      new_and_popular: New and Popular
+      title:
+      cta:
+      connected:
+      new_and_popular:
     shop:
-      title: Shop
-      need_another: Need another TRMNL?
+      title:
+      need_another:
     time_saved:
-      title: Time saved
-      cta: Read about
+      title:
+      cta:
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
-      morning_salutation: Good morning
-      afternoon_salutation: Good afternoon
-      evening_salutation: Good evening
+      morning_salutation:
+      afternoon_salutation:
+      evening_salutation:
   devices:
     edit:
-      accepts_beta_firmware: Firmware Early Release
-      accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
-      back_to_devices: Back to Devices
-      battery_and_sleep: Battery & Sleep
-      battery_consumption: Battery Consumption
-      battery_consumption_hint: Save power and enjoy a longer battery life by enabling Sleep Mode.
-      battery_learn_more: Learn more about battery charging __here__.
-      battery_refresh: Refresh
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
-      developer_perks: Developer Perks
+      accepts_beta_firmware:
+      accepts_beta_firmware_hint:
+      back_to_devices:
+      battery_and_sleep:
+      battery_consumption:
+      battery_consumption_hint:
+      battery_learn_more:
+      battery_refresh:
+      click:
+      click_action:
+      controls:
+      developer_perks:
       developer_perks_hint: Options below require the __Developer add-on__.
-      device_credentials: Device Credentials
-      device_credentials_hint: See what you can do with these credentials __here__
-      device_name: Device Name
-      device_name_hint: We use this to make the TRMNL interface more comfortable
-      device_model: Device Model
-      device_model_hint: Your hardware Model
-      device_model_switch_warning: This is a dangerous operation, learn more __here__
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
-      display_calibration: Display Calibration
-      display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
-      display_calibration_pixel_ratio: Pixel Ratio
-      display_calibration_pixel_ratio_hint: 'Image zoom level (0.5–3.0). Default:'
-      display_calibration_ui_scale: UI Scale
-      display_calibration_ui_scale_hint: 'Text and element sizes (0.5–2.0). Default:'
-      edit_device: Edit Device
-      firmware: Firmware
-      firmware_updates_enabled: Updates enabled
-      firmware_updates_disabled: Updates disabled
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
-      guest_mode: Guest Mode
-      guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
-      guest_mode_item_placeholder: Choose an item
-      guest_mode_duration_placeholder: Choose a duration
-      identify: Identify
-      identify_device: Identify Device
-      identify_device_hint: Click the button below to generate a screen on this device that helps identify it.
-      logs: Logs
-      logs_hint: Debug your device and plugins with a live feed of raw error logs.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
-      low_battery_email_notification: Low Battery Email Notification
-      low_battery_email_notification_hint: Get notified via email when your device battery is running low.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
-      mirror: Mirror
-      mirror_device: Mirror another Device
-      mirror_device_hint: Provide a (shareable) Device ID to mirror its playlist. Your playlist will still be displayed.
-      mirror_disabled: Mirroring disabled
-      mirror_enabled: Mirroring
-      mirror_stop: Disconnect Mirroring
-      mirror_sync: Sync Screens
-      ota_enabled: OTA Updates Enabled
-      ota_enabled_hint: Automatically install new firmware. Disable to use your own firmware.
-      ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
-      maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      device_credentials:
+      device_credentials_hint:
+      device_name:
+      device_name_hint:
+      device_model:
+      device_model_hint:
+      device_model_switch_warning:
+      device_info:
+      current_firmware:
+      last_ping:
+      unknown:
+      never:
+      display_calibration:
+      display_calibration_hint:
+      display_calibration_pixel_ratio:
+      display_calibration_pixel_ratio_hint:
+      display_calibration_ui_scale:
+      display_calibration_ui_scale_hint:
+      edit_device:
+      firmware:
+      firmware_updates_enabled:
+      firmware_updates_disabled:
+      font_family:
+      font_family_hint:
+      guest_mode:
+      guest_mode_hint:
+      guest_mode_item_placeholder:
+      guest_mode_duration_placeholder:
+      identify:
+      identify_device:
+      identify_device_hint:
+      logs:
+      logs_hint:
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
+      low_battery_email_notification:
+      low_battery_email_notification_hint:
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
+      mirror:
+      mirror_device:
+      mirror_device_hint:
+      mirror_disabled:
+      mirror_enabled:
+      mirror_stop:
+      mirror_sync:
+      ota_enabled:
+      ota_enabled_hint:
+      ota_byod_not_supported:
+      maximum_compatibility:
+      maximum_compatibility_hint:
       color_and_rotation: Colour & Rotation
-      image_rotation: Image Rotation
-      screen_rotation: Screen Rotation
-      screen_rotation_not_supported: Screen rotation is currently not supported on your device.
+      image_rotation:
+      screen_rotation:
+      screen_rotation_not_supported:
       palette: Colour Palette
       palette_hint: Select the set of colours to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
-      presentation: Presentation
-      sleep_mode: Sleep Mode
-      sleep_mode_hint: Adjust your refresh rate to optimize focus and battery life.
-      sleep_screen: Sleep Screen
-      sleep_screen_tooltip: Enable Sleep Mode to use this feature
-      sleep_screen_hint: Display a sleep screen during sleep mode hours.
-      special_function: Special Function
-      special_function_hint: Set a custom feature for the button on the back of your device.
+      presentation:
+      sleep_mode:
+      sleep_mode_hint:
+      sleep_screen:
+      sleep_screen_tooltip:
+      sleep_screen_hint:
+      special_function:
+      special_function_hint:
       special_function_learn_more: Learn more about special functions __here__.
-      temperature_profile: Temperature Profile
-      temperature_profile_hint: Don't change unless instructed. For displays with washed out images.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
-      tidbyt_credentials: Tidbyt Credentials
-      tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
-      tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
-      tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
-      unlink: Unlink
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
-      unlink_device: Unlink Device
+      temperature_profile:
+      temperature_profile_hint:
+      touchbar_mode:
+      touchbar_mode_hint:
+      tidbyt_credentials:
+      tidbyt_credentials_hint:
+      tidbyt_api_key:
+      tidbyt_credentials_invalid:
+      tidbyt_device_id:
+      tidbyt_device_api_key:
+      unlink:
+      unlink_confirm:
+      unlink_device:
       unlink_device_hint: Unlinking a TRMNL device makes it safe to re-sell or give to someone else.
-      unlink_device_learn_more: Follow the full guide __here__.
-      visibility: Visibility
-      visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
-      your_device: Your TRMNL
+      unlink_device_learn_more:
+      visibility:
+      visibility_hint:
+      your_device:
       upgrade_og:
-        title: Upgrade to 2-bit Display Available
+        title:
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 colour levels instead of 2.
-        warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
-        warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
-        cta: Upgrade to TRMNL OG (2-bit)
+        warning_1:
+        warning_2:
+        cta:
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
-      title: Devices
-      tagline: Your TRMNL devices
-      add_device_modal_title: Add a new device
-      add_first_device: Start by adding your first device!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      title:
+      tagline:
+      add_device_modal_title:
+      add_first_device:
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
-      title: Add a new device
-      description: Enter your Friendly ID to add a new device to your account.
-      add_device: Add new device
+      title:
+      description:
+      add_device:
     associate:
-      error: Error linking device
-      success: Device successfully linked
+      error:
+      success:
     dissociate:
-      error: Error disconnecting device
-      success: Device successfully unlinked
+      error:
+      success:
     external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
+      error:
+      success:
     identify:
-      error: Error updating device
-      success: Device identification requested
+      error:
+      success:
     mirror:
-      error: Error mirroring device
-      error_not_shared: Provided Device ID is not shareable
-      error_oneself: Can't mirror oneself
-      success: Device %{friendly_id} successfully mirrored
-      success_removed: Mirroring Removed
+      error:
+      error_not_shared:
+      error_oneself:
+      success:
+      success_removed:
     switch:
-      error: Error switching device
-      success: Device switched successfully
-      title: Switch to device
+      error:
+      success:
+      title:
     update:
-      error: Error updating device
-      success: "%{device} device settings updated successfully"
+      error:
+      success:
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
-    rate_limit: Too many attempts, please wait and try again
-    invoice_not_found: Invoice not found
+    rate_limit:
+    invoice_not_found:
   logs:
     index:
-      title: Logs
-      all: All
-      bulk_destroy: Bulk Destroy
-      dump: Dump
-      id: ID
-      private_plugins: Private Plugins
-      source: Source
-      time: Time
+      title:
+      all:
+      bulk_destroy:
+      dump:
+      id:
+      private_plugins:
+      source:
+      time:
   markups:
     console_logs:
-      js_logs: JS Logs
+      js_logs:
     form:
-      back_to_plugin_settings: Back to plugin settings
-      design_system: Leverage our native design system
-      design_system_docs: Design System Docs
-      dirty_confirm: You have unsaved changes. Are you sure you want to leave this page?
-      edit_composition: Edit Composition
-      edit_markup: Edit Markup
-      edit_markup_for_plugin: Edit markup for %{plugin_setting_name}
-      edit_markup_please_save_first: Please save before editing markup
-      edit_markup_without_preview: Edit Markup (without preview)
-      error_rendering_markup: Error rendering that markup
-      fix_indentation: Fix indentation
-      go_to_preview: Go To Preview
-      live_preview: Live Preview
-      no_changes_to_save: No changes to save
-      pop_out_preview: Pop Out Preview
-      quickstart_examples: Quick-start Examples
-      quickstart_example_applied: Applied!
-      quickstart_use_this_example: Use this example
-      revert: Revert
-      revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
-      save_changes: Save Changes (⌘﹢S)
-      separate_preview: Preview is open in a separate window
+      back_to_plugin_settings:
+      design_system:
+      design_system_docs:
+      dirty_confirm:
+      edit_composition:
+      edit_markup:
+      edit_markup_for_plugin:
+      edit_markup_please_save_first:
+      edit_markup_without_preview:
+      error_rendering_markup:
+      fix_indentation:
+      go_to_preview:
+      live_preview:
+      no_changes_to_save:
+      pop_out_preview:
+      quickstart_examples:
+      quickstart_example_applied:
+      quickstart_use_this_example:
+      revert:
+      revert_confirm:
+      save_changes:
+      separate_preview:
     merge_variables:
-      your_variables: Your variables
+      your_variables:
     no_merge_variables:
-      force_refresh: If you've provided variables but they aren't being detected, try a __force refresh__.
-      no_variables_detected: No variables detected.
+      force_refresh:
+      no_variables_detected:
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
-      success: 2FA Disabled
-      invalid_otp: Invalid OTP
-      invalid_password: Invalid Password
-      invalid_otp_and_password: Invalid OTP and Password
+      success:
+      invalid_otp:
+      invalid_password:
+      invalid_otp_and_password:
     enable_otp:
-      input_otp: Enter OTP
-      submit: Verify and Enable
-      already_enabled: 2FA is already enabled
+      input_otp:
+      submit:
+      already_enabled:
     enable_otp_verify:
-      success: 2FA Enabled
-      error: Invalid OTP code
+      success:
+      error:
     verify_otp:
-      verify: Verify
-      reset: Reset MFA
-      reset_instructions: Click the button on the back of your TRMNL to generate a reset code
-      success: 2FA successful
-      error: Invalid OTP code
+      verify:
+      reset:
+      reset_instructions:
+      success:
+      error:
   playlist_items:
     index:
-      title: Playlist
-      tagline: Choose what's shown on
-      add_a_group: Add a Group
-      add_a_plugin: Add a Plugin
-      add_first_device_cta: Start by __adding__ your first TRMNL device!
-      add_to_playlist: Add to playlist
-      create_first_playlist_cta: Create your Playlist after __connecting__ your first plugin!
-      custom: Custom
-      device_default: Device default
-      display_period_from: Display from
-      display_period_to: to
-      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
-      never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
+      title:
+      tagline:
+      add_a_group:
+      add_a_plugin:
+      add_first_device_cta:
+      add_to_playlist:
+      create_first_playlist_cta:
+      custom:
+      device_default:
+      display_period_from:
+      display_period_to:
+      display_period_validation:
+      every:
+      never_skip:
+      smart_playlist:
+      smart_playlist_hint:
       skip_after:
-        one: Skip stale screens after 1 day
-        other: Skip stale screens after %{count} days
+        one:
+        other:
     playlist_item:
-      adjust_schedule: Adjust schedule
-      delete: Are you sure you want to remove this item? The plugin will remain connected, just not shown on your device.
-      displayed_now: Displayed now
-      not_displayed_yet: Not displayed yet
-      remove_from_playlist: Remove from playlist
-      hide_playlist: Hide this item
-      show_playlist: Show this item
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
+      adjust_schedule:
+      delete:
+      displayed_now:
+      not_displayed_yet:
+      remove_from_playlist:
+      hide_playlist:
+      show_playlist:
+      duplicate:
+      duplicate_confirm:
+      presentation:
       color_palette: Colour Palette
-      device_default: Device Default (%{name})
+      device_default:
       palette_unavailable: Only available for devices with multiple colour palettes
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default:
+        external:
+        global:
+        mashup:
+        readonly:
     create:
-      error: Failed to update Playlist
-      success: Playlist updated
+      error:
+      success:
     destroy:
-      error: Error removing item from playlist
-      success: Plugin removed from playlist
+      error:
+      success:
     toggle_visibility:
-      success: Playlist item %{change}
+      success:
     duplicate:
       success: Playlist duplicated
     sort:
-      success: Playlist order updated
+      success:
     set_preferences:
-      success: Smart Playlist preference updated
+      success:
     update:
-      success: Playlist order updated
+      success:
   plugins:
     index:
-      title: Plugins
-      tagline: What will you put on your TRMNL?
-      available: Available
-      connected: Connected
-      supported_by_this_device: Supported by this device
-      recipes: Recipes
-      recipes_hint: Private plugins by community members that can be installed in 1 click. __Learn more__.
+      title:
+      tagline:
+      available:
+      connected:
+      supported_by_this_device:
+      recipes:
+      recipes_hint:
     search:
-      placeholder: Search Plugins
+      placeholder:
     my:
       index:
-        title: My Plugins
-        tagline: Develop Plugins for the public marketplace
+        title:
+        tagline:
       card:
-        connections: connections
-        install: Install
-        review_are_you_sure: Are you sure? The TRMNL team will test it and email you any questions.
-        submit_for_review: Submit for Review
+        connections:
+        install:
+        review_are_you_sure:
+        submit_for_review:
     new:
-      title: Create New Plugin
-      tagline: Other users will be able to install your plugin.
-      name: Name
-      category: Category
-      category_hint: Hold cmd or ctrl to choose up to 3
-      refresh_every: Supported Refresh Interval
-      refresh_every_hint: The fastest refresh interval your plugin can support.
-      description: Description
-      description_hint: Maximum 50 characters
-      icon: Icon
-      icon_hint: 512x512px recommended
-      installation_url: Installation URL
-      installation_url_hint: Learn more about the installation flow __here__.
-      installation_success_webhook_url: Installation Success Webhook URL
-      knowledge_base_url: Knowledge Base URL
-      management_url: Plugin Management URL
-      management_url_hint: Learn more about the management flow __here__.
-      markup_url: Plugin Markup URL
-      markup_url_hint: Learn more about screen generation __here__.
-      no_screen_padding: No Screen Padding
-      no_screen_padding_hint: Removes the outermost padding in fullscreen mode.
-      uninstallation_webhook_url: Uninstallation Webhook URL
+      title:
+      tagline:
+      name:
+      category:
+      category_hint:
+      refresh_every:
+      refresh_every_hint:
+      description:
+      description_hint:
+      icon:
+      icon_hint:
+      installation_url:
+      installation_url_hint:
+      installation_success_webhook_url:
+      knowledge_base_url:
+      management_url:
+      management_url_hint:
+      markup_url:
+      markup_url_hint:
+      no_screen_padding:
+      no_screen_padding_hint:
+      uninstallation_webhook_url:
     edit:
-      title: Edit Plugin
-      tagline: Update your plugin details.
-      name: Name
-      description: Description
+      title:
+      tagline:
+      name:
+      description:
   plugin_recipes:
-    connected: Recipe connected
+    connected:
     connections:
-      one: Connection
-      other: Connections
+      one:
+      other:
     forks:
-      one: Fork
-      other: Forks
-    forked: Recipe forked
+      one:
+      other:
+    forked:
     new:
-      error: Recipe not found
+      error:
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
-    active: Active
-    copy_are_you_sure: Are you sure you want to copy this setting?
-    delete_are_you_sure: Are you sure you want to delete this setting?
-    delete: This will completely remove the plugin's settings. To simply hide this plugin from your device, delete it from your playlist instead.
-    inactive: Inactive
-    no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: No plugin settings found.
-    not_supported: Not supported on current device
-    refreshing_now_please_wait: Refreshing now, reload this page in a few seconds.
-    reset_credentials: "%{plugin_name} account reset successfully"
+    active:
+    copy_are_you_sure:
+    delete_are_you_sure:
+    delete:
+    inactive:
+    no_matches_found:
+    no_plugin_settings_found:
+    not_supported:
+    refreshing_now_please_wait:
+    reset_credentials:
     form:
-      active_hint: Show or hide this plugin instance on your device
-      advanced_settings: Advanced Settings
-      back_to_playlist: Back to Playlist
-      back_to_plugin: Back to %{plugin}
-      back_to_plugins: Back to Plugins
-      connect_with: Connect with %{plugin}
-      debug_logs: Debug Logs
-      debug_logs_click_here: Click here
-      debug_logs_click_here_hint: to enable debug logs for this plugin instance.
-      debug_logs_enabled: Debug logs enabled for %{hours} hours.
-      debug_logs_enabled_link: View logs
-      disconnect_account: Disconnect Account
-      manage_plugin: Configure %{plugin}
-      force_refresh: Force Refresh
-      force_refresh_hint: This feature is designed for testing only - please do not abuse it.
-      force_refresh_click_here: Click here
-      force_refresh_click_here_hint: to generate a new screen immediately
-      force_refresh_not_possible: This plugin cannot be force-refreshed because the TRMNL server does not perform image processing. Learn how to test your instance __here__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
-      learn_more: Learn about this plugin in our knowledge base
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
-      learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
-      linked_account: Linked Account
-      linked_account_success: Successfully linked with %{plugin_name}
-      link_oauth: Link Account
-      link_oauth_hint: Before you continue, follow the secure authorization process provided by %{plugin}
-      mirrored: Mirrored
-      multiple_instances_hint: This plugin supports multiple instances.
-      name: Name
-      name_hint: Give it a name for easy reference
-      parse: Parse
-      parse_save_first: Parse (Save plugin first)
-      parsed: Parsed
-      plugin_uuid: Plugin UUID
-      plugin_uuid_hint: Use this to make Webhook API requests.
-      preview: Preview - your device will show actual data
+      active_hint:
+      advanced_settings:
+      back_to_playlist:
+      back_to_plugin:
+      back_to_plugins:
+      connect_with:
+      debug_logs:
+      debug_logs_click_here:
+      debug_logs_click_here_hint:
+      debug_logs_enabled:
+      debug_logs_enabled_link:
+      disconnect_account:
+      manage_plugin:
+      force_refresh:
+      force_refresh_hint:
+      force_refresh_click_here:
+      force_refresh_click_here_hint:
+      force_refresh_not_possible:
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
+      learn_more:
+      learn_more_fork:
+      learn_more_fork_original:
+      learn_more_native_long:
+      learn_more_native_short:
+      learn_more_recipe_author:
+      learn_more_recipe_long:
+      learn_more_recipe_short:
+      learn_more_third_party_long:
+      learn_more_third_party_short:
+      linked_account:
+      linked_account_success:
+      link_oauth:
+      link_oauth_hint:
+      mirrored:
+      multiple_instances_hint:
+      name:
+      name_hint:
+      parse:
+      parse_save_first:
+      parsed:
+      plugin_uuid:
+      plugin_uuid_hint:
+      preview:
       recipe_cta_heading_published: This plugin is a Recipe
-      recipe_cta_heading_unlisted: This plugin is unlisted
+      recipe_cta_heading_unlisted:
       recipe_cta_heading_in_review: Recipe in review
       recipe_cta_heading_not_published: Publish as a Recipe?
-      recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
-      recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
-      recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
-      recipe_mirrored: This screen is mirrored from the recipe.
-      recipe_visibility_title: How would you like to publish?
-      recipe_visibility_edit_title: Edit Submission
-      recipe_visibility_public: Public
-      recipe_visibility_public_hint: Anyone can find and install.
-      recipe_visibility_private: Private
-      recipe_visibility_private_hint: Breaks external installs.
-      recipe_visibility_unlisted: Unlisted
-      recipe_visibility_unlisted_hint: Anyone with the link can install.
-      refresh_rate: Refresh rate
-      refresh_rate_hint: Define how frequently this plugin instance fetches fresh data
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
-      refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
-      refreshed: Refreshed
-      remove_plugin: Remove plugin
-      remove_plugin_hint: Removing a plugin will also remove it from your playlist
-      synced: Synced
-      refresh_paused: Refresh Paused
-      refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
-      refresh_paused_mashup: Refreshing Mashups
-      refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
-      refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.
-      view_recipe: View Recipe
-      visit_docs: Visit Docs
+      recipe_cta_body_published:
+      recipe_cta_body_in_review:
+      recipe_cta_body_not_published:
+      recipe_cta_confirm:
+      recipe_mirrored:
+      recipe_visibility_title:
+      recipe_visibility_edit_title:
+      recipe_visibility_public:
+      recipe_visibility_public_hint:
+      recipe_visibility_private:
+      recipe_visibility_private_hint:
+      recipe_visibility_unlisted:
+      recipe_visibility_unlisted_hint:
+      refresh_rate:
+      refresh_rate_hint:
+      refresh_rate_jit_hint:
+      refresh_rate_not_configurable:
+      refreshed:
+      remove_plugin:
+      remove_plugin_hint:
+      synced:
+      refresh_paused:
+      refresh_paused_hint:
+      refresh_paused_hidden_hint:
+      refresh_paused_mashup:
+      refresh_paused_mashup_hint:
+      refresh_stopped:
+      view_recipe:
+      visit_docs:
     import:
-      archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
-      missing_entry: The ZIP file does not contain %{filename}
-      entry_too_large: "%{filename} is too large"
-      malformed: "%{filename} is malformed"
+      archive_too_large:
+      missing_entry:
+      entry_too_large:
+      malformed:
     create:
-      success: Plugin created and added to your
-      playlist: playlist
+      success:
+      playlist:
     destroy:
-      success: Plugin deleted
-    handle_canceled_consent: Consent canceled, please try again
+      success:
+    handle_canceled_consent:
     update:
-      success: Plugin configuration updated successfully
+      success:
     add_to_playlist:
-      success: Plugin added to playlist
+      success:
   referral_code:
     create:
-      request_received: Request received, check your inbox
+      request_received:
   recipes:
     index:
-      newest_to_oldest: Newest to Oldest
-      oldest_to_newest: Oldest to Newest
-      most_popular: Most Popular
-      install: Install
-      fork: Fork
+      newest_to_oldest:
+      oldest_to_newest:
+      most_popular:
+      install:
+      fork:
   schedules:
     form:
-      add: Add a custom schedule
-      append: And during…
-      no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
-      to: to
-      copy_prompt: Copy schedule from…
-      no_days_error: Please select at least one day.
+      add:
+      append:
+      no_schedule:
+      some_schedule:
+      to:
+      copy_prompt:
+      no_days_error:
   upgrade:
     index:
-      title: 'Upgrading device:'
-      tagline: Unlock custom plugins and __more__.
-      pay: Pay
-      error: Device %{device_name} is already upgraded, switch to another device
+      title:
+      tagline:
+      pay:
+      error:
     confirm:
-      success: Developer edition add-on is now enabled
+      success:

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -2,16 +2,16 @@
 es-ES:
   locale_name: Español (España)
   about: Acerca de
-  actions: Actions
+  actions:
   add: Crear
   add_new: Crear nueva
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: Ya tengo una cuenta
   are_you_sure: "¿Estás seguro?"
   back: Atrás
   back_to_all_blog_posts: Volver a todas las publicaciones
-  blog: Blog
+  blog:
   brand: Marca
   buy_now: Comprar ahora
   cancel: Cancelar
@@ -35,7 +35,7 @@ es-ES:
   developer_edition_required: Se requiere la Edición para Desarrolladores para activar esta función.
   device_id: ID del dispositivo
   device: Dispositivo
-  discard: Discard
+  discard:
   edit: Editar
   email_address: Dirección de correo electrónico
   export: Exportar
@@ -83,7 +83,7 @@ es-ES:
   subscribe: Suscribirse
   help_center: Soporte
   terms: Términos
-  unsaved_changes: You have unsaved changes
+  unsaved_changes:
   update: Actualizar
   view: Ver
   collaboration_request: "¿Quieres colaborar?"
@@ -159,7 +159,7 @@ es-ES:
       email_address_hint: Se usa para conectarse a TRMNL y recibir mensajes.
       first_name_hint: Usamos tu nombre para hacer que la interfaz de TRMNL sea más cómoda.
       last_name_hint: Usamos tu apellido para hacer que la interfaz de TRMNL sea más cómoda.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: Para proteger tu cuenta de TRMNL.
       enable_2fa: "¿Habilitar 2FA?"
       enable_2fa_hint: __Haz clic aquí__ para habilitar OTP.
@@ -173,7 +173,7 @@ es-ES:
       session_hint: Conectado como %{user}
       show_title_bar: Mostrar la barra de título
       show_title_bar_hint: Si se deshabilita, los plugins nativos (no globales) y los de terceros serán más minimalistas.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
+      theme_hint:
       time_zone: Zona horaria
       time_zone_hint: Determina la tasa de refresco y el tiempo de suspensión del dispositivo.
       locale: Idioma
@@ -202,7 +202,7 @@ es-ES:
       cta: Editar lista de reproducción
       pieces_of_content_displayed: Contenido mostrado
     plugins:
-      title: Plugins
+      title:
       cta: Ir a Plugins
       connected: Conectado
       new_and_popular: Nuevos y Populares
@@ -213,10 +213,10 @@ es-ES:
       title: Tiempo ahorrado
       cta: Leer más
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: "¡Buenos días,"
       afternoon_salutation: "¡Buenas tardes,"
@@ -231,9 +231,9 @@ es-ES:
       battery_consumption_hint: Ahorra energía y mejora el uso de batería habilitando el Modo de suspensión.
       battery_learn_more: Aprende más sobre la carga de la batería __aquí__.
       battery_refresh: Actualizar
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      click:
+      click_action:
+      controls:
       developer_perks: Ventajas para desarrolladores
       developer_perks_hint: Las opciones a continuación requieren el __plugin de Desarrolladores__.
       device_credentials: Credenciales del dispositivo
@@ -255,11 +255,11 @@ es-ES:
       display_calibration_ui_scale: Escala de la interfaz
       display_calibration_ui_scale_hint: 'Tamaño de texto y elementos (0.5–2.0). Por defecto:'
       edit_device: Editar dispositivo
-      firmware: Firmware
+      firmware:
       firmware_updates_enabled: Actualizaciones habilitadas
       firmware_updates_disabled: Actualizaciones deshabilitadas
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family:
+      font_family_hint:
       guest_mode: Modo invitado
       guest_mode_hint: Elige qué mostrar (y por cuánto tiempo) cuando el modo invitado esté activado.
       guest_mode_item_placeholder: Elige un elemento
@@ -269,16 +269,16 @@ es-ES:
       identify_device_hint: Haz clic en el botón de abajo para crear una pantalla en este dispositivo que ayude a identificarlo.
       logs: Registros
       logs_hint: Depura tu dispositivo y plugins con un feed en vivo de logs de error.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
       low_battery_email_notification: Notificación por correo de batería baja
       low_battery_email_notification_hint: Recibe un correo cuando la batería de tu dispositivo esté baja.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: Modo espejo
       mirror_device: Replicar otro dispositivo
       mirror_device_hint: Introduce un ID de dispositivo (compartible) para replicar su lista de reproducción. Tu lista seguirá mostrándose.
@@ -292,12 +292,12 @@ es-ES:
       maximum_compatibility: Habilitar Compatibilidad Máxima
       maximum_compatibility_hint: Resuelve problemas de visualización causados por ciertos chips de tinta electrónica. Desactiva la actualización rápida. Firmware 1.6.0+ requerido.
       color_and_rotation: Color & Rotación
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Rotación de pantalla
       screen_rotation_not_supported: La rotación de pantalla no está actualmente soportada en tu dispositivo.
       palette: Paleta de colores
       palette_hint: Selecciona la paleta de colores para las pantallas de este dispositivo. Una paleta mayor se ve mejor, pero una menor dibuja más rápido en ePaper. Los elementos de la lista pueden anular esto.
-      presentation: Presentation
+      presentation:
       sleep_mode: Modo de suspensión
       sleep_mode_hint: Ajusta tu tasa de refresco para optimizar el enfoque y la duración de la batería.
       sleep_screen: Pantalla de suspensión
@@ -312,12 +312,12 @@ es-ES:
       touchbar_mode_hint: "¿A qué tipo de gestos debe responder tu dispositivo?"
       tidbyt_credentials: Credenciales Tidbyt
       tidbyt_credentials_hint: Introduce las credenciales API de tu dispositivo Tidbyt desde la app de Tidbyt en Ajustes → Developer → Obtener clave API.
-      tidbyt_api_key: Tidbyt API Key
+      tidbyt_api_key:
       tidbyt_credentials_invalid: Las credenciales API de Tidbyt no son válidas. Por favor, comprueba y vuelve a intentarlo.
       tidbyt_device_id: ID del dispositivo
       tidbyt_device_api_key: Clave API
       unlink: Desvincular
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm:
       unlink_device: Desvincular dispositivo
       unlink_device_hint: Desvincular un dispositivo TRMNL lo hace seguro para revender o regalar a otra persona.
       unlink_device_learn_more: Sigue la guía completa __aquí__.
@@ -331,41 +331,41 @@ es-ES:
         warning_2: Entiendo que es una acción <strong>peligrosa</strong> y puede inutilizar mi dispositivo.
         cta: Actualizar a TRMNL OG (2-bit)
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Dispositivos
       tagline: Tus dispositivos TRMNL
       add_device_modal_title: Añadir un nuevo dispositivo
       add_first_device: "¡Añade tu primer dispositivo!"
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: Añadir un nuevo dispositivo
       description: Introduce tu ID de Dispositivo para añadir un nuevo dispositivo TRMNL a tu cuenta.
@@ -391,32 +391,32 @@ es-ES:
     switch:
       error: Error al cambiar de dispositivo
       success: Dispositivo cambiado con éxito
-      title: Switch to device
+      title:
     update:
       error: Error al actualizar el dispositivo
       success: Configuración del dispositivo %{device} actualizada con éxito
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: Demasiados intentos, por favor, espera e inténtalo de nuevo
     invoice_not_found: Factura no encontrada
@@ -426,7 +426,7 @@ es-ES:
       all: Todos
       bulk_destroy: Eliminar masivamente
       dump: Volcado
-      id: ID
+      id:
       private_plugins: Plugins privados
       source: Fuente
       time: Hora
@@ -438,7 +438,7 @@ es-ES:
       design_system: Aprovecha nuestro sistema de diseño nativo
       design_system_docs: Documentación del sistema de diseño
       dirty_confirm: Tienes cambios sin guardar. ¿Seguro que quieres salir de esta página?
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: Editar markup
       edit_markup_for_plugin: Editar markup para %{plugin_setting_name}
       edit_markup_please_save_first: Por favor guarda antes de editar el markup
@@ -463,7 +463,7 @@ es-ES:
       no_variables_detected: No se detectaron variables
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: 2FA deshabilitado
@@ -512,12 +512,12 @@ es-ES:
       remove_from_playlist: Eliminar de la lista
       hide_playlist: Ocultar este elemento
       show_playlist: Mostrar este elemento
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
         default: La tasa de actualización de este plugin no se puede configurar.
         external: Este plugin obtiene datos al vuelo, por lo que la configuración de la tasa de actualización no se aplica.
@@ -542,11 +542,11 @@ es-ES:
       success: Orden de la lista actualizado
   plugins:
     index:
-      title: Plugins
+      title:
       tagline: "¿Qué pondrás en tu TRMNL?"
       available: Disponible
       connected: Conectado
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: Recetas
       recipes_hint: Plugins privados creados por miembros de la comunidad que se pueden instalar en 1 click. __Aprende más__.
     search:
@@ -594,21 +594,21 @@ es-ES:
       one: Conexión
       other: Conexiones
     forks:
-      one: Fork
-      other: Forks
-    forked: Recipe forked
+      one:
+      other:
+    forked:
     new:
       error: Receta no encontrada
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: Activo
     copy_are_you_sure: "¿Estás seguro de que quieres copiar este plugin?"
     delete_are_you_sure: "¿Estás seguro de que quieres eliminar este plugin?"
     delete: Esto borrará completamente la configuración del plugin. Para ocultar este plugin de tu dispositivo, elimínalo de tu lista de reproducción.
     inactive: Inactivo
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: No se encontraron configuraciones del plugin.
     not_supported: No compatible con el dispositivo actual
     refreshing_now_please_wait: Actualizando, refresca la página en unos segundos.
@@ -632,9 +632,9 @@ es-ES:
       force_refresh_click_here: Haz clic aquí
       force_refresh_click_here_hint: Genera una nueva pantalla inmediatamente
       force_refresh_not_possible: Este plugin no puede forzarse a actualizar porque el servidor TRMNL no realiza procesamiento de imágenes. Aprende cómo probar tu instancia __aquí__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: Aprende sobre este plugin en nuestra base de conocimientos
       learn_more_fork: Este plugin fue bifurcado de una receta.
       learn_more_fork_original: Ver original
@@ -678,7 +678,7 @@ es-ES:
       recipe_visibility_unlisted_hint: Cualquiera con el enlace puede instalarlo.
       refresh_rate: Tasa de refresco
       refresh_rate_hint: Define con qué frecuencia esta instancia de plugin obtiene nuevos datos
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
+      refresh_rate_jit_hint:
       refresh_rate_not_configurable: Sincroniza %{refresh_rate} (no configurable)
       refreshed: Refrescado
       remove_plugin: Eliminar plugin
@@ -686,7 +686,7 @@ es-ES:
       synced: Sincronizado
       refresh_paused: Actualización en pausa
       refresh_paused_hint: La actualización automática está en pausa. Añade a la lista para comenzar de nuevo.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
+      refresh_paused_hidden_hint:
       refresh_paused_mashup: Actualizando mashups
       refresh_paused_mashup_hint: Actualización automática pausada para pantalla completa. Mashups están actualizando.
       refresh_stopped: La actualización automática se ha detenido. Por favor, arregla el error del plugin para continuar.
@@ -716,7 +716,7 @@ es-ES:
       oldest_to_newest: más antiguas a más nuevas
       most_popular: Más populares
       install: Instalar
-      fork: Fork
+      fork:
   schedules:
     form:
       add: Añade una programación personalizada
@@ -725,7 +725,7 @@ es-ES:
       some_schedule: Solo mostrar esta pantalla durante…
       to: a
       copy_prompt: Copiar programación de…
-      no_days_error: Please select at least one day.
+      no_days_error:
   upgrade:
     index:
       title: 'Actualizando dispositivo:'

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -2,16 +2,16 @@
 fr:
   locale_name: Français
   about: À propos
-  actions: Actions
+  actions:
   add: Ajouter
   add_new: Ajouter
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: J'ai déjà un compte
   are_you_sure: Êtes-vous sûr ?
   back: Retour
   back_to_all_blog_posts: Retour à tous les articles
-  blog: Blog
+  blog:
   brand: Marque
   buy_now: Acheter maintenant
   cancel: Annuler
@@ -19,7 +19,7 @@ fr:
   charge_level: Niveau de charge
   charged: chargé
   charging: En cours de chargement
-  claim_plus_trial: Claim 6 Months Free
+  claim_plus_trial:
   close: Fermer
   confirm_change_password: Changer mon mot de passe
   confirm_password: Confirmer le nouveau mot de passe
@@ -35,7 +35,7 @@ fr:
   developer_edition_required: Édition développeur nécessaire pour activer cette fonctionnalité.
   device_id: ID de l'appareil
   device: Appareil
-  discard: Discard
+  discard:
   edit: Modifier
   email_address: Adresse email
   export: Exporter
@@ -43,7 +43,7 @@ fr:
   first_name: Prénom
   forgot_password: J'ai oublié mon mot de passe
   forgot_password_title: Réinitialiser le mot de passe
-  friendly_id: Friendly ID
+  friendly_id:
   get_started: Commençons !
   hidden: masqué
   identify: Identifier
@@ -67,23 +67,23 @@ fr:
   plugin_not_found: Plugin introuvable
   preview: Aperçu
   privacy: Confidentialité
-  refresh_rate: Refresh rate
+  refresh_rate:
   refresh_rates_hint: Apprenez comment le taux de rafraîchissement fonctionne __ici__.
   reset_password: Réinitialiser mon mot de passe
-  reset_to_defaults: Reset to defaults
+  reset_to_defaults:
   required: Requis
   save: Enregistrer
   shown: affiché
-  section: Section
+  section:
   settings: Paramètres
   sign_in: S'identifier
   sign_up: S'inscrire
   something_went_wrong: Une erreur est survenue
   status: Statut
   subscribe: S'abonner
-  help_center: Support
+  help_center:
   terms: Conditions
-  unsaved_changes: You have unsaved changes
+  unsaved_changes:
   update: Mise à jour
   view: Vue
   collaboration_request: Envie de collaborer ?
@@ -112,8 +112,8 @@ fr:
           one: "%{count} seconde"
           other: "%{count} secondes"
         x_minutes:
-          one: "%{count} minute"
-          other: "%{count} minutes"
+          one:
+          other:
         about_x_hours:
           one: environ une heure
           other: environ %{count} heures
@@ -161,24 +161,24 @@ fr:
       email_address_hint: Utilisé pour s'identifier dans TRMNL et recevoir des messages du système.
       first_name_hint: Nous utilisons votre prénom pour rendre l'interface de TRMNL plus agréable.
       last_name_hint: Nous utilisons votre nom pour rendre l'interface de TRMNL plus agréable.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: Utilisé pour protéger votre compte TRMNL.
       enable_2fa: Activer l'authentification à 2 facteurs (A2F) ?
       enable_2fa_hint: __Cliquer ici__ pour activer le mot de passe à usage unique (OTP).
       disable_2fa: Désactiver l'authentification à 2 facteurs (A2F)
       disable_2fa_hint: Fournissez un OTP valide et votre mot de passe actuel pour désactiver l'A2F.
       plus_subscription: Abonnement TRMNL+
-      plus_subscription_trial_until: You're on a free trial until %{plus_trial_end_at}.
+      plus_subscription_trial_until:
       plus_subscription_hint: Débloquez des taux de rafraîchissement plus rapides et des limites de débit plus élevées. __En savoir plus__.
       plus_subscription_modify: Voulez-vous mettre à jour votre moyen de paiement ou annuler ?
-      session: Session
+      session:
       session_hint: Vous êtes connecté en tant que %{user}
       show_title_bar: Afficher la barre de titre
       show_title_bar_hint: Si cette option est désactivée, les plugins natifs (non globaux) et les plugins tiers seront minimisés.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
+      theme_hint:
       time_zone: Fuseau horaire
       time_zone_hint: Détermine les taux de rafraîchissement et le temps de veille de l'appareil.
-      locale: Locale
+      locale:
       locale_hint: Quel langage et localisation préférez-vous ? __Voir ici__.
     update:
       success: Profil mis à jour avec succès
@@ -204,7 +204,7 @@ fr:
       cta: Accéder aux playlists
       pieces_of_content_displayed: Éléments affichés
     plugins:
-      title: Plugins
+      title:
       cta: Accéder aux plugins
       connected: Connectés
       new_and_popular: Récents et populaires
@@ -215,10 +215,10 @@ fr:
       title: Temps économisé
       cta: À propos
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: Bonjour
       afternoon_salutation: Bonjour
@@ -233,9 +233,9 @@ fr:
       battery_consumption_hint: Économisez de l'énergie et appréciez une meilleure durée de vie de la batterie en activant le Mode Veille.
       battery_learn_more: En savoir plus sur la charge de la batterie __ici__.
       battery_refresh: Rafraîchir
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      click:
+      click_action:
+      controls:
       developer_perks: Avantages pour les développeurs
       developer_perks_hint: Les options ci-dessous requièrent le __complément payant Developer__.
       device_credentials: Identifiants de l'appareil
@@ -245,23 +245,23 @@ fr:
       device_model: Modèle d'appareil
       device_model_hint: Le modèle de votre appareil
       device_model_switch_warning: Cette opération est dangereuse, en savoir plus __ici__
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
-      display_calibration: Display Calibration
-      display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
-      display_calibration_pixel_ratio: Pixel Ratio
-      display_calibration_pixel_ratio_hint: 'Image zoom level (0.5–3.0). Default:'
-      display_calibration_ui_scale: UI Scale
-      display_calibration_ui_scale_hint: 'Text and element sizes (0.5–2.0). Default:'
+      device_info:
+      current_firmware:
+      last_ping:
+      unknown:
+      never:
+      display_calibration:
+      display_calibration_hint:
+      display_calibration_pixel_ratio:
+      display_calibration_pixel_ratio_hint:
+      display_calibration_ui_scale:
+      display_calibration_ui_scale_hint:
       edit_device: Modifier l'appareil
-      firmware: Firmware
+      firmware:
       firmware_updates_enabled: Mises à jour activées
       firmware_updates_disabled: Mises à jour désactivées
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family:
+      font_family_hint:
       guest_mode: Mode invité
       guest_mode_hint: Choisissez ce qui s'affiche (et pendant combien de temps) quand le mode invité est activé.
       guest_mode_item_placeholder: Choisir un élément
@@ -269,18 +269,18 @@ fr:
       identify: Identifier
       identify_device: Identifier l'appareil
       identify_device_hint: Cliquez sur le bouton ci-dessous pour afficher un écran sur cet appareil qui vous aidera à l'identifier.
-      logs: Logs
+      logs:
       logs_hint: Débugguez votre appareil et plugins avec des logs d'erreurs en temps réel.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
       low_battery_email_notification: Notification par e-mail de batterie faible
       low_battery_email_notification_hint: Recevez une notification par e-mail lorsque la batterie de votre appareil est faible.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: Synchroniser
       mirror_device: Synchroniser avec un autre appareil
       mirror_device_hint: Ajoutez un identifiant (partageable) pour synchroniser vos playlists avec un autre appareil. Vos playlists resteront toujours visibles.
@@ -294,12 +294,12 @@ fr:
       maximum_compatibility: Activer la compatibilité maximale
       maximum_compatibility_hint: Résout les problèmes d'affichage causés par certaines puces de pilote ePaper. Désactive le rafraîchissement rapide. Firmware 1.6.0+ requis.
       color_and_rotation: Couleur & Rotation
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Rotation de l'écran
       screen_rotation_not_supported: La rotation de l'écran n'est pas actuellement prise en charge sur votre appareil.
-      palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
-      presentation: Presentation
+      palette:
+      palette_hint:
+      presentation:
       sleep_mode: Mode Veille
       sleep_mode_hint: Ajustez la fréquence de rafraîchissement pour réduire les distractions et augmenter l'autonomie de la batterie.
       sleep_screen: Écran de veille
@@ -310,16 +310,16 @@ fr:
       special_function_learn_more: En savoir plus sur les actions spéciales __ici__.
       temperature_profile: Profil de température
       temperature_profile_hint: Ne changez pas sauf instruction contraire. Pour les écrans aux images délavées.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
+      touchbar_mode:
+      touchbar_mode_hint:
       tidbyt_credentials: Identifiants Tidbyt
       tidbyt_credentials_hint: Entrez les identifiants API de votre appareil Tidbyt depuis l'app Tidbyt sous Paramètres → Développeur → Obtenir la clé API.
-      tidbyt_api_key: Tidbyt API Key
+      tidbyt_api_key:
       tidbyt_credentials_invalid: Les identifiants API Tidbyt sont invalides. Veuillez vérifier et réessayer.
       tidbyt_device_id: ID de l'appareil
       tidbyt_device_api_key: Clé API
       unlink: Dissocier
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm:
       unlink_device: Dissocier l'appareil
       unlink_device_hint: Dissocier un appareil TRMNL permet de le revendre ou de le donner en toute sécurité.
       unlink_device_learn_more: Suivez le guide complet __ici__.
@@ -333,41 +333,41 @@ fr:
         warning_2: Je comprends qu'il s'agit d'une opération <strong>risquée</strong> qui peut endommager mon appareil.
         cta: Mettre à niveau vers TRMNL OG (2 bits)
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Appareils
       tagline: Vos appareils TRMNL
       add_device_modal_title: Ajouter un nouvel appareil
       add_first_device: Commencez en ajoutant votre premier appareil !
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: Ajouter un nouvel appareil
       description: Entrez votre ID d'appareil pour ajouter un nouveau TRMNL à votre compte.
@@ -379,8 +379,8 @@ fr:
       error: Erreur lors de la dissociation de l'appareil
       success: Appareil dissocié avec succès
     external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
+      error:
+      success:
     identify:
       error: Erreur lors de l'identification de l'appareil
       success: Appareil identifié avec succès
@@ -393,54 +393,54 @@ fr:
     switch:
       error: Erreur lors du changement d'appareil
       success: Appareil changé avec succès
-      title: Switch to device
+      title:
     update:
       error: Erreur lors de la mise à jour de l'appareil
       success: "%{device} mis à jour avec succès"
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: Trop de tentatives, veuillez patienter et réessayer
     invoice_not_found: Facture introuvable
   logs:
     index:
-      title: Logs
+      title:
       all: Tous
-      bulk_destroy: Bulk Destroy
+      bulk_destroy:
       dump: Message
-      id: ID
+      id:
       private_plugins: Plugins privés
-      source: Source
+      source:
       time: Heure
   markups:
     console_logs:
-      js_logs: JS Logs
+      js_logs:
     form:
       back_to_plugin_settings: Retour aux paramètres du plugin
       design_system: Utilisez notre système de design natif
       design_system_docs: Documentation système de design
       dirty_confirm: Vous avez des modifications non enregistrées. Êtes-vous sûr de vouloir quitter cette page ?
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: Modifier le balisage
       edit_markup_for_plugin: Modifier le balisage pour %{plugin_setting_name}
       edit_markup_please_save_first: Enregistrez avant de modifier le balisage
@@ -465,7 +465,7 @@ fr:
       no_variables_detected: Aucune variable détectée.
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: A2F désactivée
@@ -487,7 +487,7 @@ fr:
       error: Code OTP invalide
   playlist_items:
     index:
-      title: Playlist
+      title:
       tagline: Choisir ce qui est affiché
       add_a_group: Ajouter un groupe
       add_a_plugin: Ajouter un plugin
@@ -514,18 +514,18 @@ fr:
       remove_from_playlist: Retirer de la playlist
       hide_playlist: Masquer cet élément
       show_playlist: Afficher cet élément
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default:
+        external:
+        global:
+        mashup:
+        readonly:
     create:
       error: Échec de la mise à jour de la playlist
       success: Playlist mise à jour
@@ -544,11 +544,11 @@ fr:
       success: Ordre de la playlist mis à jour
   plugins:
     index:
-      title: Plugins
+      title:
       tagline: Qu'allez-vous afficher sur votre TRMNL ?
       available: Disponible
       connected: Connecté
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: Recettes
       recipes_hint: Plugins privés créés par des membres de la communauté pouvant être installés en 1 clic. __En apprendre plus__.
     search:
@@ -567,10 +567,10 @@ fr:
       tagline: Permettre à d'autres d'installer votre plugin.
       name: Nom
       category: Catégorie
-      category_hint: Hold cmd or ctrl to choose up to 3
+      category_hint:
       refresh_every: Intervalle de rafraîchissement pris en charge
       refresh_every_hint: L'intervalle de rafraîchissement le plus rapide que votre plugin peut prendre en charge.
-      description: Description
+      description:
       description_hint: Maximum 50 caractères
       icon: Icône
       icon_hint: 512x512px recommandé
@@ -589,7 +589,7 @@ fr:
       title: Modifier le plugin
       tagline: Mettre à jour les détails de votre plugin.
       name: Nom
-      description: Description
+      description:
   plugin_recipes:
     connected: Recette connectée
     connections:
@@ -598,19 +598,19 @@ fr:
     forks:
       one: Duplication
       other: Duplications
-    forked: Recipe forked
+    forked:
     new:
       error: Recette introuvable
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: Actif
     copy_are_you_sure: Êtes-vous sûr de vouloir copier ce paramètre ?
     delete_are_you_sure: Êtes-vous sûr de vouloir supprimer ce paramètre ?
     delete: Cela va entièrement supprimer les paramètres du plugin. Pour simplement masquer le plugin de votre appareil, supprimez-le plutôt de la playlist.
     inactive: Inactif
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: Aucun paramètre pour le plugin trouvé.
     not_supported: Non pris en charge sur l'appareil actuel
     refreshing_now_please_wait: Actualisation en cours, veuillez recharger cette page dans quelques secondes.
@@ -618,7 +618,7 @@ fr:
     form:
       active_hint: Afficher ou masquer cette instance de plugin sur votre appareil
       advanced_settings: Paramètres avancés
-      back_to_playlist: Back to Playlist
+      back_to_playlist:
       back_to_plugin: Retour à %{plugin}
       back_to_plugins: Retour aux plugins
       connect_with: Se connecter avec %{plugin}
@@ -634,9 +634,9 @@ fr:
       force_refresh_click_here: Cliquez ici
       force_refresh_click_here_hint: pour générer un nouvel écran immédiatement
       force_refresh_not_possible: Ce plugin ne peut pas être rafraîchi de force car le serveur TRMNL n'effectue pas le traitement d'image. Apprenez comment tester votre instance __ici__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: Plus d'informations sur ce plugin dans notre base de connaissances
       learn_more_fork: Ce plugin a été dupliqué à partir d'une Recette.
       learn_more_fork_original: Voir l'original
@@ -651,7 +651,7 @@ fr:
       linked_account_success: Lié avec succès à %{plugin_name}
       link_oauth: Lier un compte
       link_oauth_hint: Avant de continuer, suivez la procédure d'autorisation sécurisée fournie par %{plugin}
-      mirrored: Mirrored
+      mirrored:
       multiple_instances_hint: Ce plugin prend en charge plusieurs instances.
       name: Nom
       name_hint: Donnez-lui un nom pour l'identifier plus facilement
@@ -669,10 +669,10 @@ fr:
       recipe_cta_body_in_review: Ce plugin a été soumis à notre équipe. Merci de patienter.
       recipe_cta_body_not_published: Soumettez ce plugin pour que d'autres puissent l'installer. __En savoir plus__.
       recipe_cta_confirm: Êtes-vous sûr ? Notre équipe va l'examiner et vous recontacter dans quelques jours. Vous pouvez continuer à apporter des modifications.
-      recipe_mirrored: This screen is mirrored from the recipe.
+      recipe_mirrored:
       recipe_visibility_title: Comment souhaitez-vous publier ?
       recipe_visibility_edit_title: Modifier la soumission
-      recipe_visibility_public: Public
+      recipe_visibility_public:
       recipe_visibility_public_hint: Tout le monde peut le trouver et l'installer.
       recipe_visibility_private: Privé
       recipe_visibility_private_hint: Interrompt les installations externes.
@@ -680,7 +680,7 @@ fr:
       recipe_visibility_unlisted_hint: Toute personne disposant du lien peut l'installer.
       refresh_rate: Taux de rafraîchissement
       refresh_rate_hint: Définit la fréquence à laquelle cette instance de plugin récupérera les nouvelles données
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
+      refresh_rate_jit_hint:
       refresh_rate_not_configurable: Synchronise %{refresh_rate} (non configurable)
       refreshed: Rafraîchi
       remove_plugin: Retirer le plugin
@@ -688,11 +688,11 @@ fr:
       synced: Synchronisé
       refresh_paused: Rafraîchissement en pause
       refresh_paused_hint: Le rafraîchissement automatique est en pause. Ajoutez à la playlist pour recommencer.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
+      refresh_paused_hidden_hint:
       refresh_paused_mashup: Rafraîchissement des combinaisons
       refresh_paused_mashup_hint: Rafraîchissement automatique en pause pour le plein écran. Les combinaisons se mettent à jour.
       refresh_stopped: Rafraîchissement automatique arrêté. Veuillez corriger l'erreur du plugin pour continuer.
-      view_recipe: View Recipe
+      view_recipe:
       visit_docs: Visiter la documentation
     import:
       archive_too_large: Le fichier ZIP est trop volumineux (%{max_mb} MB maximum)
@@ -701,7 +701,7 @@ fr:
       malformed: "%{filename} est corrompu"
     create:
       success: Plugin créé et ajouté à votre
-      playlist: playlist
+      playlist:
     destroy:
       success: Plugin supprimé
     handle_canceled_consent: Consentement retiré, veuillez réessayer
@@ -727,7 +727,7 @@ fr:
       some_schedule: Afficher cet écran uniquement pendant…
       to: à
       copy_prompt: Copier l'horaire depuis…
-      no_days_error: Please select at least one day.
+      no_days_error:
   upgrade:
     index:
       title: 'Mise à niveau de l''appareil :'

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -1,99 +1,99 @@
 ---
 he:
   locale_name: Hebrew
-  about: About
-  actions: Actions
-  add: Add
-  add_new: Add new
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
-  already_have_account: I already have an account
-  are_you_sure: Are you sure?
-  back: Back
-  back_to_all_blog_posts: Back to all posts
-  blog: Blog
-  brand: Brand
-  buy_now: Buy Now
-  cancel: Cancel
-  change_password: Change Password
-  charge_level: Charge Level
-  charged: charged
-  charging: Charging
-  claim_plus_trial: Claim 6 Months Free
-  close: Close
-  confirm_change_password: Change my password
-  confirm_password: Confirm new password
-  copy: Copy
-  copied_to_clipboard: Copied!
-  copy_to_clipboard: Copy to clipboard
-  created: Created
-  create_an_account: Create an account
-  current_device: Current device
-  days: days
-  delete: Delete
-  developers: Developers
-  developer_edition_required: Developer edition is required to enable this feature.
-  device_id: Device ID
-  device: Device
-  discard: Discard
+  about:
+  actions:
+  add:
+  add_new:
+  ai_assistant:
+  ai_assistant_hint:
+  already_have_account:
+  are_you_sure:
+  back:
+  back_to_all_blog_posts:
+  blog:
+  brand:
+  buy_now:
+  cancel:
+  change_password:
+  charge_level:
+  charged:
+  charging:
+  claim_plus_trial:
+  close:
+  confirm_change_password:
+  confirm_password:
+  copy:
+  copied_to_clipboard:
+  copy_to_clipboard:
+  created:
+  create_an_account:
+  current_device:
+  days:
+  delete:
+  developers:
+  developer_edition_required:
+  device_id:
+  device:
+  discard:
   edit: Settings
-  email_address: Email address
-  export: Export
-  fetching: Fetching
-  first_name: First Name
-  forgot_password: I forgot my password
-  forgot_password_title: Here we go again
-  friendly_id: Friendly ID
-  get_started: Let's get you started!
-  hidden: hidden
-  identify: Identify
-  import: Import
-  import_new: Import new
-  integrations: Integrations
-  keep_me_signed_in: Keep me signed in
-  knowledge_base: Knowledge base
-  last_name: Last Name
-  learn_more: Learn more
-  loading: Loading
-  login: Login
-  log_out: Log out
-  manage: Manage
-  minimum_characters: characters minimum
-  mins: mins
-  my_playlist: My Playlist
-  new_password: New password
-  password: Password
-  please_wait: Please Wait...
-  plugin_not_found: Plugin not found
-  preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
-  refresh_rates_hint: Learn how refresh rates work __here__.
-  reset_password: Reset my password
-  reset_to_defaults: Reset to defaults
-  required: Required
-  save: Save
-  shown: shown
-  section: Section
-  settings: Settings
-  sign_in: Sign in
-  sign_up: Sign up
-  something_went_wrong: Something went wrong
-  status: Status
-  subscribe: Subscribe
-  help_center: Support
-  terms: Terms
-  unsaved_changes: You have unsaved changes
-  update: Update
-  view: View
-  collaboration_request: Wanna collaborate?
-  collaboration_request_hint: Partnerships, group sales, special projects, your call.
-  collaboration_request_cta: Let's talk
-  welcome: Welcome
+  email_address:
+  export:
+  fetching:
+  first_name:
+  forgot_password:
+  forgot_password_title:
+  friendly_id:
+  get_started:
+  hidden:
+  identify:
+  import:
+  import_new:
+  integrations:
+  keep_me_signed_in:
+  knowledge_base:
+  last_name:
+  learn_more:
+  loading:
+  login:
+  log_out:
+  manage:
+  minimum_characters:
+  mins:
+  my_playlist:
+  new_password:
+  password:
+  please_wait:
+  plugin_not_found:
+  preview:
+  privacy:
+  refresh_rate:
+  refresh_rates_hint:
+  reset_password:
+  reset_to_defaults:
+  required:
+  save:
+  shown:
+  section:
+  settings:
+  sign_in:
+  sign_up:
+  something_went_wrong:
+  status:
+  subscribe:
+  help_center:
+  terms:
+  unsaved_changes:
+  update:
+  view:
+  collaboration_request:
+  collaboration_request_hint:
+  collaboration_request_cta:
+  welcome:
   time:
     formats:
       shorter: "%-H:%M"
-    start_of_week: 0
+    start_of_week:
   datetime:
     relative:
       past: לפני %{time}
@@ -137,602 +137,602 @@ he:
           other: כמעט %{count} שנים
   account:
     index:
-      title: Account
-      tagline: Manage your account settings
-      api_key_confirm: Are you sure you want to regenerate your API Key? The old key will be invalidated.
-      api_key_hint: See __the docs__ to learn how to configure your local environment.
-      api_key_label: The credential for authenticating local development tools
-      api_key_not_generated: "(none yet)"
-      api_key_reset: Regenerate
+      title:
+      tagline:
+      api_key_confirm:
+      api_key_hint:
+      api_key_label:
+      api_key_not_generated:
+      api_key_reset:
       api_key: API Key
-      beta_features: Beta Features
-      beta_features_hint: Try out new stuff here. Options may disappear at any time.
-      discord_community: Discord Community
-      discord_username: What's your Discord username?
-      discord_username_hint: May be used for support, attribution on published Recipes, etc.
-      email_address: Email Address
-      refer_and_earn: Refer and Earn
-      refer_and_earn_hint: Give the gift of TRMNL with a personalized coupon. Earn per use, paid monthly.
-      refer_and_earn_redemptions: Redemptions
-      refer_and_earn_request_code: Request a Code
-      device_invoice: Device Invoice
-      device_invoice_label: Download commercial documents for your accountant or (weird) PDF collection.
-      device_invoice_hint: Find this on your package tracking page or shipment notification email.
-      email_address_hint: Used to sign into TRMNL and receive system messages.
-      first_name_hint: We use your name to make the TRMNL interface more comfortable.
-      last_name_hint: We use your name to make the TRMNL interface more comfortable.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
-      password_hint: Used to protect your TRMNL account.
-      enable_2fa: Enable 2FA?
-      enable_2fa_hint: __Click here__ to enable OTP.
-      disable_2fa: Disable 2FA
-      disable_2fa_hint: Provide valid OTP and current password above to disable this feature.
-      plus_subscription: TRMNL+ Subscription
-      plus_subscription_trial_until: You're on a free trial until %{plus_trial_end_at}.
-      plus_subscription_hint: Unlock faster refresh rates and higher rate limits. __Learn more__.
-      plus_subscription_modify: Want to update your payment method or cancel?
-      session: Session
-      session_hint: You're logged in as %{user}
-      show_title_bar: Show title bar
-      show_title_bar_hint: If disabled, native (non global) and third party plugins will be more minimal.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
-      time_zone: Time Zone
-      time_zone_hint: Determines refresh rates and device sleep time.
-      locale: Locale
-      locale_hint: What language and localization do you prefer? __Go here__.
+      beta_features:
+      beta_features_hint:
+      discord_community:
+      discord_username:
+      discord_username_hint:
+      email_address:
+      refer_and_earn:
+      refer_and_earn_hint:
+      refer_and_earn_redemptions:
+      refer_and_earn_request_code:
+      device_invoice:
+      device_invoice_label:
+      device_invoice_hint:
+      email_address_hint:
+      first_name_hint:
+      last_name_hint:
+      github_username_hint:
+      password_hint:
+      enable_2fa:
+      enable_2fa_hint:
+      disable_2fa:
+      disable_2fa_hint:
+      plus_subscription:
+      plus_subscription_trial_until:
+      plus_subscription_hint:
+      plus_subscription_modify:
+      session:
+      session_hint:
+      show_title_bar:
+      show_title_bar_hint:
+      theme_hint:
+      time_zone:
+      time_zone_hint:
+      locale:
+      locale_hint:
     update:
-      success: Profile updated successfully
+      success:
     reset_api_key:
-      success: API key was regenerated successfully
+      success:
   dashboard:
     index:
-      title: Dashboard
-      last_7_days: Last 7 days
-      last_30_days: Last 30 days
-      last_90_days: Last 90 days
-      today: Today
-      yesterday: Yesterday
+      title:
+      last_7_days:
+      last_30_days:
+      last_90_days:
+      today:
+      yesterday:
     health:
-      bad: Plugins are experiencing issues
-      good: Plugins are healthy
-      next_steps: We will inform you if anything changes
+      bad:
+      good:
+      next_steps:
     news:
-      title: News
-      cta: View All
+      title:
+      cta:
     playlist_items:
-      title: Playlist
-      cta: Edit Playlist
-      pieces_of_content_displayed: Pieces of content displayed
+      title:
+      cta:
+      pieces_of_content_displayed:
     plugins:
-      title: Plugins
-      cta: Go to Plugins
-      connected: Connected
-      new_and_popular: New and Popular
+      title:
+      cta:
+      connected:
+      new_and_popular:
     shop:
-      title: Shop
-      need_another: Need another TRMNL?
+      title:
+      need_another:
     time_saved:
-      title: Time saved
-      cta: Read about
+      title:
+      cta:
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
-      morning_salutation: Good morning
-      afternoon_salutation: Good afternoon
-      evening_salutation: Good evening
+      morning_salutation:
+      afternoon_salutation:
+      evening_salutation:
   devices:
     edit:
-      accepts_beta_firmware: Firmware Early Release
-      accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
-      back_to_devices: Back to Devices
-      battery_and_sleep: Battery & Sleep
-      battery_consumption: Battery Consumption
-      battery_consumption_hint: Save power and enjoy a longer battery life by enabling Sleep Mode.
-      battery_learn_more: Learn more about battery charging __here__.
-      battery_refresh: Refresh
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
-      developer_perks: Developer Perks
+      accepts_beta_firmware:
+      accepts_beta_firmware_hint:
+      back_to_devices:
+      battery_and_sleep:
+      battery_consumption:
+      battery_consumption_hint:
+      battery_learn_more:
+      battery_refresh:
+      click:
+      click_action:
+      controls:
+      developer_perks:
       developer_perks_hint: Options below require the __Developer add-on__.
-      device_credentials: Device Credentials
-      device_credentials_hint: See what you can do with these credentials __here__
-      device_name: Device Name
-      device_name_hint: We use this to make the TRMNL interface more comfortable
-      device_model: Device Model
-      device_model_hint: Your hardware Model
-      device_model_switch_warning: This is a dangerous operation, learn more __here__
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
-      display_calibration: Display Calibration
-      display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
-      display_calibration_pixel_ratio: Pixel Ratio
-      display_calibration_pixel_ratio_hint: 'Image zoom level (0.5–3.0). Default:'
-      display_calibration_ui_scale: UI Scale
-      display_calibration_ui_scale_hint: 'Text and element sizes (0.5–2.0). Default:'
-      edit_device: Edit Device
-      firmware: Firmware
-      firmware_updates_enabled: Updates enabled
-      firmware_updates_disabled: Updates disabled
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
-      guest_mode: Guest Mode
-      guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
-      guest_mode_item_placeholder: Choose an item
-      guest_mode_duration_placeholder: Choose a duration
-      identify: Identify
-      identify_device: Identify Device
-      identify_device_hint: Click the button below to generate a screen on this device that helps identify it.
-      logs: Logs
-      logs_hint: Debug your device and plugins with a live feed of raw error logs.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
-      low_battery_email_notification: Low Battery Email Notification
-      low_battery_email_notification_hint: Get notified via email when your device battery is running low.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
-      mirror: Mirror
-      mirror_device: Mirror another Device
-      mirror_device_hint: Provide a (shareable) Device ID to mirror its playlist. Your playlist will still be displayed.
-      mirror_disabled: Mirroring disabled
-      mirror_enabled: Mirroring
-      mirror_stop: Disconnect Mirroring
-      mirror_sync: Sync Screens
-      ota_enabled: OTA Updates Enabled
-      ota_enabled_hint: Automatically install new firmware. Disable to use your own firmware.
-      ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
-      maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
-      color_and_rotation: Color & Rotation
-      image_rotation: Image Rotation
-      screen_rotation: Screen Rotation
-      screen_rotation_not_supported: Screen rotation is currently not supported on your device.
-      palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
-      presentation: Presentation
-      sleep_mode: Sleep Mode
-      sleep_mode_hint: Adjust your refresh rate to optimize focus and battery life.
-      sleep_screen: Sleep Screen
-      sleep_screen_tooltip: Enable Sleep Mode to use this feature
-      sleep_screen_hint: Display a sleep screen during sleep mode hours.
-      special_function: Special Function
-      special_function_hint: Set a custom feature for the button on the back of your device.
+      device_credentials:
+      device_credentials_hint:
+      device_name:
+      device_name_hint:
+      device_model:
+      device_model_hint:
+      device_model_switch_warning:
+      device_info:
+      current_firmware:
+      last_ping:
+      unknown:
+      never:
+      display_calibration:
+      display_calibration_hint:
+      display_calibration_pixel_ratio:
+      display_calibration_pixel_ratio_hint:
+      display_calibration_ui_scale:
+      display_calibration_ui_scale_hint:
+      edit_device:
+      firmware:
+      firmware_updates_enabled:
+      firmware_updates_disabled:
+      font_family:
+      font_family_hint:
+      guest_mode:
+      guest_mode_hint:
+      guest_mode_item_placeholder:
+      guest_mode_duration_placeholder:
+      identify:
+      identify_device:
+      identify_device_hint:
+      logs:
+      logs_hint:
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
+      low_battery_email_notification:
+      low_battery_email_notification_hint:
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
+      mirror:
+      mirror_device:
+      mirror_device_hint:
+      mirror_disabled:
+      mirror_enabled:
+      mirror_stop:
+      mirror_sync:
+      ota_enabled:
+      ota_enabled_hint:
+      ota_byod_not_supported:
+      maximum_compatibility:
+      maximum_compatibility_hint:
+      color_and_rotation:
+      image_rotation:
+      screen_rotation:
+      screen_rotation_not_supported:
+      palette:
+      palette_hint:
+      presentation:
+      sleep_mode:
+      sleep_mode_hint:
+      sleep_screen:
+      sleep_screen_tooltip:
+      sleep_screen_hint:
+      special_function:
+      special_function_hint:
       special_function_learn_more: Learn more about special functions __here__.
-      temperature_profile: Temperature Profile
-      temperature_profile_hint: Don't change unless instructed. For displays with washed out images.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
-      tidbyt_credentials: Tidbyt Credentials
-      tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
-      tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
-      tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
-      unlink: Unlink
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
-      unlink_device: Unlink Device
+      temperature_profile:
+      temperature_profile_hint:
+      touchbar_mode:
+      touchbar_mode_hint:
+      tidbyt_credentials:
+      tidbyt_credentials_hint:
+      tidbyt_api_key:
+      tidbyt_credentials_invalid:
+      tidbyt_device_id:
+      tidbyt_device_api_key:
+      unlink:
+      unlink_confirm:
+      unlink_device:
       unlink_device_hint: Unlinking a TRMNL device makes it safe to re-sell or give to someone else.
-      unlink_device_learn_more: Follow the full guide __here__.
-      visibility: Visibility
-      visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
-      your_device: Your TRMNL
+      unlink_device_learn_more:
+      visibility:
+      visibility_hint:
+      your_device:
       upgrade_og:
-        title: Upgrade to 2-bit Display Available
-        sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
-        warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
-        warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
-        cta: Upgrade to TRMNL OG (2-bit)
+        title:
+        sub_title:
+        warning_1:
+        warning_2:
+        cta:
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
-      title: Devices
-      tagline: Your TRMNL devices
-      add_device_modal_title: Add a new device
-      add_first_device: Start by adding your first device!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      title:
+      tagline:
+      add_device_modal_title:
+      add_first_device:
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
-      title: Add a new device
-      description: Enter your Friendly ID to add a new device to your account.
-      add_device: Add new device
+      title:
+      description:
+      add_device:
     associate:
-      error: Error linking device
-      success: Device successfully linked
+      error:
+      success:
     dissociate:
-      error: Error disconnecting device
-      success: Device successfully unlinked
+      error:
+      success:
     external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
+      error:
+      success:
     identify:
-      error: Error updating device
-      success: Device identification requested
+      error:
+      success:
     mirror:
-      error: Error mirroring device
-      error_not_shared: Provided Device ID is not shareable
-      error_oneself: Can't mirror oneself
-      success: Device %{friendly_id} successfully mirrored
-      success_removed: Mirroring Removed
+      error:
+      error_not_shared:
+      error_oneself:
+      success:
+      success_removed:
     switch:
-      error: Error switching device
-      success: Device switched successfully
-      title: Switch to device
+      error:
+      success:
+      title:
     update:
-      error: Error updating device
-      success: "%{device} device settings updated successfully"
+      error:
+      success:
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
-    rate_limit: Too many attempts, please wait and try again
-    invoice_not_found: Invoice not found
+    rate_limit:
+    invoice_not_found:
   logs:
     index:
-      title: Logs
-      all: All
-      bulk_destroy: Bulk Destroy
-      dump: Dump
-      id: ID
-      private_plugins: Private Plugins
-      source: Source
-      time: Time
+      title:
+      all:
+      bulk_destroy:
+      dump:
+      id:
+      private_plugins:
+      source:
+      time:
   markups:
     console_logs:
-      js_logs: JS Logs
+      js_logs:
     form:
-      back_to_plugin_settings: Back to plugin settings
-      design_system: Leverage our native design system
-      design_system_docs: Design System Docs
-      dirty_confirm: You have unsaved changes. Are you sure you want to leave this page?
-      edit_composition: Edit Composition
-      edit_markup: Edit Markup
-      edit_markup_for_plugin: Edit markup for %{plugin_setting_name}
-      edit_markup_please_save_first: Please save before editing markup
-      edit_markup_without_preview: Edit Markup (without preview)
-      error_rendering_markup: Error rendering that markup
-      fix_indentation: Fix indentation
-      go_to_preview: Go To Preview
-      live_preview: Live Preview
-      no_changes_to_save: No changes to save
-      pop_out_preview: Pop Out Preview
-      quickstart_examples: Quick-start Examples
-      quickstart_example_applied: Applied!
-      quickstart_use_this_example: Use this example
-      revert: Revert
-      revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
-      save_changes: Save Changes (⌘﹢S)
-      separate_preview: Preview is open in a separate window
+      back_to_plugin_settings:
+      design_system:
+      design_system_docs:
+      dirty_confirm:
+      edit_composition:
+      edit_markup:
+      edit_markup_for_plugin:
+      edit_markup_please_save_first:
+      edit_markup_without_preview:
+      error_rendering_markup:
+      fix_indentation:
+      go_to_preview:
+      live_preview:
+      no_changes_to_save:
+      pop_out_preview:
+      quickstart_examples:
+      quickstart_example_applied:
+      quickstart_use_this_example:
+      revert:
+      revert_confirm:
+      save_changes:
+      separate_preview:
     merge_variables:
-      your_variables: Your variables
+      your_variables:
     no_merge_variables:
-      force_refresh: If you've provided variables but they aren't being detected, try a __force refresh__.
-      no_variables_detected: No variables detected.
+      force_refresh:
+      no_variables_detected:
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
-      success: 2FA Disabled
-      invalid_otp: Invalid OTP
-      invalid_password: Invalid Password
-      invalid_otp_and_password: Invalid OTP and Password
+      success:
+      invalid_otp:
+      invalid_password:
+      invalid_otp_and_password:
     enable_otp:
-      input_otp: Enter OTP
-      submit: Verify and Enable
-      already_enabled: 2FA is already enabled
+      input_otp:
+      submit:
+      already_enabled:
     enable_otp_verify:
-      success: 2FA Enabled
-      error: Invalid OTP code
+      success:
+      error:
     verify_otp:
-      verify: Verify
-      reset: Reset MFA
-      reset_instructions: Click the button on the back of your TRMNL to generate a reset code
-      success: 2FA successful
-      error: Invalid OTP code
+      verify:
+      reset:
+      reset_instructions:
+      success:
+      error:
   playlist_items:
     index:
-      title: Playlist
-      tagline: Choose what's shown on
-      add_a_group: Add a Group
-      add_a_plugin: Add a Plugin
-      add_first_device_cta: Start by __adding__ your first TRMNL device!
+      title:
+      tagline:
+      add_a_group:
+      add_a_plugin:
+      add_first_device_cta:
       add_to_playlist: Add to Playlist
       create_first_playlist_cta: Create your playlist after __connecting__ your first plugin!
-      custom: Custom
-      device_default: Device default
-      display_period_from: Display from
-      display_period_to: to
-      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
-      never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
+      custom:
+      device_default:
+      display_period_from:
+      display_period_to:
+      display_period_validation:
+      every:
+      never_skip:
+      smart_playlist:
+      smart_playlist_hint:
       skip_after:
-        one: Skip stale screens after 1 day
-        other: Skip stale screens after %{count} days
+        one:
+        other:
     playlist_item:
-      adjust_schedule: Adjust schedule
-      delete: Are you sure you want to remove this item? The plugin will remain connected, just not shown on your device.
-      displayed_now: Displayed now
-      not_displayed_yet: Not displayed yet
-      remove_from_playlist: Remove from playlist
-      hide_playlist: Hide this item
-      show_playlist: Show this item
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      adjust_schedule:
+      delete:
+      displayed_now:
+      not_displayed_yet:
+      remove_from_playlist:
+      hide_playlist:
+      show_playlist:
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default:
+        external:
+        global:
+        mashup:
+        readonly:
     create:
       error: Failed to update playlist
-      success: Playlist updated
+      success:
     destroy:
-      error: Error removing item from playlist
+      error:
       success: Plugin removed from Playlist
     toggle_visibility:
-      success: Playlist item %{change}
+      success:
     duplicate:
       success: Playlist duplicated
     sort:
-      success: Playlist order updated
+      success:
     set_preferences:
       success: Smart playlist preference updated
     update:
-      success: Playlist order updated
+      success:
   plugins:
     index:
-      title: Plugins
-      tagline: What will you put on your TRMNL?
-      available: Available
-      connected: Connected
-      supported_by_this_device: Supported by this device
-      recipes: Recipes
-      recipes_hint: Private plugins by community members that can be installed in 1 click. __Learn more__.
+      title:
+      tagline:
+      available:
+      connected:
+      supported_by_this_device:
+      recipes:
+      recipes_hint:
     search:
-      placeholder: Search Plugins
+      placeholder:
     my:
       index:
-        title: My Plugins
-        tagline: Develop Plugins for the public marketplace
+        title:
+        tagline:
       card:
-        connections: connections
-        install: Install
-        review_are_you_sure: Are you sure? The TRMNL team will test it and email you any questions.
-        submit_for_review: Submit for Review
+        connections:
+        install:
+        review_are_you_sure:
+        submit_for_review:
     new:
-      title: Create New Plugin
-      tagline: Other users will be able to install your plugin.
-      name: Name
-      category: Category
-      category_hint: Hold cmd or ctrl to choose up to 3
-      refresh_every: Supported Refresh Interval
-      refresh_every_hint: The fastest refresh interval your plugin can support.
-      description: Description
-      description_hint: Maximum 50 characters
-      icon: Icon
-      icon_hint: 512x512px recommended
-      installation_url: Installation URL
-      installation_url_hint: Learn more about the installation flow __here__.
-      installation_success_webhook_url: Installation Success Webhook URL
-      knowledge_base_url: Knowledge Base URL
-      management_url: Plugin Management URL
-      management_url_hint: Learn more about the management flow __here__.
-      markup_url: Plugin Markup URL
-      markup_url_hint: Learn more about screen generation __here__.
-      no_screen_padding: No Screen Padding
-      no_screen_padding_hint: Removes the outermost padding in fullscreen mode.
-      uninstallation_webhook_url: Uninstallation Webhook URL
+      title:
+      tagline:
+      name:
+      category:
+      category_hint:
+      refresh_every:
+      refresh_every_hint:
+      description:
+      description_hint:
+      icon:
+      icon_hint:
+      installation_url:
+      installation_url_hint:
+      installation_success_webhook_url:
+      knowledge_base_url:
+      management_url:
+      management_url_hint:
+      markup_url:
+      markup_url_hint:
+      no_screen_padding:
+      no_screen_padding_hint:
+      uninstallation_webhook_url:
     edit:
-      title: Edit Plugin
-      tagline: Update your plugin details.
-      name: Name
-      description: Description
+      title:
+      tagline:
+      name:
+      description:
   plugin_recipes:
-    connected: Recipe connected
+    connected:
     connections:
-      one: Connection
-      other: Connections
+      one:
+      other:
     forks:
-      one: Fork
-      other: Forks
-    forked: Recipe forked
+      one:
+      other:
+    forked:
     new:
-      error: Recipe not found
+      error:
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
-    active: Active
-    copy_are_you_sure: Are you sure you want to copy this setting?
-    delete_are_you_sure: Are you sure you want to delete this setting?
+    active:
+    copy_are_you_sure:
+    delete_are_you_sure:
     delete: This will completely remove the plugin's settings. To simply hide this plugin from your device, delete it from your Playlist instead.
-    inactive: Inactive
-    no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: No plugin settings found.
-    not_supported: Not supported on current device
-    refreshing_now_please_wait: Refreshing now, reload this page in a few seconds.
-    reset_credentials: "%{plugin_name} account reset successfully"
+    inactive:
+    no_matches_found:
+    no_plugin_settings_found:
+    not_supported:
+    refreshing_now_please_wait:
+    reset_credentials:
     form:
-      active_hint: Show or hide this plugin instance on your device
-      advanced_settings: Advanced Settings
-      back_to_playlist: Back to Playlist
-      back_to_plugin: Back to %{plugin}
-      back_to_plugins: Back to Plugins
-      connect_with: Connect with %{plugin}
-      debug_logs: Debug Logs
-      debug_logs_click_here: Click here
-      debug_logs_click_here_hint: to enable debug logs for this plugin instance.
-      debug_logs_enabled: Debug logs enabled for %{hours} hours.
-      debug_logs_enabled_link: View logs
-      disconnect_account: Disconnect Account
-      manage_plugin: Configure %{plugin}
-      force_refresh: Force Refresh
-      force_refresh_hint: This feature is designed for testing only - please do not abuse it.
-      force_refresh_click_here: Click here
-      force_refresh_click_here_hint: to generate a new screen immediately
-      force_refresh_not_possible: This plugin cannot be force-refreshed because the TRMNL server does not perform image processing. Learn how to test your instance __here__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
-      learn_more: Learn about this plugin in our knowledge base
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
-      learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
-      linked_account: Linked Account
-      linked_account_success: Successfully linked with %{plugin_name}
-      link_oauth: Link Account
-      link_oauth_hint: Before you continue, follow the secure authorization process provided by %{plugin}
-      mirrored: Mirrored
-      multiple_instances_hint: This plugin supports multiple instances.
-      name: Name
-      name_hint: Give it a name for easy reference
-      parse: Parse
-      parse_save_first: Parse (Save plugin first)
-      parsed: Parsed
-      plugin_uuid: Plugin UUID
-      plugin_uuid_hint: Use this to make Webhook API requests.
-      preview: Preview - your device will show actual data
+      active_hint:
+      advanced_settings:
+      back_to_playlist:
+      back_to_plugin:
+      back_to_plugins:
+      connect_with:
+      debug_logs:
+      debug_logs_click_here:
+      debug_logs_click_here_hint:
+      debug_logs_enabled:
+      debug_logs_enabled_link:
+      disconnect_account:
+      manage_plugin:
+      force_refresh:
+      force_refresh_hint:
+      force_refresh_click_here:
+      force_refresh_click_here_hint:
+      force_refresh_not_possible:
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
+      learn_more:
+      learn_more_fork:
+      learn_more_fork_original:
+      learn_more_native_long:
+      learn_more_native_short:
+      learn_more_recipe_author:
+      learn_more_recipe_long:
+      learn_more_recipe_short:
+      learn_more_third_party_long:
+      learn_more_third_party_short:
+      linked_account:
+      linked_account_success:
+      link_oauth:
+      link_oauth_hint:
+      mirrored:
+      multiple_instances_hint:
+      name:
+      name_hint:
+      parse:
+      parse_save_first:
+      parsed:
+      plugin_uuid:
+      plugin_uuid_hint:
+      preview:
       recipe_cta_heading_published: This plugin is a Recipe
-      recipe_cta_heading_unlisted: This plugin is unlisted
+      recipe_cta_heading_unlisted:
       recipe_cta_heading_in_review: Recipe in review
       recipe_cta_heading_not_published: Publish as a Recipe?
-      recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
-      recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
-      recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
-      recipe_mirrored: This screen is mirrored from the recipe.
-      recipe_visibility_title: How would you like to publish?
-      recipe_visibility_edit_title: Edit Submission
-      recipe_visibility_public: Public
-      recipe_visibility_public_hint: Anyone can find and install.
-      recipe_visibility_private: Private
-      recipe_visibility_private_hint: Breaks external installs.
-      recipe_visibility_unlisted: Unlisted
-      recipe_visibility_unlisted_hint: Anyone with the link can install.
-      refresh_rate: Refresh rate
-      refresh_rate_hint: Define how frequently this plugin instance fetches fresh data
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
-      refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
-      refreshed: Refreshed
-      remove_plugin: Remove plugin
-      remove_plugin_hint: Removing a plugin will also remove it from your playlist
-      synced: Synced
-      refresh_paused: Refresh Paused
-      refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
-      refresh_paused_mashup: Refreshing Mashups
-      refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
-      refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.
-      view_recipe: View Recipe
-      visit_docs: Visit Docs
+      recipe_cta_body_published:
+      recipe_cta_body_in_review:
+      recipe_cta_body_not_published:
+      recipe_cta_confirm:
+      recipe_mirrored:
+      recipe_visibility_title:
+      recipe_visibility_edit_title:
+      recipe_visibility_public:
+      recipe_visibility_public_hint:
+      recipe_visibility_private:
+      recipe_visibility_private_hint:
+      recipe_visibility_unlisted:
+      recipe_visibility_unlisted_hint:
+      refresh_rate:
+      refresh_rate_hint:
+      refresh_rate_jit_hint:
+      refresh_rate_not_configurable:
+      refreshed:
+      remove_plugin:
+      remove_plugin_hint:
+      synced:
+      refresh_paused:
+      refresh_paused_hint:
+      refresh_paused_hidden_hint:
+      refresh_paused_mashup:
+      refresh_paused_mashup_hint:
+      refresh_stopped:
+      view_recipe:
+      visit_docs:
     import:
-      archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
-      missing_entry: The ZIP file does not contain %{filename}
-      entry_too_large: "%{filename} is too large"
-      malformed: "%{filename} is malformed"
+      archive_too_large:
+      missing_entry:
+      entry_too_large:
+      malformed:
     create:
-      success: Plugin created and added to your
-      playlist: playlist
+      success:
+      playlist:
     destroy:
-      success: Plugin deleted
-    handle_canceled_consent: Consent canceled, please try again
+      success:
+    handle_canceled_consent:
     update:
-      success: Plugin configuration updated successfully
+      success:
     add_to_playlist:
       success: Plugin added to Playlist
   referral_code:
     create:
-      request_received: Request received, check your inbox
+      request_received:
   recipes:
     index:
-      newest_to_oldest: Newest to Oldest
-      oldest_to_newest: Oldest to Newest
-      most_popular: Most Popular
-      install: Install
-      fork: Fork
+      newest_to_oldest:
+      oldest_to_newest:
+      most_popular:
+      install:
+      fork:
   schedules:
     form:
-      add: Add a custom schedule
-      append: And during…
-      no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
-      to: to
-      copy_prompt: Copy schedule from…
-      no_days_error: Please select at least one day.
+      add:
+      append:
+      no_schedule:
+      some_schedule:
+      to:
+      copy_prompt:
+      no_days_error:
   upgrade:
     index:
-      title: 'Upgrading device:'
-      tagline: Unlock custom plugins and __more__.
-      pay: Pay
-      error: Device %{device_name} is already upgraded, switch to another device
+      title:
+      tagline:
+      pay:
+      error:
     confirm:
-      success: Developer edition add-on is now enabled
+      success:

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -1,25 +1,25 @@
 ---
 hu:
   locale_name: Magyar
-  about: About
-  actions: Actions
+  about:
+  actions:
   add: Hozzáadás
   add_new: Új hozzáadása
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: Már van fiókom
-  are_you_sure: Are you sure?
+  are_you_sure:
   back: Vissza
   back_to_all_blog_posts: Vissza az összes bejegyzéshez
-  blog: Blog
-  brand: Brand
+  blog:
+  brand:
   buy_now: Megveszem
   cancel: Mégsem
   change_password: Jelszó módosítása
   charge_level: Töltöttségi szint
   charged: Feltöltve
   charging: Töltés alatt
-  claim_plus_trial: Claim 6 Months Free
+  claim_plus_trial:
   close: Bezárás
   confirm_change_password: Jelszó megváltoztatása
   confirm_password: Új jelszó megerősítése
@@ -31,11 +31,11 @@ hu:
   current_device: Jelenlegi eszköz
   days: nap
   delete: Törlés
-  developers: Developers
+  developers:
   developer_edition_required: A funkció használatához fejlesztői kiadás szükséges.
   device_id: Eszközazonosító
   device: Eszköz
-  discard: Discard
+  discard:
   edit: Szerkesztés
   email_address: E-mail cím
   export: Exportálás
@@ -43,9 +43,9 @@ hu:
   first_name: Keresztnév
   forgot_password: Elfelejtettem a jelszavam
   forgot_password_title: Semmi gond, megoldjuk!
-  friendly_id: Friendly ID
+  friendly_id:
   get_started: Kezdjük el!
-  hidden: hidden
+  hidden:
   identify: Azonosítás
   import: Importálás
   import_new: Új importálása
@@ -65,39 +65,39 @@ hu:
   password: Jelszó
   please_wait: Kérlek, várj...
   plugin_not_found: A bővítmény nem található
-  preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
+  preview:
+  privacy:
+  refresh_rate:
   refresh_rates_hint: Itt megtudhatod, hogyan működnek a frissítési gyakoriságok __itt__.
   reset_password: Jelszó visszaállítása
-  reset_to_defaults: Reset to defaults
-  required: Required
+  reset_to_defaults:
+  required:
   save: Mentés
-  shown: shown
+  shown:
   section: Szakasz
   settings: Beállítások
   sign_in: Bejelentkezés
   sign_up: Regisztráció
   something_went_wrong: Valami hiba történt
-  status: Status
+  status:
   subscribe: Feliratkozás
   help_center: Technikai támogatás
-  terms: Terms
-  unsaved_changes: You have unsaved changes
+  terms:
+  unsaved_changes:
   update: Frissítés
   view: Megtekintés
-  collaboration_request: Wanna collaborate?
-  collaboration_request_hint: Partnerships, group sales, special projects, your call.
-  collaboration_request_cta: Let's talk
+  collaboration_request:
+  collaboration_request_hint:
+  collaboration_request_cta:
   welcome: Üdvözlünk
   time:
     formats:
-      shorter: "%-I:%M %p"
-    start_of_week: 0
+      shorter:
+    start_of_week:
   datetime:
     relative:
-      past: "%{time} ago"
-      future: in %{time}
+      past:
+      future:
       distance_in_words:
         half_a_minute: fél perce
         less_than_x_seconds:
@@ -159,21 +159,21 @@ hu:
       email_address_hint: A TRMNL-ba való bejelentkezéshez és rendszerüzenetek fogadásához használjuk.
       first_name_hint: A keresztneved segít személyesebbé tenni a TRMNL felületét.
       last_name_hint: A vezetékneved segít személyesebbé tenni a TRMNL felületét.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: A fiókod védelmére szolgál.
       enable_2fa: Kétlépcsős azonosítás engedélyezése
       enable_2fa_hint: __Kattints ide__ az egyszeri jelszó (OTP) engedélyezéséhez.
       disable_2fa: Kétlépcsős azonosítás kikapcsolása
       disable_2fa_hint: Add meg az érvényes OTP-t és a jelenlegi jelszavad a funkció letiltásához.
       plus_subscription: TRMNL+ előfizetés
-      plus_subscription_trial_until: You're on a free trial until %{plus_trial_end_at}.
+      plus_subscription_trial_until:
       plus_subscription_hint: Oldd fel a gyorsabb frissítési rátákat és a magasabb korlátokat. __Tudj meg többet__.
       plus_subscription_modify: Frissítenéd a fizetési módot vagy lemondanád?
       session: Munkamenet
       session_hint: Be vagy jelentkezve mint %{user}
       show_title_bar: Címsor megjelenítése
       show_title_bar_hint: Ha kikapcsolod, a natív és harmadik féltől származó bővítmények minimalizáltabban jelennek meg.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
+      theme_hint:
       time_zone: Időzóna
       time_zone_hint: Meghatározza a frissítési rátákat és az eszköz alvási idejét.
       locale: Nyelv és lokalizáció
@@ -213,10 +213,10 @@ hu:
       title: Megtakarított idő
       cta: Olvass róla
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: Jó reggelt
       afternoon_salutation: Jó napot
@@ -226,14 +226,14 @@ hu:
       accepts_beta_firmware: Korai firmware kiadás
       accepts_beta_firmware_hint: Kapcsold be, hogy a legújabb firmware-fejlesztéseket a többiek előtt megkapd.
       back_to_devices: Vissza az eszközökhöz
-      battery_and_sleep: Battery & Sleep
+      battery_and_sleep:
       battery_consumption: Akkumulátorhasználat
       battery_consumption_hint: Spórolj energiát és élvezd a hosszabb üzemidőt az alvó mód bekapcsolásával.
       battery_learn_more: Tudj meg többet az akkumulátortöltésről __itt__.
-      battery_refresh: Refresh
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      battery_refresh:
+      click:
+      click_action:
+      controls:
       developer_perks: Fejlesztői extrák
       developer_perks_hint: Az alábbi opciók használatához a __Fejlesztői bővítmény__ szükséges.
       device_credentials: Eszköz hitelesítő adatok
@@ -243,23 +243,23 @@ hu:
       device_model: Eszközmodell
       device_model_hint: A hardvered típusa
       device_model_switch_warning: Ez veszélyes művelet, tudj meg róla többet __itt__.
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
-      display_calibration: Display Calibration
-      display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
-      display_calibration_pixel_ratio: Pixel Ratio
-      display_calibration_pixel_ratio_hint: 'Image zoom level (0.5–3.0). Default:'
-      display_calibration_ui_scale: UI Scale
-      display_calibration_ui_scale_hint: 'Text and element sizes (0.5–2.0). Default:'
+      device_info:
+      current_firmware:
+      last_ping:
+      unknown:
+      never:
+      display_calibration:
+      display_calibration_hint:
+      display_calibration_pixel_ratio:
+      display_calibration_pixel_ratio_hint:
+      display_calibration_ui_scale:
+      display_calibration_ui_scale_hint:
       edit_device: Eszköz szerkesztése
-      firmware: Firmware
-      firmware_updates_enabled: Updates enabled
-      firmware_updates_disabled: Updates disabled
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
+      firmware:
+      firmware_updates_enabled:
+      firmware_updates_disabled:
+      font_family:
+      font_family_hint:
       guest_mode: Vendég mód
       guest_mode_hint: Válaszd ki, mit (és mennyi ideig) jelenítsen meg az eszköz, amikor a vendég mód be van kapcsolva.
       guest_mode_item_placeholder: Válassz egy elemet
@@ -269,21 +269,21 @@ hu:
       identify_device_hint: Kattints a lenti gombra, hogy az eszköz kijelzőjén megjelenjen egy azonosító képernyő.
       logs: Naplók
       logs_hint: Figyeld az eszköz és a bővítmények hibajegyzékét élőben.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
       low_battery_email_notification: Alacsony akkumulátor e-mail értesítés
       low_battery_email_notification_hint: Kapsz egy e-mailt, ha az eszköz akkumulátora lemerülőben van.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: Tükrözés
       mirror_device: Másik eszköz tükrözése
       mirror_device_hint: Adj meg egy megosztható eszközazonosítót, hogy tükrözd annak lejátszási listáját. A saját listád továbbra is megjelenik.
-      mirror_disabled: Mirroring disabled
-      mirror_enabled: Mirroring
+      mirror_disabled:
+      mirror_enabled:
       mirror_stop: Tükrözés leállítása
       mirror_sync: Képernyők szinkronizálása
       ota_enabled: OTA frissítések engedélyezve
@@ -292,12 +292,12 @@ hu:
       maximum_compatibility: Maximális kompatibilitás engedélyezése
       maximum_compatibility_hint: Kijavítja az egyes ePaper kijelzőchipek által okozott megjelenítési hibákat. Kikapcsolja a gyors frissítést. Firmware 1.6.0+ szükséges.
       color_and_rotation: Szín & forgatás
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Képernyő forgatása
       screen_rotation_not_supported: A képernyő forgatása jelenleg nem támogatott a te eszközödön.
-      palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
-      presentation: Presentation
+      palette:
+      palette_hint:
+      presentation:
       sleep_mode: Alvó mód
       sleep_mode_hint: Állítsd be a frissítési rátát a fókusz és az akkumulátor-élettartam optimalizálásához.
       sleep_screen: Alvóképernyő
@@ -308,16 +308,16 @@ hu:
       special_function_learn_more: Tudj meg többet a különleges funkciókról __itt__.
       temperature_profile: Hőmérsékleti profil
       temperature_profile_hint: Ne módosítsd, hacsak nem utasítottak rá. Kifehéredett kijelzők esetén hasznos.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
-      tidbyt_credentials: Tidbyt Credentials
-      tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
-      tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
-      tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
+      touchbar_mode:
+      touchbar_mode_hint:
+      tidbyt_credentials:
+      tidbyt_credentials_hint:
+      tidbyt_api_key:
+      tidbyt_credentials_invalid:
+      tidbyt_device_id:
+      tidbyt_device_api_key:
       unlink: Leválasztás
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm:
       unlink_device: Eszköz leválasztása
       unlink_device_hint: A TRMNL leválasztása biztonságossá teszi az újraértékesítést vagy ajándékozást.
       unlink_device_learn_more: Kövesd a teljes útmutatót __itt__.
@@ -331,41 +331,41 @@ hu:
         warning_2: Megértem, hogy ez egy <strong>veszélyes</strong> művelet, amely tönkreteheti az eszközt.
         cta: Frissítés TRMNL OG (2-bit) verzióra
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Eszközök
       tagline: A te TRMNL eszközeid
       add_device_modal_title: Új eszköz hozzáadása
       add_first_device: Kezdd az első eszközöd hozzáadásával!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: Új eszköz hozzáadása
       description: Add meg az eszközazonosítót, hogy új TRMNL eszközt kapcsolj a fiókodhoz.
@@ -377,8 +377,8 @@ hu:
       error: Hiba az eszköz leválasztása közben
       success: Az eszköz sikeresen leválasztva
     external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
+      error:
+      success:
     identify:
       error: Hiba az eszköz frissítésekor
       success: Eszközazonosítási kérés elküldve
@@ -391,32 +391,32 @@ hu:
     switch:
       error: Hiba az eszközváltáskor
       success: Az eszköz sikeresen átváltva
-      title: Switch to device
+      title:
     update:
       error: Hiba az eszköz frissítésekor
       success: "%{device} eszközbeállításai sikeresen frissítve"
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: Túl sok próbálkozás, kérlek várj, majd próbáld újra
     invoice_not_found: A számla nem található
@@ -424,7 +424,7 @@ hu:
     index:
       title: Naplók
       all: Összes
-      bulk_destroy: Bulk Destroy
+      bulk_destroy:
       dump: Adatkiíratás
       id: Azonosító
       private_plugins: Saját bővítmények
@@ -438,7 +438,7 @@ hu:
       design_system: Használd a beépített tervezési rendszert
       design_system_docs: Tervezési rendszer dokumentáció
       dirty_confirm: Vannak nem mentett módosításaid. Biztosan el szeretnéd hagyni az oldalt?
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: Jelölés szerkesztése
       edit_markup_for_plugin: 'Jelölés szerkesztése ehhez a bővítményhez: %{plugin_setting_name}'
       edit_markup_please_save_first: Kérlek, mentsd el a módosításokat, mielőtt szerkesztenéd a jelölést
@@ -463,7 +463,7 @@ hu:
       no_variables_detected: Nem észleltek változókat.
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: Kétlépcsős azonosítás kikapcsolva
@@ -512,18 +512,18 @@ hu:
       remove_from_playlist: Eltávolítás a lejátszási listáról
       hide_playlist: Elem elrejtése
       show_playlist: Elem megjelenítése
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default:
+        external:
+        global:
+        mashup:
+        readonly:
     create:
       error: Hiba történt a lejátszási lista frissítésekor
       success: Lejátszási lista frissítve
@@ -539,14 +539,14 @@ hu:
     set_preferences:
       success: Az intelligens lejátszási lista beállítása frissítve
     update:
-      success: Playlist order updated
+      success:
   plugins:
     index:
       title: Bővítmények
       tagline: Mit szeretnél megjeleníteni a TRMNL-on?
       available: Elérhető
       connected: Csatlakoztatva
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: Receptek
       recipes_hint: Közösségi tagok által készített privát bővítmények, amelyek egy kattintással telepíthetők. __Tudj meg többet__.
     search:
@@ -594,29 +594,29 @@ hu:
       one: Kapcsolat
       other: Kapcsolatok
     forks:
-      one: Fork
-      other: Forks
-    forked: Recipe forked
+      one:
+      other:
+    forked:
     new:
       error: A recept nem található
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: Aktív
     copy_are_you_sure: Biztosan másolni szeretnéd ezt a beállítást?
     delete_are_you_sure: Biztosan törölni szeretnéd ezt a beállítást?
     delete: Ez teljesen eltávolítja a bővítmény beállításait. Ha csak elrejteni szeretnéd a bővítményt az eszközödről, töröld azt a lejátszási listádról.
     inactive: Inaktív
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: Nem találhatók bővítménybeállítások.
-    not_supported: Not supported on current device
+    not_supported:
     refreshing_now_please_wait: Frissítés folyamatban, kérlek frissítsd az oldalt néhány másodperc múlva.
     reset_credentials: "%{plugin_name} fiók sikeresen visszaállítva"
     form:
       active_hint: Megjeleníti vagy elrejti ezt a bővítmény példányt az eszközödön
       advanced_settings: Speciális beállítások
-      back_to_playlist: Back to Playlist
+      back_to_playlist:
       back_to_plugin: 'Vissza ide: %{plugin}'
       back_to_plugins: Vissza a bővítményekhez
       connect_with: 'Kapcsolódás a következőhöz: %{plugin}'
@@ -631,25 +631,25 @@ hu:
       force_refresh_hint: Ez a funkció csak tesztelési célokra készült — kérlek, ne használd túl gyakran.
       force_refresh_click_here: Kattints ide
       force_refresh_click_here_hint: hogy azonnal új képernyőt generálj
-      force_refresh_not_possible: This plugin cannot be force-refreshed because the TRMNL server does not perform image processing. Learn how to test your instance __here__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      force_refresh_not_possible:
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: Tudj meg többet erről a bővítményről a tudásbázisunkban
       learn_more_fork: Ez a bővítmény egy receptből lett létrehozva.
       learn_more_fork_original: Eredeti megtekintése
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long:
+      learn_more_native_short:
       learn_more_recipe_author: Segítségre van szükséged? Lépj kapcsolatba %{recipe_author}-ral Discordon.
       learn_more_recipe_long: Ez a bővítmény egy közösségi recept, amelyet nem a TRMNL tart karban.
       learn_more_recipe_short: 'Megjegyzés: ez a bővítmény egy recept.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long:
+      learn_more_third_party_short:
       linked_account: Összekapcsolt fiók
       linked_account_success: 'Sikeres összekapcsolás a következővel: %{plugin_name}'
       link_oauth: Fiók összekapcsolása
       link_oauth_hint: Mielőtt folytatod, kövesd a %{plugin} által biztosított biztonságos hitelesítési folyamatot.
-      mirrored: Mirrored
+      mirrored:
       multiple_instances_hint: Ez a bővítmény több példányt is támogat.
       name: Név
       name_hint: Adj neki egy nevet a könnyebb azonosításhoz
@@ -667,7 +667,7 @@ hu:
       recipe_cta_body_in_review: Ez a bővítmény be lett nyújtva a csapatunkhoz. Kérlek, várj türelemmel.
       recipe_cta_body_not_published: Küldd be a bővítményt, hogy mások is telepíthessék. __Tudj meg többet__.
       recipe_cta_confirm: Biztos vagy benne? A csapatunk pár napon belül visszajelez. Közben folytathatod a módosításokat.
-      recipe_mirrored: This screen is mirrored from the recipe.
+      recipe_mirrored:
       recipe_visibility_title: Hogyan szeretnéd közzétenni?
       recipe_visibility_edit_title: Beküldés szerkesztése
       recipe_visibility_public: Nyilvános
@@ -678,19 +678,19 @@ hu:
       recipe_visibility_unlisted_hint: Bárki, aki ismeri a linket, telepítheti.
       refresh_rate: Frissítési gyakoriság
       refresh_rate_hint: Add meg, milyen gyakran frissítse ez a bővítmény az adatokat
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
-      refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
+      refresh_rate_jit_hint:
+      refresh_rate_not_configurable:
       refreshed: Frissítve
       remove_plugin: Bővítmény eltávolítása
       remove_plugin_hint: A bővítmény eltávolítása a lejátszási listáról is törli azt
       synced: Szinkronizálva
       refresh_paused: Frissítés szüneteltetve
       refresh_paused_hint: Az automatikus frissítés szünetel. Add hozzá a lejátszási listához a folytatáshoz.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
+      refresh_paused_hidden_hint:
       refresh_paused_mashup: Összevonások frissítése
       refresh_paused_mashup_hint: Az automatikus frissítés teljes képernyős módban szünetel. Az összevonások frissülnek.
       refresh_stopped: Az automatikus frissítés leállt. Kérlek, javítsd a bővítmény hibáját a folytatáshoz.
-      view_recipe: View Recipe
+      view_recipe:
       visit_docs: Dokumentáció megtekintése
     import:
       archive_too_large: A ZIP fájl túl nagy (%{max_mb} MB a maximális méret)
@@ -725,7 +725,7 @@ hu:
       some_schedule: Csak ebben az időszakban jelenjen meg…
       to: "-ig"
       copy_prompt: Ütemezés másolása innen…
-      no_days_error: Please select at least one day.
+      no_days_error:
   upgrade:
     index:
       title: 'Eszköz frissítése:'

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -1,94 +1,94 @@
 ---
 id:
   locale_name: Indonesian
-  about: About
-  actions: Actions
+  about:
+  actions:
   add: Tambah
   add_new: Tambah baru
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: Saya sudah punya akun
-  are_you_sure: Are you sure?
+  are_you_sure:
   back: Kembali
-  back_to_all_blog_posts: Back to all posts
-  blog: Blog
-  brand: Brand
+  back_to_all_blog_posts:
+  blog:
+  brand:
   buy_now: Beli Sekarang
   cancel: Batal
   change_password: Ubah Kata Sandi
   charge_level: Tingkat Pengisian
   charged: Terisi penuh
-  charging: Charging
-  claim_plus_trial: Claim 6 Months Free
+  charging:
+  claim_plus_trial:
   close: Tutup
   confirm_change_password: Ubah kata sandi saya
   confirm_password: Konfirmasi kata sandi baru
-  copy: Copy
-  copied_to_clipboard: Copied!
-  copy_to_clipboard: Copy to clipboard
-  created: Created
+  copy:
+  copied_to_clipboard:
+  copy_to_clipboard:
+  created:
   create_an_account: Buat akun baru
-  current_device: Current device
+  current_device:
   days: hari
   delete: Hapus
-  developers: Developers
-  developer_edition_required: Developer edition is required to enable this feature.
+  developers:
+  developer_edition_required:
   device_id: ID Perangkat
-  device: Device
-  discard: Discard
+  device:
+  discard:
   edit: Pengaturan
   email_address: Alamat Email
-  export: Export
-  fetching: Fetching
+  export:
+  fetching:
   first_name: Nama Depan
   forgot_password: Lupa kata sandi
   forgot_password_title: Atur ulang kata sandi
-  friendly_id: Friendly ID
+  friendly_id:
   get_started: Mari kita mulai!
-  hidden: hidden
+  hidden:
   identify: Identifikasi
-  import: Import
-  import_new: Import new
-  integrations: Integrations
+  import:
+  import_new:
+  integrations:
   keep_me_signed_in: Biarkan saya tetap masuk
   knowledge_base: Basis pengetahuan
   last_name: Nama Belakang
-  learn_more: Learn more
-  loading: Loading
+  learn_more:
+  loading:
   login: Masuk
   log_out: Keluar
-  manage: Manage
+  manage:
   minimum_characters: karakter minimal
   mins: menit
-  my_playlist: My Playlist
+  my_playlist:
   new_password: Kata sandi baru
   password: Kata Sandi
-  please_wait: Please Wait...
-  plugin_not_found: Plugin not found
-  preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
-  refresh_rates_hint: Learn how refresh rates work __here__.
+  please_wait:
+  plugin_not_found:
+  preview:
+  privacy:
+  refresh_rate:
+  refresh_rates_hint:
   reset_password: Atur Ulang Kata Sandi
-  reset_to_defaults: Reset to defaults
-  required: Required
+  reset_to_defaults:
+  required:
   save: Simpan
-  shown: shown
-  section: Section
-  settings: Settings
+  shown:
+  section:
+  settings:
   sign_in: Masuk
   sign_up: Daftar
-  something_went_wrong: Something went wrong
-  status: Status
-  subscribe: Subscribe
-  help_center: Support
-  terms: Terms
-  unsaved_changes: You have unsaved changes
+  something_went_wrong:
+  status:
+  subscribe:
+  help_center:
+  terms:
+  unsaved_changes:
   update: Perbarui
   view: Lihat
-  collaboration_request: Wanna collaborate?
-  collaboration_request_hint: Partnerships, group sales, special projects, your call.
-  collaboration_request_cta: Let's talk
+  collaboration_request:
+  collaboration_request_hint:
+  collaboration_request_cta:
   welcome: Selamat datang
   time:
     formats:
@@ -96,8 +96,8 @@ id:
     start_of_week: 1
   datetime:
     relative:
-      past: "%{time} ago"
-      future: in %{time}
+      past:
+      future:
       distance_in_words:
         half_a_minute: setengah menit
         less_than_x_seconds:
@@ -139,51 +139,51 @@ id:
     index:
       title: Akun
       tagline: Kelola pengaturan akun Anda
-      api_key_confirm: Are you sure you want to regenerate your API Key? The old key will be invalidated.
-      api_key_hint: See __the docs__ to learn how to configure your local environment.
-      api_key_label: The credential for authenticating local development tools
-      api_key_not_generated: "(none yet)"
-      api_key_reset: Regenerate
+      api_key_confirm:
+      api_key_hint:
+      api_key_label:
+      api_key_not_generated:
+      api_key_reset:
       api_key: API Key
-      beta_features: Beta Features
-      beta_features_hint: Try out new stuff here. Options may disappear at any time.
-      discord_community: Discord Community
-      discord_username: What's your Discord username?
-      discord_username_hint: May be used for support, attribution on published Recipes, etc.
+      beta_features:
+      beta_features_hint:
+      discord_community:
+      discord_username:
+      discord_username_hint:
       email_address: Alamat Email
-      refer_and_earn: Refer and Earn
-      refer_and_earn_hint: Give the gift of TRMNL with a personalized coupon. Earn per use, paid monthly.
-      refer_and_earn_redemptions: Redemptions
-      refer_and_earn_request_code: Request a Code
-      device_invoice: Device Invoice
-      device_invoice_label: Download commercial documents for your accountant or (weird) PDF collection.
-      device_invoice_hint: Find this on your package tracking page or shipment notification email.
+      refer_and_earn:
+      refer_and_earn_hint:
+      refer_and_earn_redemptions:
+      refer_and_earn_request_code:
+      device_invoice:
+      device_invoice_label:
+      device_invoice_hint:
       email_address_hint: Digunakan untuk masuk ke TRMNL dan menerima pesan sistem.
       first_name_hint: Kami menggunakan nama Anda untuk membuat antarmuka TRMNL lebih nyaman.
       last_name_hint: Kami menggunakan nama Anda untuk membuat antarmuka TRMNL lebih nyaman.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: Digunakan untuk melindungi akun TRMNL Anda.
-      enable_2fa: Enable 2FA?
-      enable_2fa_hint: __Click here__ to enable OTP.
-      disable_2fa: Disable 2FA
-      disable_2fa_hint: Provide valid OTP and current password above to disable this feature.
-      plus_subscription: TRMNL+ Subscription
-      plus_subscription_trial_until: You're on a free trial until %{plus_trial_end_at}.
-      plus_subscription_hint: Unlock faster refresh rates and higher rate limits. __Learn more__.
-      plus_subscription_modify: Want to update your payment method or cancel?
+      enable_2fa:
+      enable_2fa_hint:
+      disable_2fa:
+      disable_2fa_hint:
+      plus_subscription:
+      plus_subscription_trial_until:
+      plus_subscription_hint:
+      plus_subscription_modify:
       session: Sesi
       session_hint: Anda sedang masuk sebagai %{user}
-      show_title_bar: Show title bar
-      show_title_bar_hint: If disabled, native (non global) and third party plugins will be more minimal.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
+      show_title_bar:
+      show_title_bar_hint:
+      theme_hint:
       time_zone: Zona Waktu
       time_zone_hint: Menentukan penyegaran dan waktu tidur perangkat.
-      locale: Locale
-      locale_hint: What language and localization do you prefer? __Go here__.
+      locale:
+      locale_hint:
     update:
       success: Profil Anda berhasil diperbarui!
     reset_api_key:
-      success: API key was regenerated successfully
+      success:
   dashboard:
     index:
       title: Dasbor
@@ -198,7 +198,7 @@ id:
       next_steps: Kami akan memberi tahu Anda jika ada perubahan
     news:
       title: Berita
-      cta: View All
+      cta:
     playlist_items:
       title: Daftar Putar
       cta: Ubah Daftar Putar
@@ -209,165 +209,165 @@ id:
       connected: Terhubung
       new_and_popular: Baru dan Populer
     shop:
-      title: Shop
-      need_another: Need another TRMNL?
+      title:
+      need_another:
     time_saved:
       title: Waktu yang dihemat
       cta: Pelajari lebih lanjut
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
-      morning_salutation: Good morning
-      afternoon_salutation: Good afternoon
-      evening_salutation: Good evening
+      morning_salutation:
+      afternoon_salutation:
+      evening_salutation:
   devices:
     edit:
       accepts_beta_firmware: Firmware tahap Beta
       accepts_beta_firmware_hint: Aktifkan untuk mendapatkan pembaruan firmware perangkat terbaru sebelum pengguna lain.
       back_to_devices: Kembali ke Perangkat
-      battery_and_sleep: Battery & Sleep
+      battery_and_sleep:
       battery_consumption: Penggunaan Baterai
       battery_consumption_hint: Hemat daya dan nikmati masa pakai baterai yang lebih lama dengan mengaktifkan Mode Tidur.
-      battery_learn_more: Learn more about battery charging __here__.
-      battery_refresh: Refresh
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      battery_learn_more:
+      battery_refresh:
+      click:
+      click_action:
+      controls:
       developer_perks: Keuntungan Pengembang
       developer_perks_hint: Opsi di bawah ini membutuhkan __add-on Pengembang__.
-      device_credentials: Device Credentials
-      device_credentials_hint: See what you can do with these credentials __here__
+      device_credentials:
+      device_credentials_hint:
       device_name: Nama Perangkat
       device_name_hint: Kami menggunakan ini untuk membuat antarmuka TRMNL lebih nyaman
-      device_model: Device Model
-      device_model_hint: Your hardware Model
-      device_model_switch_warning: This is a dangerous operation, learn more __here__
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
-      display_calibration: Display Calibration
-      display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
-      display_calibration_pixel_ratio: Pixel Ratio
-      display_calibration_pixel_ratio_hint: 'Image zoom level (0.5–3.0). Default:'
-      display_calibration_ui_scale: UI Scale
-      display_calibration_ui_scale_hint: 'Text and element sizes (0.5–2.0). Default:'
+      device_model:
+      device_model_hint:
+      device_model_switch_warning:
+      device_info:
+      current_firmware:
+      last_ping:
+      unknown:
+      never:
+      display_calibration:
+      display_calibration_hint:
+      display_calibration_pixel_ratio:
+      display_calibration_pixel_ratio_hint:
+      display_calibration_ui_scale:
+      display_calibration_ui_scale_hint:
       edit_device: Ubah Perangkat
-      firmware: Firmware
-      firmware_updates_enabled: Updates enabled
-      firmware_updates_disabled: Updates disabled
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
-      guest_mode: Guest Mode
-      guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
-      guest_mode_item_placeholder: Choose an item
-      guest_mode_duration_placeholder: Choose a duration
+      firmware:
+      firmware_updates_enabled:
+      firmware_updates_disabled:
+      font_family:
+      font_family_hint:
+      guest_mode:
+      guest_mode_hint:
+      guest_mode_item_placeholder:
+      guest_mode_duration_placeholder:
       identify: Identifikasi
       identify_device: Identifikasi Perangkat
       identify_device_hint: Klik tombol di bawah ini untuk menampilkan layar pada perangkat ini yang membantu mengidentifikasinya.
-      logs: Logs
-      logs_hint: Debug your device and plugins with a live feed of raw error logs.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
-      low_battery_email_notification: Low Battery Email Notification
-      low_battery_email_notification_hint: Get notified via email when your device battery is running low.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      logs:
+      logs_hint:
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
+      low_battery_email_notification:
+      low_battery_email_notification_hint:
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: Mirroring
       mirror_device: Mirror Perangkat Lain
       mirror_device_hint: Masukkan ID Perangkat (yang dapat dibagikan) untuk mirror daftar putarnya. Daftar putar Anda tetap akan ditampilkan.
-      mirror_disabled: Mirroring disabled
-      mirror_enabled: Mirroring
-      mirror_stop: Disconnect Mirroring
-      mirror_sync: Sync Screens
+      mirror_disabled:
+      mirror_enabled:
+      mirror_stop:
+      mirror_sync:
       ota_enabled: Pembaruan OTA Diaktifkan
       ota_enabled_hint: Firmware terbaru akan diinstal secara otomatis. Nonaktifkan jika menggunakan firmware Anda sendiri.
-      ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
-      maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      ota_byod_not_supported:
+      maximum_compatibility:
+      maximum_compatibility_hint:
       color_and_rotation: Warna dan Rotasi Layar
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Rotasi Layar
       screen_rotation_not_supported: Rotasi layar saat ini tidak didukung pada perangkat Anda.
-      palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
-      presentation: Presentation
+      palette:
+      palette_hint:
+      presentation:
       sleep_mode: Mode Tidur
       sleep_mode_hint: Sesuaikan tingkat penyegaran untuk fokus dan hemat baterai.
-      sleep_screen: Sleep Screen
-      sleep_screen_tooltip: Enable Sleep Mode to use this feature
-      sleep_screen_hint: Display a sleep screen during sleep mode hours.
+      sleep_screen:
+      sleep_screen_tooltip:
+      sleep_screen_hint:
       special_function: Fungsi Khusus
       special_function_hint: Atur fitur klik ganda untuk tombol di belakang perangkat Anda.
       special_function_learn_more: Pelajari lebih lanjut tentang fungsi khusus __di sini__.
-      temperature_profile: Temperature Profile
-      temperature_profile_hint: Don't change unless instructed. For displays with washed out images.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
-      tidbyt_credentials: Tidbyt Credentials
-      tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
-      tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
-      tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
+      temperature_profile:
+      temperature_profile_hint:
+      touchbar_mode:
+      touchbar_mode_hint:
+      tidbyt_credentials:
+      tidbyt_credentials_hint:
+      tidbyt_api_key:
+      tidbyt_credentials_invalid:
+      tidbyt_device_id:
+      tidbyt_device_api_key:
       unlink: Lepas Tautan
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm:
       unlink_device: Lepaskan Tautan Perangkat
       unlink_device_hint: Lepaskan tautan perangkat TRMNL agar aman untuk dijual kembali atau diberikan kepada orang lain.
-      unlink_device_learn_more: Follow the full guide __here__.
+      unlink_device_learn_more:
       visibility: Visibilitas
       visibility_hint: Jadikan perangkat TRMNL Anda dapat di-mirroring dengan mengubah pengaturan di bawah ini.
       your_device: TRMNL Anda
       upgrade_og:
-        title: Upgrade to 2-bit Display Available
-        sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
-        warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
-        warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
-        cta: Upgrade to TRMNL OG (2-bit)
+        title:
+        sub_title:
+        warning_1:
+        warning_2:
+        cta:
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Perangkat
       tagline: Perangkat TRMNL Anda
       add_device_modal_title: Tambah perangkat baru
       add_first_device: Mulai dengan menambahkan perangkat pertama Anda!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: Tambah perangkat baru
       description: Masukkan ID Perangkat Anda untuk menambahkan perangkat TRMNL baru ke akun Anda.
@@ -379,8 +379,8 @@ id:
       error: Terjadi kesalahan saat melepaskan tautan perangkat
       success: Perangkat berhasil dilepaskan tautannya
     external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
+      error:
+      success:
     identify:
       error: Terjadi kesalahan saat memperbarui perangkat
       success: Permintaan identifikasi perangkat berhasil
@@ -389,143 +389,143 @@ id:
       error_not_shared: ID Perangkat yang dimasukan tidak dapat di-mirroring
       error_oneself: Tidak bisa mirror perangkat milik sendiri
       success: Perangkat %{friendly_id} berhasil di-mirroring
-      success_removed: Mirroring Removed
+      success_removed:
     switch:
       error: Terjadi kesalahan saat mengganti perangkat
       success: Perangkat berhasil diganti
-      title: Switch to device
+      title:
     update:
       error: Terjadi kesalahan saat memperbarui perangkat
       success: Pengaturan perangkat %{device} berhasil diperbarui
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
-    rate_limit: Too many attempts, please wait and try again
-    invoice_not_found: Invoice not found
+    rate_limit:
+    invoice_not_found:
   logs:
     index:
-      title: Logs
-      all: All
-      bulk_destroy: Bulk Destroy
-      dump: Dump
-      id: ID
-      private_plugins: Private Plugins
-      source: Source
-      time: Time
+      title:
+      all:
+      bulk_destroy:
+      dump:
+      id:
+      private_plugins:
+      source:
+      time:
   markups:
     console_logs:
-      js_logs: JS Logs
+      js_logs:
     form:
-      back_to_plugin_settings: Back to plugin settings
-      design_system: Leverage our native design system
-      design_system_docs: Design System Docs
-      dirty_confirm: You have unsaved changes. Are you sure you want to leave this page?
-      edit_composition: Edit Composition
-      edit_markup: Edit Markup
-      edit_markup_for_plugin: Edit markup for %{plugin_setting_name}
-      edit_markup_please_save_first: Please save before editing markup
-      edit_markup_without_preview: Edit Markup (without preview)
-      error_rendering_markup: Error rendering that markup
-      fix_indentation: Fix indentation
-      go_to_preview: Go To Preview
-      live_preview: Live Preview
-      no_changes_to_save: No changes to save
-      pop_out_preview: Pop Out Preview
-      quickstart_examples: Quick-start Examples
-      quickstart_example_applied: Applied!
-      quickstart_use_this_example: Use this example
-      revert: Revert
-      revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
-      save_changes: Save Changes (⌘﹢S)
-      separate_preview: Preview is open in a separate window
+      back_to_plugin_settings:
+      design_system:
+      design_system_docs:
+      dirty_confirm:
+      edit_composition:
+      edit_markup:
+      edit_markup_for_plugin:
+      edit_markup_please_save_first:
+      edit_markup_without_preview:
+      error_rendering_markup:
+      fix_indentation:
+      go_to_preview:
+      live_preview:
+      no_changes_to_save:
+      pop_out_preview:
+      quickstart_examples:
+      quickstart_example_applied:
+      quickstart_use_this_example:
+      revert:
+      revert_confirm:
+      save_changes:
+      separate_preview:
     merge_variables:
-      your_variables: Your variables
+      your_variables:
     no_merge_variables:
-      force_refresh: If you've provided variables but they aren't being detected, try a __force refresh__.
-      no_variables_detected: No variables detected.
+      force_refresh:
+      no_variables_detected:
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
-      success: 2FA Disabled
-      invalid_otp: Invalid OTP
-      invalid_password: Invalid Password
-      invalid_otp_and_password: Invalid OTP and Password
+      success:
+      invalid_otp:
+      invalid_password:
+      invalid_otp_and_password:
     enable_otp:
-      input_otp: Enter OTP
-      submit: Verify and Enable
-      already_enabled: 2FA is already enabled
+      input_otp:
+      submit:
+      already_enabled:
     enable_otp_verify:
-      success: 2FA Enabled
-      error: Invalid OTP code
+      success:
+      error:
     verify_otp:
-      verify: Verify
-      reset: Reset MFA
-      reset_instructions: Click the button on the back of your TRMNL to generate a reset code
-      success: 2FA successful
-      error: Invalid OTP code
+      verify:
+      reset:
+      reset_instructions:
+      success:
+      error:
   playlist_items:
     index:
       title: Daftar Putar
       tagline: Pilih apa yang ingin Anda tampilkan di
-      add_a_group: Add a Group
-      add_a_plugin: Add a Plugin
+      add_a_group:
+      add_a_plugin:
       add_first_device_cta: Mulai dengan __menambahkan__ perangkat TRMNL pertama Anda!
       add_to_playlist: Tambahkan ke Daftar Putar
       create_first_playlist_cta: Buat daftar putar setelah __menghubungkan__ plugin pertama Anda!
-      custom: Custom
-      device_default: Device default
-      display_period_from: Display from
-      display_period_to: to
-      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
-      never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
+      custom:
+      device_default:
+      display_period_from:
+      display_period_to:
+      display_period_validation:
+      every:
+      never_skip:
+      smart_playlist:
+      smart_playlist_hint:
       skip_after:
-        one: Skip stale screens after 1 day
-        other: Skip stale screens after %{count} days
+        one:
+        other:
     playlist_item:
-      adjust_schedule: Adjust schedule
+      adjust_schedule:
       delete: Apakah Anda yakin ingin menghapus item ini? Plugin akan tetap terhubung, hanya tidak ditampilkan di perangkat Anda.
       displayed_now: Ditampilkan sekarang
       not_displayed_yet: Tertunda
       remove_from_playlist: Hapus dari daftar putar
-      hide_playlist: Hide this item
-      show_playlist: Show this item
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      hide_playlist:
+      show_playlist:
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default:
+        external:
+        global:
+        mashup:
+        readonly:
     create:
       error: Gagal memperbarui daftar putar
       success: Daftar putar berhasil diperbarui
@@ -533,11 +533,11 @@ id:
       error: Terjadi kesalahan saat menghapus item dari daftar putar
       success: Plugin berhasil dihapus dari Daftar Putar
     toggle_visibility:
-      success: Playlist item %{change}
+      success:
     duplicate:
       success: Playlist duplicated
     sort:
-      success: Playlist order updated
+      success:
     set_preferences:
       success: Smart playlist preference updated
     update:
@@ -548,9 +548,9 @@ id:
       tagline: Apa yang ingin Anda tampilkan di TRMNL Anda?
       available: Tersedia
       connected: Terhubung
-      supported_by_this_device: Supported by this device
-      recipes: Recipes
-      recipes_hint: Private plugins by community members that can be installed in 1 click. __Learn more__.
+      supported_by_this_device:
+      recipes:
+      recipes_hint:
     search:
       placeholder: Cari Plugin
     my:
@@ -558,147 +558,147 @@ id:
         title: Plugin Saya
         tagline: Kembangkan Plugin Anda untuk lokapasar plugin
       card:
-        connections: connections
-        install: Install
-        review_are_you_sure: Are you sure? The TRMNL team will test it and email you any questions.
+        connections:
+        install:
+        review_are_you_sure:
         submit_for_review: Ajukan untuk ditinjau
     new:
       title: Buat Plugin Baru
       tagline: Permudah pengguna lain memasang plugin buatan Anda!
       name: Nama
-      category: Category
-      category_hint: Hold cmd or ctrl to choose up to 3
-      refresh_every: Supported Refresh Interval
-      refresh_every_hint: The fastest refresh interval your plugin can support.
+      category:
+      category_hint:
+      refresh_every:
+      refresh_every_hint:
       description: Deskripsi
-      description_hint: Maximum 50 characters
+      description_hint:
       icon: Ikon
       icon_hint: Disarankan ukuran 512x512px
-      installation_url: Installation URL
-      installation_url_hint: Learn more about the installation flow __here__.
-      installation_success_webhook_url: Installation Success Webhook URL
-      knowledge_base_url: Knowledge Base URL
-      management_url: Plugin Management URL
-      management_url_hint: Learn more about the management flow __here__.
-      markup_url: Plugin Markup URL
-      markup_url_hint: Learn more about screen generation __here__.
-      no_screen_padding: No Screen Padding
-      no_screen_padding_hint: Removes the outermost padding in fullscreen mode.
-      uninstallation_webhook_url: Uninstallation Webhook URL
+      installation_url:
+      installation_url_hint:
+      installation_success_webhook_url:
+      knowledge_base_url:
+      management_url:
+      management_url_hint:
+      markup_url:
+      markup_url_hint:
+      no_screen_padding:
+      no_screen_padding_hint:
+      uninstallation_webhook_url:
     edit:
       title: Ubah Plugin
       tagline: Perbarui detail plugin Anda.
       name: Nama
       description: Deskripsi
   plugin_recipes:
-    connected: Recipe connected
+    connected:
     connections:
-      one: Connection
-      other: Connections
+      one:
+      other:
     forks:
-      one: Fork
-      other: Forks
-    forked: Recipe forked
+      one:
+      other:
+    forked:
     new:
-      error: Recipe not found
+      error:
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: Aktif
-    copy_are_you_sure: Are you sure you want to copy this setting?
-    delete_are_you_sure: Are you sure you want to delete this setting?
+    copy_are_you_sure:
+    delete_are_you_sure:
     delete: Ini akan sepenuhnya menghapus pengaturan plugin. Untuk hanya menyembunyikan plugin ini dari perangkat Anda, hapus dari Daftar Putar Anda.
     inactive: Tidak Aktif
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: Tidak ditemukan pengaturan plugin.
-    not_supported: Not supported on current device
-    refreshing_now_please_wait: Refreshing now, reload this page in a few seconds.
-    reset_credentials: "%{plugin_name} account reset successfully"
+    not_supported:
+    refreshing_now_please_wait:
+    reset_credentials:
     form:
       active_hint: Tampilkan atau sembunyikan plugin ini di perangkat Anda
-      advanced_settings: Advanced Settings
-      back_to_playlist: Back to Playlist
+      advanced_settings:
+      back_to_playlist:
       back_to_plugin: Kembali ke %{plugin}
       back_to_plugins: Kembali ke Plugin
       connect_with: Hubungkan dengan %{plugin}
-      debug_logs: Debug Logs
-      debug_logs_click_here: Click here
-      debug_logs_click_here_hint: to enable debug logs for this plugin instance.
-      debug_logs_enabled: Debug logs enabled for %{hours} hours.
-      debug_logs_enabled_link: View logs
-      disconnect_account: Disconnect Account
+      debug_logs:
+      debug_logs_click_here:
+      debug_logs_click_here_hint:
+      debug_logs_enabled:
+      debug_logs_enabled_link:
+      disconnect_account:
       manage_plugin: Konfigurasi %{plugin}
       force_refresh: Penyegaran Paksa
       force_refresh_hint: Fitur ini dirancang untuk pengujian saja - mohon jangan disalahgunakan.
       force_refresh_click_here: Klik di sini
       force_refresh_click_here_hint: untuk menghasilkan layar baru segera
-      force_refresh_not_possible: This plugin cannot be force-refreshed because the TRMNL server does not perform image processing. Learn how to test your instance __here__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      force_refresh_not_possible:
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: Pelajari tentang plugin ini di basis pengetahuan kami
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
-      learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
-      linked_account: Linked Account
-      linked_account_success: Successfully linked with %{plugin_name}
+      learn_more_fork:
+      learn_more_fork_original:
+      learn_more_native_long:
+      learn_more_native_short:
+      learn_more_recipe_author:
+      learn_more_recipe_long:
+      learn_more_recipe_short:
+      learn_more_third_party_long:
+      learn_more_third_party_short:
+      linked_account:
+      linked_account_success:
       link_oauth: Tautkan Akun
       link_oauth_hint: Sebelum Anda melanjutkan, ikuti proses otorisasi aman yang disediakan oleh %{plugin}
-      mirrored: Mirrored
+      mirrored:
       multiple_instances_hint: Plugin ini mendukung beberapa instance.
       name: Nama
       name_hint: Beri nama untuk referensi yang lebih mudah
-      parse: Parse
-      parse_save_first: Parse (Save plugin first)
-      parsed: Parsed
-      plugin_uuid: Plugin UUID
+      parse:
+      parse_save_first:
+      parsed:
+      plugin_uuid:
       plugin_uuid_hint: Gunakan ini untuk membuat permintaan API Webhook.
       preview: Pratinjau - perangkat Anda akan menampilkan data nyata
       recipe_cta_heading_published: This plugin is a Recipe
-      recipe_cta_heading_unlisted: This plugin is unlisted
+      recipe_cta_heading_unlisted:
       recipe_cta_heading_in_review: Recipe in review
       recipe_cta_heading_not_published: Publish as a Recipe?
-      recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
-      recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
-      recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
-      recipe_mirrored: This screen is mirrored from the recipe.
-      recipe_visibility_title: How would you like to publish?
-      recipe_visibility_edit_title: Edit Submission
-      recipe_visibility_public: Public
-      recipe_visibility_public_hint: Anyone can find and install.
-      recipe_visibility_private: Private
-      recipe_visibility_private_hint: Breaks external installs.
-      recipe_visibility_unlisted: Unlisted
-      recipe_visibility_unlisted_hint: Anyone with the link can install.
+      recipe_cta_body_published:
+      recipe_cta_body_in_review:
+      recipe_cta_body_not_published:
+      recipe_cta_confirm:
+      recipe_mirrored:
+      recipe_visibility_title:
+      recipe_visibility_edit_title:
+      recipe_visibility_public:
+      recipe_visibility_public_hint:
+      recipe_visibility_private:
+      recipe_visibility_private_hint:
+      recipe_visibility_unlisted:
+      recipe_visibility_unlisted_hint:
       refresh_rate: Tingkat Penyegaran
       refresh_rate_hint: Tentukan seberapa sering plugin ini mengambil data baru
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
-      refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
+      refresh_rate_jit_hint:
+      refresh_rate_not_configurable:
       refreshed: Diperbarui
-      remove_plugin: Remove plugin
-      remove_plugin_hint: Removing a plugin will also remove it from your playlist
-      synced: Synced
-      refresh_paused: Refresh Paused
-      refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
-      refresh_paused_mashup: Refreshing Mashups
-      refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
-      refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.
-      view_recipe: View Recipe
+      remove_plugin:
+      remove_plugin_hint:
+      synced:
+      refresh_paused:
+      refresh_paused_hint:
+      refresh_paused_hidden_hint:
+      refresh_paused_mashup:
+      refresh_paused_mashup_hint:
+      refresh_stopped:
+      view_recipe:
       visit_docs: Kunjungi Dokumentasi
     import:
-      archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
-      missing_entry: The ZIP file does not contain %{filename}
-      entry_too_large: "%{filename} is too large"
-      malformed: "%{filename} is malformed"
+      archive_too_large:
+      missing_entry:
+      entry_too_large:
+      malformed:
     create:
       success: Plugin berhasil dibuat dan ditambahkan ke
       playlist: daftar putar
@@ -711,28 +711,28 @@ id:
       success: Plugin added to Playlist
   referral_code:
     create:
-      request_received: Request received, check your inbox
+      request_received:
   recipes:
     index:
-      newest_to_oldest: Newest to Oldest
-      oldest_to_newest: Oldest to Newest
-      most_popular: Most Popular
-      install: Install
-      fork: Fork
+      newest_to_oldest:
+      oldest_to_newest:
+      most_popular:
+      install:
+      fork:
   schedules:
     form:
-      add: Add a custom schedule
-      append: And during…
-      no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
-      to: to
-      copy_prompt: Copy schedule from…
-      no_days_error: Please select at least one day.
+      add:
+      append:
+      no_schedule:
+      some_schedule:
+      to:
+      copy_prompt:
+      no_days_error:
   upgrade:
     index:
-      title: 'Upgrading device:'
-      tagline: Unlock custom plugins and __more__.
-      pay: Pay
-      error: Device %{device_name} is already upgraded, switch to another device
+      title:
+      tagline:
+      pay:
+      error:
     confirm:
-      success: Developer edition add-on is now enabled
+      success:

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -1,25 +1,25 @@
 ---
 is:
   locale_name: Íslenska
-  about: About
-  actions: Actions
+  about:
+  actions:
   add: Bæta við
   add_new: Bæta nýju við
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: Ég á nú þegar aðgang
-  are_you_sure: Are you sure?
+  are_you_sure:
   back: Til baka
   back_to_all_blog_posts: Til baka í allar færslur
   blog: Blogg
-  brand: Brand
+  brand:
   buy_now: Kaupa núna
   cancel: Hætta við
   change_password: Breyta lykilorði
   charge_level: Hleðsla
   charged: hlaðið
   charging: Hleður
-  claim_plus_trial: Claim 6 Months Free
+  claim_plus_trial:
   close: Loka
   confirm_change_password: Breyta lykilorðinu mínu
   confirm_password: Staðfesta nýtt lykilorð
@@ -31,11 +31,11 @@ is:
   current_device: Núverandi tæki
   days: dagar
   delete: Eyða
-  developers: Developers
+  developers:
   developer_edition_required: Þróunarútgáfa er nauðsynleg til að virkja þennan eiginleika.
   device_id: Kennimerki tækis
   device: Tæki
-  discard: Discard
+  discard:
   edit: Breyta
   email_address: Netfang
   export: Flytja út
@@ -43,9 +43,9 @@ is:
   first_name: Fornafn
   forgot_password: Ég gleymdi lykilorði mínu
   forgot_password_title: Nú förum við aftur af stað
-  friendly_id: Friendly ID
+  friendly_id:
   get_started: Byrjum!
-  hidden: hidden
+  hidden:
   identify: Auðkenna
   import: Flytja inn
   import_new: Flytja inn nýtt
@@ -65,39 +65,39 @@ is:
   password: Lykilorð
   please_wait: Vinsamlegast bíðið...
   plugin_not_found: Viðbót fannst ekki
-  preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
+  preview:
+  privacy:
+  refresh_rate:
   refresh_rates_hint: Lestu um uppfærslutíðni __hér__.
   reset_password: Endurstilla lykilorð
-  reset_to_defaults: Reset to defaults
-  required: Required
+  reset_to_defaults:
+  required:
   save: Vista
-  shown: shown
+  shown:
   section: Hluti
   settings: Stillingar
   sign_in: Skrá inn
   sign_up: Skrá nýjan aðgang
   something_went_wrong: Eitthvað fór úrskeiðis
-  status: Status
+  status:
   subscribe: Gerast áskrifandi
   help_center: Aðstoð
-  terms: Terms
-  unsaved_changes: You have unsaved changes
+  terms:
+  unsaved_changes:
   update: Uppfæra
   view: Skoða
-  collaboration_request: Wanna collaborate?
-  collaboration_request_hint: Partnerships, group sales, special projects, your call.
-  collaboration_request_cta: Let's talk
+  collaboration_request:
+  collaboration_request_hint:
+  collaboration_request_cta:
   welcome: Velkomin
   time:
     formats:
       shorter: "%-H:%M"
-    start_of_week: 0
+    start_of_week:
   datetime:
     relative:
-      past: "%{time} ago"
-      future: in %{time}
+      past:
+      future:
       distance_in_words:
         half_a_minute: hálf mínúta
         less_than_x_seconds:
@@ -159,21 +159,21 @@ is:
       email_address_hint: Notað til að skrá þig inn  á TRMNL og fá kerfistilkynningar.
       first_name_hint: Nafnið þitt birtist í TRMNL viðmótinu.
       last_name_hint: Nafnið þitt birtist í TRMNL viðmótinu.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: Verndar TRMNL aðganginn þinn.
       enable_2fa: Virkja 2FA?
       enable_2fa_hint: __Smelltu hér__ til að virkja OTP.
       disable_2fa: Slökkva á 2FA
       disable_2fa_hint: Sláðu inn OTP og lykilorð til að slökkva.
       plus_subscription: TRMNL+ áskrift
-      plus_subscription_trial_until: You're on a free trial until %{plus_trial_end_at}.
+      plus_subscription_trial_until:
       plus_subscription_hint: Opnar hraðari uppfærslur og fleiri beiðnir. __Lesa meira__.
       plus_subscription_modify: Uppfæra greiðslumáta eða hætta við?
       session: Seta
       session_hint: Þú ert innskráður sem %{user}
       show_title_bar: Sýna titilrönd
       show_title_bar_hint: Ef slökkt, verða viðbætur einfaldari í útliti.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
+      theme_hint:
       time_zone: Tímabelti
       time_zone_hint: Stýrir uppfærslutíðni og svefntíma tækisins.
       locale: Landsstaðall
@@ -213,10 +213,10 @@ is:
       title: Sparaður tími
       cta: Lesa meira
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: Góðan dag
       afternoon_salutation: Góðan dag
@@ -226,14 +226,14 @@ is:
       accepts_beta_firmware: Snemmútgáfa fastbúnaðar
       accepts_beta_firmware_hint: Kveiktu á þessu til að fá nýjustu fastbúnaðaruppfærslur á undan öðrum.
       back_to_devices: Til baka í tæki
-      battery_and_sleep: Battery & Sleep
+      battery_and_sleep:
       battery_consumption: Rafhlöðunotkun
       battery_consumption_hint: Sparaðu orku og lengdu rafhlöðuendingu með því að virkja svefnham.
       battery_learn_more: Lestu meira um hleðslu rafhlöðu __hér__.
-      battery_refresh: Refresh
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      battery_refresh:
+      click:
+      click_action:
+      controls:
       developer_perks: Forritaraeiginleikar
       developer_perks_hint: Valkostir hér að neðan krefjast __forritaraviðbótar__.
       device_credentials: Auðkenni tækis
@@ -243,23 +243,23 @@ is:
       device_model: Gerð tækis
       device_model_hint: Gerð vélbúnaðarins þíns
       device_model_switch_warning: Þetta er hættuleg aðgerð, lestu meira __hér__
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
-      display_calibration: Display Calibration
-      display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
-      display_calibration_pixel_ratio: Pixel Ratio
-      display_calibration_pixel_ratio_hint: 'Image zoom level (0.5–3.0). Default:'
-      display_calibration_ui_scale: UI Scale
-      display_calibration_ui_scale_hint: 'Text and element sizes (0.5–2.0). Default:'
+      device_info:
+      current_firmware:
+      last_ping:
+      unknown:
+      never:
+      display_calibration:
+      display_calibration_hint:
+      display_calibration_pixel_ratio:
+      display_calibration_pixel_ratio_hint:
+      display_calibration_ui_scale:
+      display_calibration_ui_scale_hint:
       edit_device: Breyta tæki
-      firmware: Firmware
-      firmware_updates_enabled: Updates enabled
-      firmware_updates_disabled: Updates disabled
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
+      firmware:
+      firmware_updates_enabled:
+      firmware_updates_disabled:
+      font_family:
+      font_family_hint:
       guest_mode: Gestahamur
       guest_mode_hint: Veldu hvað á að birta (og hversu lengi) þegar gestahamur er virkjaður.
       guest_mode_item_placeholder: Veldu atriði
@@ -269,21 +269,21 @@ is:
       identify_device_hint: Smelltu á hnappinn hér að neðan til að birta skjá sem auðkennir tækið.
       logs: Atburðaskrár
       logs_hint: Villuleitaðu tækið og viðbætur með lifandi atburðaskrá.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
       low_battery_email_notification: Lág rafhlaða - tilkynning með tölvupósti
       low_battery_email_notification_hint: Fáðu tilkynningu með tölvupósti þegar rafhlaðan er að tæmast.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: Spegla
       mirror_device: Spegla annað tæki
       mirror_device_hint: Sláðu inn deilanlegt tækis ID til að spegla spilunarlista þess. Þinn listi birtist áfram.
-      mirror_disabled: Mirroring disabled
-      mirror_enabled: Mirroring
+      mirror_disabled:
+      mirror_enabled:
       mirror_stop: Hætta að spegla
       mirror_sync: Samstilla skjái
       ota_enabled: OTA uppfærslur virkar
@@ -292,12 +292,12 @@ is:
       maximum_compatibility: Hámarkssamhæfni
       maximum_compatibility_hint: Leysir skjávandamál af völdum sumra ePaper rekla. Slekkur á hraðri uppfærslu. Krefst fastbúnaðar 1.6.0+.
       color_and_rotation: Litur og Snúningur
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Skjásnúningur
       screen_rotation_not_supported: Skjásnúningur er ekki í boði fyrir þetta tæki.
-      palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
-      presentation: Presentation
+      palette:
+      palette_hint:
+      presentation:
       sleep_mode: Svefnhamur
       sleep_mode_hint: Stilltu uppfærslutíðni til að bæta einbeitingu og lengja rafhlöðuendingu.
       sleep_screen: Svefnskjár
@@ -306,18 +306,18 @@ is:
       special_function: Sérstakt hnappahlutverk
       special_function_hint: Stilltu sérhæft hlutverk fyrir hnappinn aftan á tækinu.
       special_function_learn_more: Lestu meira um sérstök hlutverk __hér__.
-      temperature_profile: Temperature Profile
-      temperature_profile_hint: Don't change unless instructed. For displays with washed out images.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
-      tidbyt_credentials: Tidbyt Credentials
-      tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
-      tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
-      tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
+      temperature_profile:
+      temperature_profile_hint:
+      touchbar_mode:
+      touchbar_mode_hint:
+      tidbyt_credentials:
+      tidbyt_credentials_hint:
+      tidbyt_api_key:
+      tidbyt_credentials_invalid:
+      tidbyt_device_id:
+      tidbyt_device_api_key:
       unlink: Aftengja
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm:
       unlink_device: Aftengja tæki
       unlink_device_hint: Aftenging gerir tækið öruggt til endursölu eða afhendingar til annars aðila.
       unlink_device_learn_more: Fylgdu leiðbeiningum __hér__.
@@ -331,41 +331,41 @@ is:
         warning_2: Ég skil að þetta er <strong>hætta</strong> og getur skemmt tækið.
         cta: Uppfæra í TRMNL OG (2-bita)
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Tæki
       tagline: TRMNL tækin þín
       add_device_modal_title: Bæta við nýju tæki
       add_first_device: Byrjaðu á því að bæta við fyrsta tækinu þínu!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: Bæta við nýju tæki
       description: Sláðu inn kennimerki tækis til að bæta TRMNL tæki við aðganginn þinn.
@@ -377,8 +377,8 @@ is:
       error: Villa við að aftengja tæki
       success: Tæki aftengt
     external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
+      error:
+      success:
     identify:
       error: Villa við að uppfæra tæki
       success: Beiðni um auðkenningu send
@@ -391,32 +391,32 @@ is:
     switch:
       error: Villa við skiptingu tækis
       success: Tæki skipt
-      title: Switch to device
+      title:
     update:
       error: Villa við að uppfæra tæki
       success: Stillingar tækis %{device} uppfærðar
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: Of margar tilraunir, vinsamlegast bíðið og reynið aftur
     invoice_not_found: Reikningur fannst ekki
@@ -424,9 +424,9 @@ is:
     index:
       title: Atburðaskrár
       all: Allt
-      bulk_destroy: Bulk Destroy
+      bulk_destroy:
       dump: Útskrift
-      id: ID
+      id:
       private_plugins: Einkaviðbætur
       source: Uppruni
       time: Tími
@@ -438,7 +438,7 @@ is:
       design_system: Nýttu innbyggða hönnunarkerfið okkar
       design_system_docs: Skjöl hönnunarkerfis
       dirty_confirm: Þú er með óvistaðar breytingar. Ertu viss um að þú viljir yfirgefa síðuna?
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: Breyta ívafsmáli
       edit_markup_for_plugin: Breyta ívafsmáli fyrir %{plugin_setting_name}
       edit_markup_please_save_first: Vinsamlegast vistaðu áður en þú breytir ívafsmáli
@@ -463,7 +463,7 @@ is:
       no_variables_detected: Engar breytur fundust.
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: 2FA óvirkt
@@ -512,18 +512,18 @@ is:
       remove_from_playlist: Fjarlægja úr spilunarlista
       hide_playlist: Fela þetta atriði
       show_playlist: Sýna þetta atriði
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default:
+        external:
+        global:
+        mashup:
+        readonly:
     create:
       error: Gat ekki uppfært spilunarlista
       success: Spilunarlisti uppfærður
@@ -539,14 +539,14 @@ is:
     set_preferences:
       success: Stillingar snjallspilunarlista uppfærðar
     update:
-      success: Playlist order updated
+      success:
   plugins:
     index:
       title: Viðbætur
       tagline: Hvað viltu setja á TRMNL tækið þitt?
       available: Tiltækar
       connected: Tengdar
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: Uppskriftir
       recipes_hint: Einkaviðbætur frá samfélaginu sem hægt er að setja upp með einum smelli. __Lesa meira__.
     search:
@@ -596,27 +596,27 @@ is:
     forks:
       one: Sjálfun
       other: Sjálfanir
-    forked: Recipe forked
+    forked:
     new:
       error: Uppskrift fannst ekki
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: Virkt
     copy_are_you_sure: Ertu viss um að þú viljir afrita þessa stillingu?
     delete_are_you_sure: Ertu viss um að þú viljir eyða þessari stillingu?
     delete: Þetta fjarlægir allar stillingar viðbótarinnar. Til að fela hana, fjarlægðu hana úr spilunarlistanum í staðinn.
     inactive: Óvirkt
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: Engar stillingar fundust.
-    not_supported: Not supported on current device
+    not_supported:
     refreshing_now_please_wait: Glæði, endurhlaðið síðuna eftir nokkrar sekúndur.
     reset_credentials: "%{plugin_name} aðgangur endurstilltur"
     form:
       active_hint: Sýna eða fela þessa viðbót á tækinu þínu
       advanced_settings: Ítarlegar stillingar
-      back_to_playlist: Back to Playlist
+      back_to_playlist:
       back_to_plugin: Til baka í %{plugin}
       back_to_plugins: Til baka í viðbætur
       connect_with: Tengjast við %{plugin}
@@ -631,25 +631,25 @@ is:
       force_refresh_hint: Aðeins fyrir prófanir – vinsamlegast varist misnotkun.
       force_refresh_click_here: Smelltu hér
       force_refresh_click_here_hint: til að uppfæra skjámynd strax
-      force_refresh_not_possible: This plugin cannot be force-refreshed because the TRMNL server does not perform image processing. Learn how to test your instance __here__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      force_refresh_not_possible:
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: Lesa meira um þessa viðbót í hjálpargagnasafni
       learn_more_fork: Þessi viðbót er afrituð úr uppskrift.
       learn_more_fork_original: Skoða upprunalega
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long:
+      learn_more_native_short:
       learn_more_recipe_author: Þarftu hjálp? Hafðu samband við %{recipe_author} á Discord.
       learn_more_recipe_long: Þessi viðbót er frá samfélaginu og er ekki viðhaldið af TRMNL.
       learn_more_recipe_short: 'Athugið: þessi viðbót er uppskrift.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long:
+      learn_more_third_party_short:
       linked_account: Tengt notandanafni
       linked_account_success: Tókst að tengja við %{plugin_name}
       link_oauth: Tengja aðgang
       link_oauth_hint: Fylgdu öruggu auðkenningarferli frá %{plugin} áður en þú heldur áfram.
-      mirrored: Mirrored
+      mirrored:
       multiple_instances_hint: Þessi viðbót styður margar uppsetningar.
       name: Heiti
       name_hint: Gefðu því auðkennt heiti
@@ -660,37 +660,37 @@ is:
       plugin_uuid_hint: Notað til að senda (Webhook) API beiðnir.
       preview: Forskoðun – tækið þitt mun sýna raunveruleg gögn
       recipe_cta_heading_published: Þessi viðbót er uppskrift
-      recipe_cta_heading_unlisted: This plugin is unlisted
+      recipe_cta_heading_unlisted:
       recipe_cta_heading_in_review: Uppskrift í skoðun
       recipe_cta_heading_not_published: Birta sem uppskrift?
       recipe_cta_body_published: Breytingar verða sýnilegar á núverandi og komandi uppsetningum.
       recipe_cta_body_in_review: Viðbótin hefur verið send inn til skoðunar. Hinkraðu.
       recipe_cta_body_not_published: Senda viðbótina til annarra. __Lesa meira__.
       recipe_cta_confirm: Ertu viss? Teymið okkar mun skoða þetta næstdu daga. Þú getur haldið áfram að breyta á meðan.
-      recipe_mirrored: This screen is mirrored from the recipe.
-      recipe_visibility_title: How would you like to publish?
-      recipe_visibility_edit_title: Edit Submission
-      recipe_visibility_public: Public
-      recipe_visibility_public_hint: Anyone can find and install.
-      recipe_visibility_private: Private
-      recipe_visibility_private_hint: Breaks external installs.
-      recipe_visibility_unlisted: Unlisted
-      recipe_visibility_unlisted_hint: Anyone with the link can install.
+      recipe_mirrored:
+      recipe_visibility_title:
+      recipe_visibility_edit_title:
+      recipe_visibility_public:
+      recipe_visibility_public_hint:
+      recipe_visibility_private:
+      recipe_visibility_private_hint:
+      recipe_visibility_unlisted:
+      recipe_visibility_unlisted_hint:
       refresh_rate: Uppfærslutíðni
       refresh_rate_hint: Stilltu hversu oft þessi viðbót sækir gögn
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
-      refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
+      refresh_rate_jit_hint:
+      refresh_rate_not_configurable:
       refreshed: Uppfært
       remove_plugin: Fjarlægja viðbót
       remove_plugin_hint: Að fjarlægja viðbót fjarlægir hana einnig úr spilunarlista
       synced: Samstillt
       refresh_paused: Uppfærsla í bið
       refresh_paused_hint: Sjálfvirk uppfærsla stöðvuð. Bættu við spilunarlista til að hefja aftur.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
+      refresh_paused_hidden_hint:
       refresh_paused_mashup: Uppfærsla á samsetningum
       refresh_paused_mashup_hint: Sjálfvirk uppfærsla í bið fyrir heilskjá. Samsetningar eru að uppfærast.
       refresh_stopped: Sjálfvirk uppfærsla stöðvuð. Lagfærðu villuna til að halda áfram.
-      view_recipe: View Recipe
+      view_recipe:
       visit_docs: Skoða skjöl
     import:
       archive_too_large: ZIP skrá er of stór (%{max_mb} MB hámark)
@@ -725,7 +725,7 @@ is:
       some_schedule: Sýna þennan skjá aðeins á…
       to: til
       copy_prompt: Afrita tímasetningu frá…
-      no_days_error: Please select at least one day.
+      no_days_error:
   upgrade:
     index:
       title: 'Uppfæri tæki:'

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -2,17 +2,17 @@
 it:
   locale_name: Italiano
   about: Informazioni
-  actions: Actions
+  actions:
   add: Aggiungi
   add_new: Aggiungi nuovo
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: Ho già un account
   are_you_sure: Sei sicuro?
   back: Indietro
   back_to_all_blog_posts: Torna a tutt i post
-  blog: Blog
-  brand: Brand
+  blog:
+  brand:
   buy_now: Compra ora
   cancel: Annulla
   change_password: Cambia Password
@@ -35,7 +35,7 @@ it:
   developer_edition_required: Developer edition è richiesta per abilitare questa funzione
   device_id: ID Dispositivo
   device: Dispositivi
-  discard: Discard
+  discard:
   edit: Modifica
   email_address: Indirizzo email
   export: Esporta
@@ -43,15 +43,15 @@ it:
   first_name: Nome
   forgot_password: Ho dimenticato la password
   forgot_password_title: Ci risiamo
-  friendly_id: Friendly ID
+  friendly_id:
   get_started: Iniziamo!
-  hidden: hidden
+  hidden:
   identify: Identifica
   import: Importa
   import_new: Importa nuovo
   integrations: Integrazioni
   keep_me_signed_in: Ricordami
-  knowledge_base: Knowledge base
+  knowledge_base:
   last_name: Cognome
   learn_more: Scopri di più
   loading: Caricamento
@@ -62,15 +62,15 @@ it:
   mins: min
   my_playlist: La mia Playlist
   new_password: Nuova password
-  password: Password
+  password:
   please_wait: Attendi...
   plugin_not_found: Plugin non trovato
   preview: Anteprima
-  privacy: Privacy
-  refresh_rate: Refresh rate
+  privacy:
+  refresh_rate:
   refresh_rates_hint: Scopri come i gli aggiornamenti fuzionano __qui__.
   reset_password: Reimposta password
-  reset_to_defaults: Reset to defaults
+  reset_to_defaults:
   required: Richiesto
   save: Salva
   shown: Mostrato
@@ -83,7 +83,7 @@ it:
   subscribe: Iscriviti
   help_center: Supporto
   terms: Termini
-  unsaved_changes: You have unsaved changes
+  unsaved_changes:
   update: Aggiorna
   view: Visualizza
   collaboration_request: Vuoi Collaborare?
@@ -145,7 +145,7 @@ it:
       api_key: API Key
       beta_features: Funzioni Beta
       beta_features_hint: Prova le novità qui. Alcune opzioni potrebbero sparire nel tempo.
-      discord_community: Discord Community
+      discord_community:
       discord_username: Qual'è il tuo username Discord?
       discord_username_hint: Potrebbe essere utilizzato per supporto, attribuzione su Recipe pubbliche, ecc.
       email_address: Indirizzo Email
@@ -159,7 +159,7 @@ it:
       email_address_hint: Usato per accedere a TRMNL e ricevere messaggi di sistema.
       first_name_hint: Usiamo il tuo nome per migliorare l'interfaccia TRMNL.
       last_name_hint: Usiamo il tuo cognome per migliorare l'interfaccia TRMNL.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: Usata per proteggere il tuo profilo TRMNL.
       enable_2fa: Abilitare 2FA?
       enable_2fa_hint: __Clicca qui__ per abilitare l'OTP.
@@ -171,10 +171,10 @@ it:
       plus_subscription_modify: Vuoi aggiornare il metodo di pagamento o annullare?
       session: Sessione
       session_hint: Sei connesso/a come %{user}
-      show_title_bar: Show title bar
+      show_title_bar:
       show_title_bar_hint: Se disabilitato, i plugin nativi (non globali) e di terze parti saranno più minimali.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
-      time_zone: Time Zone
+      theme_hint:
+      time_zone:
       time_zone_hint: Determina la frequenza di aggiornamento e il periodo di riposo del dispositivo.
       locale: Lingua
       locale_hint: Quale lingua e localizzazione preferisci? __Vai qui__.
@@ -184,7 +184,7 @@ it:
       success: API key ricreata correttamente
   dashboard:
     index:
-      title: Dashboard
+      title:
       last_7_days: Ultimi 7 giorni
       last_30_days: Ultimi 30 giorni
       last_90_days: Ultimi 90 giorni
@@ -198,7 +198,7 @@ it:
       title: Novità
       cta: Vedi tutti
     playlist_items:
-      title: Playlist
+      title:
       cta: Vai alle Playlist
       pieces_of_content_displayed: Elementi di contenuto mostrati
     plugins:
@@ -213,10 +213,10 @@ it:
       title: Tempo risparmiato
       cta: Maggiori informazioni
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: Buongiorno
       afternoon_salutation: Buon pomeriggio
@@ -231,9 +231,9 @@ it:
       battery_consumption_hint: Risparmia energia e aumenta la durata della batteria attivando la Modalità Riposo.
       battery_learn_more: Scopri di più sulla ricarica della batteria __qui__.
       battery_refresh: Ricarica
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      click:
+      click_action:
+      controls:
       developer_perks: Modalità Sviluppatore
       developer_perks_hint: Queste opzioni richiedono la Modalità Sviluppatore.
       device_credentials: Credenziali Dispositivo
@@ -244,22 +244,22 @@ it:
       device_model_hint: Il tuo modello di Hardware
       device_model_switch_warning: Questa è un operazione pericolosa, scopri di più __qui__
       device_info: Informazioni Dispositivo
-      current_firmware: Current firmware
+      current_firmware:
       last_ping: Ultimo Ping
-      unknown: Unknown
+      unknown:
       never: Mai
       display_calibration: Calibrazione Schermo
       display_calibration_hint: Personalizza il rendering del tuo schermo. Lascia vuoto per usare le impostazioni default del tuo modello.
-      display_calibration_pixel_ratio: Pixel Ratio
+      display_calibration_pixel_ratio:
       display_calibration_pixel_ratio_hint: 'Livello di zoom (0.5–3.0). Default:'
       display_calibration_ui_scale: Scala UI
       display_calibration_ui_scale_hint: 'Dimensioni testo ed elementi (0.5–2.0). Default:'
       edit_device: Modifica Dispositivo
-      firmware: Firmware
+      firmware:
       firmware_updates_enabled: Aggiornamenti attivi
       firmware_updates_disabled: Aggiornamenti disattivati
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family:
+      font_family_hint:
       guest_mode: Modalità Ospite
       guest_mode_hint: Scegli cosa mostrare (e per quanto tempo) quando la modalità ospite è attiva.
       guest_mode_item_placeholder: Scegli un elemento
@@ -267,37 +267,37 @@ it:
       identify: Identifica
       identify_device: Identifica Dispositivo
       identify_device_hint: Fai click sul pulsante sottostante per mostrare una schermata di identificazione sul dispositivo.
-      logs: Logs
+      logs:
       logs_hint: Effettua il debug del tuo dispositivo o plugin con un log degli errori in tempo reale.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
       low_battery_email_notification: Notifica di batteria scarica per Email
-      low_battery_email_notification_hint: Get notified via email when your device battery is running low.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      low_battery_email_notification_hint:
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: Duplica
       mirror_device: Duplica un altro Dispositivo
       mirror_device_hint: Indica un ID Dispositivo (condivisibile) per duplicare la sua playlist. La tua playlist rimarrà visibile.
       mirror_disabled: Mirroring disabilitato
-      mirror_enabled: Mirroring
+      mirror_enabled:
       mirror_stop: Disconnetti Mirroring
       mirror_sync: Sinctronizza Schermi
       ota_enabled: Abilita aggiornamenti OTA
       ota_enabled_hint: Installa automaticamente i nuovi firmware. Disabilita per utilizzare il tuo firmware
-      ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
+      ota_byod_not_supported:
       maximum_compatibility: Abilita compatibilità massima
       maximum_compatibility_hint: Risolve problemi dello schermo causati da alcuni chip driver per ePaper. Disattiva il fast refresh. Richiede Firmware 1.6.0 o successivo.
       color_and_rotation: Colore e Rotazione
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Rotazione Schermo
       screen_rotation_not_supported: La rotazione dello schermo non è attualmente supportata sul tuo dispositivo.
       palette: Palette Colori
       palette_hint: Scegli il set di colori da utilizzare durante la generazione delle schermate per questo dispositivo. Un set più grande è più bello da vedere, ma uno più piccolo viene disegnato più rapidamente. GLi elementi della playlist possono sovrascrivere questa opzione.
-      presentation: Presentation
+      presentation:
       sleep_mode: Modalità Riposo
       sleep_mode_hint: Regola la frequenza di aggiornamento per ottimizzare la concentrazione e la durata della batteria.
       sleep_screen: Schermata di riposo
@@ -308,16 +308,16 @@ it:
       special_function_learn_more: Scopri di più sulle funzioni speciali __qui__.
       temperature_profile: Profilo temperatura
       temperature_profile_hint: Non cambiare se non specificato. Per schermi con immagini sbiadite.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
+      touchbar_mode:
+      touchbar_mode_hint:
       tidbyt_credentials: Credenziali Tidbyt.
       tidbyt_credentials_hint: Inserisci le tue credenziali API per il dispositivo Tidbyt dall'applicazione Tidbyt nelle impostazioni -> Sviluppo -> Ottieni chiave API.
-      tidbyt_api_key: Tidbyt API Key
+      tidbyt_api_key:
       tidbyt_credentials_invalid: Credenziali API Tidbyt API Invalide. Perfavore controlla e riprova.
       tidbyt_device_id: ID Dispositivo
       tidbyt_device_api_key: Chiave API
       unlink: Scollega
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm:
       unlink_device: Scollega Dispositivo
       unlink_device_hint: Scollegare un dispositivo TRMNL rende sicuro rivenderlo o darlo a qualcun altro.
       unlink_device_learn_more: Segui la guida completa __qui__.
@@ -331,41 +331,41 @@ it:
         warning_2: Sono consapevole che questa è un azione <strong>pericolosa</strong> e che può bloccare il mio dispositivo.
         cta: Aggiorna al TRMNL OG (2-bit)
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Dispositivi
       tagline: I tuoi dispositivi TRMNL
       add_device_modal_title: Aggiungi un nuovo dispositivo
       add_first_device: Inizia aggiungendo il tuo primo dispositivo!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: Aggiungi un nuovo dispositivo
       description: Immetti l'ID del dispositivo per aggiungere un nuovo dispositivo TRMNL al tuo profilo.
@@ -391,54 +391,54 @@ it:
     switch:
       error: Errore nel cambio dispositivo
       success: Dispositivo cambiato
-      title: Switch to device
+      title:
     update:
       error: Errore nell'aggiornamento del dispositivo
       success: "%{device} impostazioni dispositivo aggiornate con successo"
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: Troppi tentativi, riprova più tardi
     invoice_not_found: Fattura non trovata
   logs:
     index:
-      title: Logs
+      title:
       all: Tutti
       bulk_destroy: Eliminazione massiva
-      dump: Dump
-      id: ID
+      dump:
+      id:
       private_plugins: Plugin Privati
       source: Sorgente
       time: Ora
   markups:
     console_logs:
-      js_logs: JS Logs
+      js_logs:
     form:
       back_to_plugin_settings: Torna alle impostazioni del plugin
       design_system: Utilizza il nostro sistema di design nativo
       design_system_docs: Documentazione del sistema di design
       dirty_confirm: Hai dei cambiamenti non salvati. Sei sicuro di voler lasciare questa pagina?
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: Modifica Markup
       edit_markup_for_plugin: Modifica markup per %{plugin_setting_name}
       edit_markup_please_save_first: Per favore salva prima di modificare il markup
@@ -463,7 +463,7 @@ it:
       no_variables_detected: Nessuna variabile trovata.
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: 2FA Disabilitato
@@ -479,27 +479,27 @@ it:
       error: Codice OTP non valido
     verify_otp:
       verify: Verifica
-      reset: Reset MFA
+      reset:
       reset_instructions: Clicca il pulsante sul retro del tuo TRMNL per generare un codice di reset
-      success: 2FA successful
+      success:
       error: Codice OTP non valido
   playlist_items:
     index:
-      title: Playlist
+      title:
       tagline: Scegli cosa mostrare
       add_a_group: Aggiungi un gruppo
       add_a_plugin: Aggiungi un Plugin
       add_first_device_cta: Comincia __aggiungendo__ il tuo primo dispositivo TRMNL!
       add_to_playlist: Aggiungi a Playlist
       create_first_playlist_cta: Crea la tua playlist, ma prima __connetti__ il tuo primo plugin!
-      custom: Custom
-      device_default: Device default
+      custom:
+      device_default:
       display_period_from: Mostra dalle
       display_period_to: alle
       display_period_validation: L'ora di inizio deve essere inferiore all'ora di fine. Crea un altro gruppo per le ore notturne.
       every: Ogni
       never_skip: Non saltare schermate.
-      smart_playlist: Smart Playlist
+      smart_playlist:
       smart_playlist_hint: Salta automaticamente le schermate nelle quali il contenuto non è campiato per un po' di tempo.
       skip_after:
         one: Salta schermate stagnanti dopo 1 giorno
@@ -514,8 +514,8 @@ it:
       show_playlist: Mostra elemento
       duplicate: Duplica
       duplicate_confirm: Verrà creata una copia di questo articolo e aggiunta alla fine della playlist. Vuoi continuare?
-      presentation: Presentation
-      color_palette: Color Palette
+      presentation:
+      color_palette:
       device_default: Dispositivo Default (%{name})
       palette_unavailable: Disponibile solo per dispositivi con pattern a più colori
       refresh_rate_disabled:
@@ -531,7 +531,7 @@ it:
       error: Errore nella rimozione dell'elemento dalla Playlist
       success: Plugin rimosso dalla Playlist
     toggle_visibility:
-      success: Playlist item %{change}
+      success:
     duplicate:
       success: Playlist duplicata
     sort:
@@ -546,8 +546,8 @@ it:
       tagline: Cosa metterai sul tuo TRMNL?
       available: Disponibile
       connected: Connesso
-      supported_by_this_device: Supported by this device
-      recipes: Recipes
+      supported_by_this_device:
+      recipes:
       recipes_hint: Plugin privati dai membri della comunità possono essere installati in 1 click. __Scopri di più__.
     search:
       placeholder: Cerca Plugin
@@ -574,13 +574,13 @@ it:
       icon_hint: 512x512px raccomandata
       installation_url: URL installazione
       installation_url_hint: Maggiori dettagli sulla procedura di installazione __qui__.
-      installation_success_webhook_url: Installation Success Webhook URL
-      knowledge_base_url: Knowledge Base URL
+      installation_success_webhook_url:
+      knowledge_base_url:
       management_url: URL gestione Plugin
       management_url_hint: Maggiori dettagli sulla procedura di gestione __qui__.
       markup_url: URL Markup Plugin
       markup_url_hint: Maggiori dettagli sulla generazione delle schermate __qui__.
-      no_screen_padding: No Screen Padding
+      no_screen_padding:
       no_screen_padding_hint: Rmuove il padding esterno per la modalità fullscreen.
       uninstallation_webhook_url: Webhook URL Disistallazione
     edit:
@@ -594,29 +594,29 @@ it:
       one: Connessione
       other: Connessioni
     forks:
-      one: Fork
-      other: Forks
-    forked: Recipe forked
+      one:
+      other:
+    forked:
     new:
       error: Recipe non trovata
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: Attivo
     copy_are_you_sure: Sei sicuro di voler copiare queste impostazioni?
     delete_are_you_sure: Sei sicuro di voler eliminare queste impostazioni?
     delete: Questo cancellerà qualunque impostazione del plugin. Per nascondere questo plugin dal dispositivo, rimuoverlo invece dalla Playlist.
     inactive: Inattivo
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: Impostazioni per plugin non trovate.
-    not_supported: Not supported on current device
+    not_supported:
     refreshing_now_please_wait: Aggiornamento, ricarica questa pagina tra qualche secondo.
     reset_credentials: "%{plugin_name} Account resettato con successo"
     form:
       active_hint: Mostra o nascondi questo plugin sul tuo dispositivo
       advanced_settings: Impostazioni Avanzate
-      back_to_playlist: Back to Playlist
+      back_to_playlist:
       back_to_plugin: Torna a %{plugin}
       back_to_plugins: Torna ai Plugin
       connect_with: Connetti con %{plugin}
@@ -632,9 +632,9 @@ it:
       force_refresh_click_here: Clicca qui
       force_refresh_click_here_hint: per generare subito una nuova schermata
       force_refresh_not_possible: Questo plugin non può essere aggiornato forzatamante perchè il server TRMNL non genera l'immagine. Scopri come provare la tua istanza __qui__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: Maggiori informazioni su questo plugin sono nella nostra knowledge base
       learn_more_fork: Questo plugin è un fork di una Recipe.
       learn_more_fork_original: Mostra Originale
@@ -649,14 +649,14 @@ it:
       linked_account_success: Connesso correttamente con %{plugin_name}
       link_oauth: Collega Profilo
       link_oauth_hint: Prima di continuare, segui la procedura di autorizzazione sicura fornita da %{plugin}
-      mirrored: Mirrored
+      mirrored:
       multiple_instances_hint: Questo plugin supporta istanze multiple.
       name: Nome
       name_hint: Dagli un nome per riconoscerlo facilmente
-      parse: Parse
+      parse:
       parse_save_first: Parse (Salva prima il plugin)
-      parsed: Parsed
-      plugin_uuid: Plugin UUID
+      parsed:
+      plugin_uuid:
       plugin_uuid_hint: Utilizzalo per richieste Webhook API.
       preview: Anteprima - il tuo dispositivo mostrerà dati reali
       recipe_cta_heading_published: Questo plugin è una Recipe
@@ -667,7 +667,7 @@ it:
       recipe_cta_body_in_review: Questo plugin è stato inviato al nostro team. Attendi.
       recipe_cta_body_not_published: Invia questo plugin per essere installabile da altri. __Scopri di più__.
       recipe_cta_confirm: Sei sicuro? Il nostro team verificherà e ti farà sapere in alcuni giorni. Potrai continuare a fare modifiche.
-      recipe_mirrored: This screen is mirrored from the recipe.
+      recipe_mirrored:
       recipe_visibility_title: Come vorresti che venga pubblicata?
       recipe_visibility_edit_title: Modifica Invio
       recipe_visibility_public: Pubblica
@@ -678,19 +678,19 @@ it:
       recipe_visibility_unlisted_hint: Tutti con il link possono installarla.
       refresh_rate: Frequenza di aggiornamento
       refresh_rate_hint: Definisce con quale frequenza questo plugin recupera dati aggiornati
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
-      refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
+      refresh_rate_jit_hint:
+      refresh_rate_not_configurable:
       refreshed: Aggiornato
       remove_plugin: Rimuovi plugin
       remove_plugin_hint: Rimuovendo un plugin verrà rimosso anche dalla tua playlist
       synced: Sincronizzato
       refresh_paused: Aggiornamento in pausa
       refresh_paused_hint: Aggiornamento automatico fermo. Aggiungi una playlist per avviarlo.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
+      refresh_paused_hidden_hint:
       refresh_paused_mashup: Aggiornamento Mashups
       refresh_paused_mashup_hint: Aggiornamento automatico in pausa per schemo interno. Mashups si aggiornano.
       refresh_stopped: Aggiornamento automatico fermo. Correggi l'errore con il plugin per continuare.
-      view_recipe: View Recipe
+      view_recipe:
       visit_docs: Guarda la Documentazione
     import:
       archive_too_large: File ZIP troppo grande (%{max_mb} MB massimi)
@@ -699,7 +699,7 @@ it:
       malformed: "%{filename} non valido"
     create:
       success: Plugin creato e aggiunto alla tua
-      playlist: playlist
+      playlist:
     destroy:
       success: Plugin eliminato
     handle_canceled_consent: Consenso revocato, riprova
@@ -716,7 +716,7 @@ it:
       oldest_to_newest: Dal più vecchio
       most_popular: Popolari
       install: Installa
-      fork: Fork
+      fork:
   schedules:
     form:
       add: Aggiungi programmazione personalizzata
@@ -725,7 +725,7 @@ it:
       some_schedule: Mostra questo schermo solo durante…
       to: alle
       copy_prompt: Copia programmazione da…
-      no_days_error: Please select at least one day.
+      no_days_error:
   upgrade:
     index:
       title: 'Aggiorna dispositivo:'

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -1,25 +1,25 @@
 ---
 ja:
   locale_name: 日本語
-  about: About
-  actions: Actions
+  about:
+  actions:
   add: 追加
   add_new: 新規追加
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: すでにアカウントをお持ちです
-  are_you_sure: Are you sure?
+  are_you_sure:
   back: 戻る
   back_to_all_blog_posts: すべてのブログ記事へ戻る
   blog: ブログ
-  brand: Brand
+  brand:
   buy_now: 今すぐ購入
   cancel: キャンセル
   change_password: パスワード変更
   charge_level: 充電状態
   charged: 充電完了
-  charging: Charging
-  claim_plus_trial: Claim 6 Months Free
+  charging:
+  claim_plus_trial:
   close: 閉じる
   confirm_change_password: パスワードを変更する
   confirm_password: 新しいパスワードを確認
@@ -31,33 +31,33 @@ ja:
   current_device: 現在のデバイス
   days: 日
   delete: 削除
-  developers: Developers
+  developers:
   developer_edition_required: この機能を有効にするには、開発者エディションが必要です。
   device_id: デバイスID
   device: デバイス
-  discard: Discard
+  discard:
   edit: 編集
   email_address: メールアドレス
-  export: Export
+  export:
   fetching: 取得中
   first_name: 名前
   forgot_password: パスワードを忘れました
   forgot_password_title: さあ、再スタートです
-  friendly_id: Friendly ID
+  friendly_id:
   get_started: 始めましょう！
-  hidden: hidden
+  hidden:
   identify: 確認する
-  import: Import
-  import_new: Import new
+  import:
+  import_new:
   integrations: 連携
   keep_me_signed_in: サインイン状態を維持する
   knowledge_base: ナレッジベース
   last_name: 姓
-  learn_more: Learn more
+  learn_more:
   loading: 読み込み中
   login: ログイン
   log_out: ログアウト
-  manage: Manage
+  manage:
   minimum_characters: 最小文字数
   mins: 分
   my_playlist: マイプレイリスト
@@ -65,35 +65,35 @@ ja:
   password: パスワード
   please_wait: しばらくお待ちください...
   plugin_not_found: プラグインが見つかりません
-  preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
+  preview:
+  privacy:
+  refresh_rate:
   refresh_rates_hint: リフレッシュレートの仕組みについては__こちら__をご覧ください。
   reset_password: パスワードをリセット
-  reset_to_defaults: Reset to defaults
-  required: Required
+  reset_to_defaults:
+  required:
   save: 保存
-  shown: shown
+  shown:
   section: セクション
-  settings: Settings
+  settings:
   sign_in: サインインする
   sign_up: サインアップ
   something_went_wrong: 問題が発生しました
-  status: Status
-  subscribe: Subscribe
+  status:
+  subscribe:
   help_center: サポート
-  terms: Terms
-  unsaved_changes: You have unsaved changes
+  terms:
+  unsaved_changes:
   update: 更新
   view: 表示
-  collaboration_request: Wanna collaborate?
-  collaboration_request_hint: Partnerships, group sales, special projects, your call.
-  collaboration_request_cta: Let's talk
+  collaboration_request:
+  collaboration_request_hint:
+  collaboration_request_cta:
   welcome: ようこそ
   time:
     formats:
       shorter: "%-H:%M"
-    start_of_week: 0
+    start_of_week:
   datetime:
     relative:
       past: "%{time}前"
@@ -137,17 +137,17 @@ ja:
     index:
       title: マイアカウント
       tagline: アカウント設定を管理する
-      api_key_confirm: Are you sure you want to regenerate your API Key? The old key will be invalidated.
-      api_key_hint: See __the docs__ to learn how to configure your local environment.
-      api_key_label: The credential for authenticating local development tools
-      api_key_not_generated: "(none yet)"
-      api_key_reset: Regenerate
+      api_key_confirm:
+      api_key_hint:
+      api_key_label:
+      api_key_not_generated:
+      api_key_reset:
       api_key: API Key
-      beta_features: Beta Features
-      beta_features_hint: Try out new stuff here. Options may disappear at any time.
-      discord_community: Discord Community
-      discord_username: What's your Discord username?
-      discord_username_hint: May be used for support, attribution on published Recipes, etc.
+      beta_features:
+      beta_features_hint:
+      discord_community:
+      discord_username:
+      discord_username_hint:
       email_address: メールアドレス
       refer_and_earn: お友達紹介プログラム
       refer_and_earn_hint: パーソナライズされたクーポンでTRMNLをプレゼントしましょう。利用ごとに報酬が発生し、毎月お支払いします。
@@ -159,21 +159,21 @@ ja:
       email_address_hint: TRMNLへのサインアップ時に使用し、システムメッセージを受信するメールアドレスです。
       first_name_hint: TRMNLインターフェースをより快適に使用するため、あなたの名前を使用します。
       last_name_hint: TRMNLインターフェースをより快適に使用するため、あなたの名前を使用します。
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: TRMNLアカウントを保護するために使用します。
       enable_2fa: 2段階認証を有効にする
       enable_2fa_hint: __こちらをクリック__してOTPを有効にします。
       disable_2fa: 2段階認証を無効にする
       disable_2fa_hint: この機能を無効にするには、上記の有効なOTPと現在のパスワードを入力してください。
-      plus_subscription: TRMNL+ Subscription
-      plus_subscription_trial_until: You're on a free trial until %{plus_trial_end_at}.
-      plus_subscription_hint: Unlock faster refresh rates and higher rate limits. __Learn more__.
-      plus_subscription_modify: Want to update your payment method or cancel?
+      plus_subscription:
+      plus_subscription_trial_until:
+      plus_subscription_hint:
+      plus_subscription_modify:
       session: セッション
       session_hint: 現在、%{user}でログインしています。
-      show_title_bar: Show title bar
-      show_title_bar_hint: If disabled, native (non global) and third party plugins will be more minimal.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
+      show_title_bar:
+      show_title_bar_hint:
+      theme_hint:
       time_zone: タイムゾーン（時間帯）
       time_zone_hint: デバイスの更新頻度やスリープモードを決定するために使用します。
       locale: 言語設定
@@ -181,7 +181,7 @@ ja:
     update:
       success: プロフィール情報が更新されました。
     reset_api_key:
-      success: API key was regenerated successfully
+      success:
   dashboard:
     index:
       title: ダッシュボード
@@ -208,15 +208,15 @@ ja:
       new_and_popular: 新着＆人気のプラグイン
     shop:
       title: ショップ
-      need_another: Need another TRMNL?
+      need_another:
     time_saved:
       title: 節約した時間
       cta: 詳しく見る
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: おはようございます
       afternoon_salutation: こんにちは
@@ -226,146 +226,146 @@ ja:
       accepts_beta_firmware: 新しいファームウェアを受け入れる
       accepts_beta_firmware_hint: 通常のユーザーよりも早く新しいデバイスファームウェアを使用するには、ボタンを押してください。
       back_to_devices: デバイス管理画面に戻る
-      battery_and_sleep: Battery & Sleep
+      battery_and_sleep:
       battery_consumption: バッテリー消費
       battery_consumption_hint: デバイスをスリープ モードにすると、バッテリー寿命を延ばすことができます
-      battery_learn_more: Learn more about battery charging __here__.
-      battery_refresh: Refresh
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      battery_learn_more:
+      battery_refresh:
+      click:
+      click_action:
+      controls:
       developer_perks: 開発者向け特典
       developer_perks_hint: 以下は、__開発者オプション__を追加した場合に利用可能です。
       device_credentials: デバイス認証情報
       device_credentials_hint: この認証情報でできることは__こちら__で確認できます
       device_name: デバイス名
       device_name_hint: TRMNLインターフェースをより快適に使用するためです。
-      device_model: Device Model
-      device_model_hint: Your hardware Model
-      device_model_switch_warning: This is a dangerous operation, learn more __here__
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
-      display_calibration: Display Calibration
-      display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
-      display_calibration_pixel_ratio: Pixel Ratio
-      display_calibration_pixel_ratio_hint: 'Image zoom level (0.5–3.0). Default:'
-      display_calibration_ui_scale: UI Scale
-      display_calibration_ui_scale_hint: 'Text and element sizes (0.5–2.0). Default:'
+      device_model:
+      device_model_hint:
+      device_model_switch_warning:
+      device_info:
+      current_firmware:
+      last_ping:
+      unknown:
+      never:
+      display_calibration:
+      display_calibration_hint:
+      display_calibration_pixel_ratio:
+      display_calibration_pixel_ratio_hint:
+      display_calibration_ui_scale:
+      display_calibration_ui_scale_hint:
       edit_device: デバイスを編集
-      firmware: Firmware
-      firmware_updates_enabled: Updates enabled
-      firmware_updates_disabled: Updates disabled
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
-      guest_mode: Guest Mode
-      guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
-      guest_mode_item_placeholder: Choose an item
-      guest_mode_duration_placeholder: Choose a duration
+      firmware:
+      firmware_updates_enabled:
+      firmware_updates_disabled:
+      font_family:
+      font_family_hint:
+      guest_mode:
+      guest_mode_hint:
+      guest_mode_item_placeholder:
+      guest_mode_duration_placeholder:
       identify: 確認する
       identify_device: デバイスを確認する
       identify_device_hint: どのデバイスかを簡単に識別するために、以下のボタンを押してどの画面が表示されているか確認してください。
       logs: ログ
       logs_hint: 生のエラーログのライブフィードでデバイスとプラグインをデバッグします。
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
-      low_battery_email_notification: Low Battery Email Notification
-      low_battery_email_notification_hint: Get notified via email when your device battery is running low.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
+      low_battery_email_notification:
+      low_battery_email_notification_hint:
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: ミラーモード
       mirror_device: 他のデバイスにミラーモードを適用する
       mirror_device_hint: 同じプレイリストを表示するには（共有可能）デバイスIDをお知らせください。あなたのプレイリストは変更なく表示されます。
-      mirror_disabled: Mirroring disabled
-      mirror_enabled: Mirroring
-      mirror_stop: Disconnect Mirroring
-      mirror_sync: Sync Screens
+      mirror_disabled:
+      mirror_enabled:
+      mirror_stop:
+      mirror_sync:
       ota_enabled: OTAアップデート有効
       ota_enabled_hint: 新しいファームウェアを自動的にインストールします。独自のファームウェアを使用するには無効にしてください。
-      ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
-      maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      ota_byod_not_supported:
+      maximum_compatibility:
+      maximum_compatibility_hint:
       color_and_rotation: 色と回転
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: 画面回転
       screen_rotation_not_supported: 画面回転は現在、あなたのデバイスではサポートされていません。
-      palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
-      presentation: Presentation
+      palette:
+      palette_hint:
+      presentation:
       sleep_mode: スリープモード
       sleep_mode_hint: 集中力とバッテリー寿命を最適化するために、更新頻度を調整します。
       sleep_screen: スリープ画面
-      sleep_screen_tooltip: Enable Sleep Mode to use this feature
-      sleep_screen_hint: Display a sleep screen during sleep mode hours.
+      sleep_screen_tooltip:
+      sleep_screen_hint:
       special_function: 特別機能
       special_function_hint: デバイスの背面にあるボタンのダブルクリック機能を設定してください。
       special_function_learn_more: 特別機能について詳しくは__こちら__をクリックしてください。
-      temperature_profile: Temperature Profile
-      temperature_profile_hint: Don't change unless instructed. For displays with washed out images.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
-      tidbyt_credentials: Tidbyt Credentials
-      tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
-      tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
-      tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
+      temperature_profile:
+      temperature_profile_hint:
+      touchbar_mode:
+      touchbar_mode_hint:
+      tidbyt_credentials:
+      tidbyt_credentials_hint:
+      tidbyt_api_key:
+      tidbyt_credentials_invalid:
+      tidbyt_device_id:
+      tidbyt_device_api_key:
       unlink: 接続解除
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm:
       unlink_device: デバイス接続を解除する
       unlink_device_hint: TRMNLデバイスの接続を解除すると、デバイスを再販したり贈ったりするときにより安全です。
-      unlink_device_learn_more: Follow the full guide __here__.
+      unlink_device_learn_more:
       visibility: 共有設定
       visibility_hint: 以下の設定を使用して、TRMNLデバイスをミラーモードにすることができます。
       your_device: あなたのTRMNL
       upgrade_og:
-        title: Upgrade to 2-bit Display Available
-        sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
-        warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
-        warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
-        cta: Upgrade to TRMNL OG (2-bit)
+        title:
+        sub_title:
+        warning_1:
+        warning_2:
+        cta:
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: デバイス管理
       tagline: あなたのTRMNLデバイス
       add_device_modal_title: 新しいデバイスを追加
       add_first_device: 始めるには最初のデバイスを追加してください！
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: 新しいデバイスを追加
       description: デバイスIDを入力して、新しいTRMNLデバイスをアカウントに追加してください。
@@ -377,8 +377,8 @@ ja:
       error: デバイス接続解除エラー
       success: デバイスの接続が正常に解除されました
     external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
+      error:
+      success:
     identify:
       error: デバイス更新エラー
       success: デバイスの確認が要求されました
@@ -391,32 +391,32 @@ ja:
     switch:
       error: デバイス切り替えエラー
       success: デバイスが正常に切り替えられました
-      title: Switch to device
+      title:
     update:
       error: デバイス更新エラー
       success: "%{device}デバイスの設定が正常に更新されました"
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: 試行回数が多すぎます。しばらく待ってから再度お試しください。
     invoice_not_found: 請求書が見つかりませんでした。
@@ -424,38 +424,38 @@ ja:
     index:
       title: ログ
       all: すべて
-      bulk_destroy: Bulk Destroy
+      bulk_destroy:
       dump: 内容
-      id: ID
+      id:
       private_plugins: プライベートプラグイン
       source: ソース
       time: 時刻
   markups:
     console_logs:
-      js_logs: JS Logs
+      js_logs:
     form:
       back_to_plugin_settings: プラグイン設定に戻る
       design_system: ネイティブデザインシステムを活用する
       design_system_docs: デザインシステムドキュメント
       dirty_confirm: 保存されていない変更があります。このページを離れてもよろしいですか？
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: マークアップを編集
       edit_markup_for_plugin: "%{plugin_setting_name}のマークアップを編集"
       edit_markup_please_save_first: マークアップを編集する前に保存してください
       edit_markup_without_preview: マークアップを編集（プレビューなし）
       error_rendering_markup: マークアップのレンダリングエラー
       fix_indentation: インデントを修正
-      go_to_preview: Go To Preview
+      go_to_preview:
       live_preview: ライブプレビュー
       no_changes_to_save: 保存する変更はありません
-      pop_out_preview: Pop Out Preview
+      pop_out_preview:
       quickstart_examples: クイックスタート例
       quickstart_example_applied: 適用済み！
       quickstart_use_this_example: この例を使用
       revert: 元に戻す
       revert_confirm: 元に戻してもよろしいですか？保存されていない変更はすべて失われます。
       save_changes: 変更を保存 (⌘﹢S)
-      separate_preview: Preview is open in a separate window
+      separate_preview:
     merge_variables:
       your_variables: 変数
     no_merge_variables:
@@ -463,7 +463,7 @@ ja:
       no_variables_detected: 変数が検出されませんでした。
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: 2段階認証を無効化しました
@@ -479,8 +479,8 @@ ja:
       error: 無効なOTPコード
     verify_otp:
       verify: 確認
-      reset: Reset MFA
-      reset_instructions: Click the button on the back of your TRMNL to generate a reset code
+      reset:
+      reset_instructions:
       success: 2段階認証に成功しました
       error: 無効なOTPコード
   playlist_items:
@@ -492,38 +492,38 @@ ja:
       add_first_device_cta: 始めるには最初のTRMNLデバイスを__追加__してください！
       add_to_playlist: プレイリストに追加
       create_first_playlist_cta: プレイリストを作成するには最初のプラグインを__接続__してください！
-      custom: Custom
-      device_default: Device default
+      custom:
+      device_default:
       display_period_from: 表示期間：
       display_period_to: "〜"
-      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
-      never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
+      display_period_validation:
+      every:
+      never_skip:
+      smart_playlist:
+      smart_playlist_hint:
       skip_after:
-        one: Skip stale screens after 1 day
-        other: Skip stale screens after %{count} days
+        one:
+        other:
     playlist_item:
-      adjust_schedule: Adjust schedule
+      adjust_schedule:
       delete: このプラグインを削除しますか？プラグインの接続は維持されますが、デバイスには表示されなくなります。
       displayed_now: 今表示中
       not_displayed_yet: まだ表示されていません
       remove_from_playlist: プレイリストから削除
-      hide_playlist: Hide this item
-      show_playlist: Show this item
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      hide_playlist:
+      show_playlist:
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default:
+        external:
+        global:
+        mashup:
+        readonly:
     create:
       error: プレイリストの更新に失敗しました
       success: プレイリストが更新されました
@@ -531,11 +531,11 @@ ja:
       error: プレイリスト内のプラグイン削除エラー
       success: プラグインがプレイリストから削除されました。
     toggle_visibility:
-      success: Playlist item %{change}
+      success:
     duplicate:
       success: Playlist duplicated
     sort:
-      success: Playlist order updated
+      success:
     set_preferences:
       success: Smart playlist preference updated
     update:
@@ -546,7 +546,7 @@ ja:
       tagline: TRMNLに何を表示しますか？
       available: 利用可能なプラグイン
       connected: 接続済み
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: レシピ
       recipes_hint: コミュニティメンバーによるプライベートプラグインで、ワンクリックでインストールできます。__詳細はこちら__。
     search:
@@ -565,9 +565,9 @@ ja:
       tagline: 他のユーザーがあなたのプラグインをインストールできるようにします。
       name: 名前
       category: カテゴリー
-      category_hint: Hold cmd or ctrl to choose up to 3
-      refresh_every: Supported Refresh Interval
-      refresh_every_hint: The fastest refresh interval your plugin can support.
+      category_hint:
+      refresh_every:
+      refresh_every_hint:
       description: 説明
       description_hint: 最大50文字
       icon: アイコン
@@ -580,8 +580,8 @@ ja:
       management_url_hint: 管理フローについては__こちら__をご覧ください。
       markup_url: プラグインマークアップURL
       markup_url_hint: 画面生成については__こちら__をご覧ください。
-      no_screen_padding: No Screen Padding
-      no_screen_padding_hint: Removes the outermost padding in fullscreen mode.
+      no_screen_padding:
+      no_screen_padding_hint:
       uninstallation_webhook_url: アンインストールWebhook URL
     edit:
       title: プラグインの編集
@@ -589,114 +589,114 @@ ja:
       name: 名前
       description: 説明
   plugin_recipes:
-    connected: Recipe connected
+    connected:
     connections:
-      one: Connection
-      other: Connections
+      one:
+      other:
     forks:
-      one: Fork
-      other: Forks
-    forked: Recipe forked
+      one:
+      other:
+    forked:
     new:
       error: レシピが見つかりません
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: アクティブ
     copy_are_you_sure: この設定をコピーしてもよろしいですか？
     delete_are_you_sure: この設定を削除してもよろしいですか？
     delete: プラグインの設定を完全に削除します。デバイスからプラグインを単に隠したいだけなら、プレイリストから削除してください。
     inactive: 非アクティブ
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: プラグインが見つかりません。
-    not_supported: Not supported on current device
+    not_supported:
     refreshing_now_please_wait: 更新中です。数秒後にこのページを再読み込みしてください。
     reset_credentials: "%{plugin_name}アカウントが正常にリセットされました"
     form:
       active_hint: デバイスにこのプラグインインスタンスを表示または非表示にする
-      advanced_settings: Advanced Settings
-      back_to_playlist: Back to Playlist
+      advanced_settings:
+      back_to_playlist:
       back_to_plugin: "%{plugin}に戻る"
       back_to_plugins: プラグイン管理に戻る
       connect_with: "%{plugin}を接続"
-      debug_logs: Debug Logs
-      debug_logs_click_here: Click here
-      debug_logs_click_here_hint: to enable debug logs for this plugin instance.
-      debug_logs_enabled: Debug logs enabled for %{hours} hours.
-      debug_logs_enabled_link: View logs
+      debug_logs:
+      debug_logs_click_here:
+      debug_logs_click_here_hint:
+      debug_logs_enabled:
+      debug_logs_enabled_link:
       disconnect_account: アカウントの接続を解除
       manage_plugin: "%{plugin}を設定"
       force_refresh: 強制リフレッシュ
       force_refresh_hint: この機能はテスト目的です。乱用しないでください。
       force_refresh_click_here: ここをクリック
       force_refresh_click_here_hint: 即座に新しい画面を再生します
-      force_refresh_not_possible: This plugin cannot be force-refreshed because the TRMNL server does not perform image processing. Learn how to test your instance __here__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      force_refresh_not_possible:
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: このプラグインについてもっと知りたい場合は、ドキュメントをご参照ください
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
-      learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_fork:
+      learn_more_fork_original:
+      learn_more_native_long:
+      learn_more_native_short:
+      learn_more_recipe_author:
+      learn_more_recipe_long:
+      learn_more_recipe_short:
+      learn_more_third_party_long:
+      learn_more_third_party_short:
       linked_account: 連携済みアカウント
       linked_account_success: 成功
       link_oauth: アカウント連携
       link_oauth_hint: 続行する前に、この%{plugin}が提供する保護された認証手順に従ってください。
-      mirrored: Mirrored
+      mirrored:
       multiple_instances_hint: このプラグインは複数のインスタンスをサポートしています。
       name: 名前
       name_hint: 覚えやすい名前を付けてください
-      parse: Parse
-      parse_save_first: Parse (Save plugin first)
-      parsed: Parsed
+      parse:
+      parse_save_first:
+      parsed:
       plugin_uuid: プラグイン UUID
       plugin_uuid_hint: Webhook APIリクエストに使用します
       preview: プレビュー - 実際のデータをデバイスに表示します
       recipe_cta_heading_published: This plugin is a Recipe
-      recipe_cta_heading_unlisted: This plugin is unlisted
+      recipe_cta_heading_unlisted:
       recipe_cta_heading_in_review: Recipe in review
       recipe_cta_heading_not_published: Publish as a Recipe?
-      recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
-      recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
-      recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
-      recipe_mirrored: This screen is mirrored from the recipe.
-      recipe_visibility_title: How would you like to publish?
-      recipe_visibility_edit_title: Edit Submission
-      recipe_visibility_public: Public
-      recipe_visibility_public_hint: Anyone can find and install.
-      recipe_visibility_private: Private
-      recipe_visibility_private_hint: Breaks external installs.
-      recipe_visibility_unlisted: Unlisted
-      recipe_visibility_unlisted_hint: Anyone with the link can install.
+      recipe_cta_body_published:
+      recipe_cta_body_in_review:
+      recipe_cta_body_not_published:
+      recipe_cta_confirm:
+      recipe_mirrored:
+      recipe_visibility_title:
+      recipe_visibility_edit_title:
+      recipe_visibility_public:
+      recipe_visibility_public_hint:
+      recipe_visibility_private:
+      recipe_visibility_private_hint:
+      recipe_visibility_unlisted:
+      recipe_visibility_unlisted_hint:
       refresh_rate: リフレッシュ頻度
       refresh_rate_hint: このプラグインインスタンスがどれくらい頻繁に新しいデータを取得するかを決定します
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
-      refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
+      refresh_rate_jit_hint:
+      refresh_rate_not_configurable:
       refreshed: リフレッシュ完了
       remove_plugin: プラグインを削除
       remove_plugin_hint: プラグインを削除すると、プレイリストからも削除されます
       synced: 同期済み
-      refresh_paused: Refresh Paused
-      refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
-      refresh_paused_mashup: Refreshing Mashups
-      refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
-      refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.
-      view_recipe: View Recipe
+      refresh_paused:
+      refresh_paused_hint:
+      refresh_paused_hidden_hint:
+      refresh_paused_mashup:
+      refresh_paused_mashup_hint:
+      refresh_stopped:
+      view_recipe:
       visit_docs: ドキュメントを開く
     import:
-      archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
-      missing_entry: The ZIP file does not contain %{filename}
-      entry_too_large: "%{filename} is too large"
-      malformed: "%{filename} is malformed"
+      archive_too_large:
+      missing_entry:
+      entry_too_large:
+      malformed:
     create:
       success: 'プラグインが作成されました。こちらで確認してください:'
       playlist: プレイリスト
@@ -712,20 +712,20 @@ ja:
       request_received: リクエストを受信しました。受信箱を確認してください
   recipes:
     index:
-      newest_to_oldest: Newest to Oldest
-      oldest_to_newest: Oldest to Newest
-      most_popular: Most Popular
-      install: Install
-      fork: Fork
+      newest_to_oldest:
+      oldest_to_newest:
+      most_popular:
+      install:
+      fork:
   schedules:
     form:
-      add: Add a custom schedule
-      append: And during…
-      no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
-      to: to
-      copy_prompt: Copy schedule from…
-      no_days_error: Please select at least one day.
+      add:
+      append:
+      no_schedule:
+      some_schedule:
+      to:
+      copy_prompt:
+      no_days_error:
   upgrade:
     index:
       title: 'デバイスのアップグレード:'

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -2,11 +2,11 @@
 ko:
   locale_name: 한국어
   about: 소개
-  actions: Actions
+  actions:
   add: 추가하기
   add_new: 새로 추가하기
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: 이미 계정이 있음
   are_you_sure: 정말요?
   back: 뒤로가기
@@ -35,7 +35,7 @@ ko:
   developer_edition_required: 이 기능은 개발자 에디션이 필요해요.
   device_id: 기기 ID
   device: 기기
-  discard: Discard
+  discard:
   edit: 수정
   email_address: 이메일 주소
   export: 내보내기
@@ -43,7 +43,7 @@ ko:
   first_name: 이름
   forgot_password: 비밀번호를 잊어버렸어요
   forgot_password_title: 자, 다시 갑시다
-  friendly_id: Friendly ID
+  friendly_id:
   get_started: 시작해 볼까요!
   hidden: 숨김
   identify: 확인하기
@@ -83,7 +83,7 @@ ko:
   subscribe: 구독
   help_center: 고객지원
   terms: 이용약관
-  unsaved_changes: You have unsaved changes
+  unsaved_changes:
   update: 업데이트
   view: 보기
   collaboration_request: 함께 해볼까요?
@@ -93,7 +93,7 @@ ko:
   time:
     formats:
       shorter: "%-H:%M"
-    start_of_week: 0
+    start_of_week:
   datetime:
     relative:
       past: "%{time} 전"
@@ -159,7 +159,7 @@ ko:
       email_address_hint: TRMNL 가입과 시스템 메시지 수신에 사용돼요.
       first_name_hint: TRMNL을 더 편안하게 만드는 데 사용돼요.
       last_name_hint: TRMNL을 더 편안하게 만드는 데 사용돼요.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: TRMNL 계정을 보호하는 데 사용돼요.
       enable_2fa: 2단계 인증을 사용할까요?
       enable_2fa_hint: OTP를 사용하려면 __여기를 눌러주세요__.
@@ -213,10 +213,10 @@ ko:
       title: 절약한 시간
       cta: 더 알아보기
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: 좋은 아침
       afternoon_salutation: 안녕
@@ -231,9 +231,9 @@ ko:
       battery_consumption_hint: 절전 모드로 배터리를 더 오래 쓸 수 있어요.
       battery_learn_more: 배터리 충전에 대해 __여기서__ 알아보세요.
       battery_refresh: 새로고침
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      click:
+      click_action:
+      controls:
       developer_perks: 개발자 혜택
       developer_perks_hint: 커스텀 플러그인 개발, MAC 주소 편집(BYOD 전용), 펌웨어 조기 배포, API 접근
       device_credentials: 기기 인증 정보
@@ -258,8 +258,8 @@ ko:
       firmware: 펌웨어
       firmware_updates_enabled: 업데이트 활성화됨
       firmware_updates_disabled: 업데이트 비활성화됨
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family:
+      font_family_hint:
       guest_mode: 게스트 모드
       guest_mode_hint: 게스트 모드로 전환될 때 무엇을 화면에 띄우고 얼마나 오래 띄울지 고르세요.
       guest_mode_item_placeholder: 아이템을 고르세요
@@ -269,16 +269,16 @@ ko:
       identify_device_hint: 아래 버튼을 눌러 이 기기를 식별하는 화면을 표시하세요.
       logs: 로그
       logs_hint: 에러 로그 피드로 기기와 플러그인을 디버그하세요.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
       low_battery_email_notification: 배터리 부족 이메일 알림
       low_battery_email_notification_hint: 기기 배터리가 부족하면 이메일로 알려드려요.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: 미러링
       mirror_device: 다른 기기 미러링
       mirror_device_hint: "(공유 가능한) 기기 ID를 입력하면 플레이리스트를 미러링해요. 내 플레이리스트는 그대로 표시돼요."
@@ -292,12 +292,12 @@ ko:
       maximum_compatibility: 최대 호환성 활성화
       maximum_compatibility_hint: 특정 ePaper 드라이버 칩의 디스플레이 문제를 해결해요. 빠른 새로고침이 비활성화돼요. 펌웨어 1.6.0 이상 필요.
       color_and_rotation: 색상과 회전
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: 화면 회전
       screen_rotation_not_supported: 화면 회전은 현재 지원되지 않아요.
       palette: 색상 팔레트
       palette_hint: 화면 생성에 사용할 색상을 선택하세요. 팔레트가 클수록 보기 좋지만, 작을수록 ePaper에서 빠르게 그려져요. 개별 플레이리스트 항목에서 재설정할 수 있어요.
-      presentation: Presentation
+      presentation:
       sleep_mode: 절전 모드
       sleep_mode_hint: 새로고침 주기를 조정해서 집중력과 배터리를 아끼세요.
       sleep_screen: 절전 화면
@@ -308,11 +308,11 @@ ko:
       special_function_learn_more: 특별 기능에 대해 __여기서__ 자세히 알아보세요.
       temperature_profile: 온도 프로파일
       temperature_profile_hint: 안내가 없으면 변경하지 마세요. 화면이 바래 보이는 디스플레이용이에요.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
+      touchbar_mode:
+      touchbar_mode_hint:
       tidbyt_credentials: Tidbyt 인증 정보
       tidbyt_credentials_hint: Tidbyt 앱의 설정 → 개발자 → API 키 받기에서 기기 API 인증 정보를 입력하세요.
-      tidbyt_api_key: Tidbyt API Key
+      tidbyt_api_key:
       tidbyt_credentials_invalid: Tidbyt API 인증 정보가 올바르지 않아요. 다시 확인해주세요.
       tidbyt_device_id: 기기 ID
       tidbyt_device_api_key: API 키
@@ -331,41 +331,41 @@ ko:
         warning_2: 이 작업은 <strong>위험</strong>하고 기기가 벽돌이 될 수 있다는 걸 이해해요.
         cta: TRMNL OG (2-bit)로 업그레이드
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: 기기 관리
       tagline: 내 TRMNL 기기
       add_device_modal_title: 새 기기 추가하기
       add_first_device: 첫 기기를 추가해서 시작하세요!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: 새 기기 추가하기
       description: Friendly ID를 입력해서 새 기기를 계정에 추가하세요.
@@ -391,32 +391,32 @@ ko:
     switch:
       error: 기기 변경 오류
       success: 기기를 변경했어요
-      title: Switch to device
+      title:
     update:
       error: 기기 업데이트 오류
       success: "%{device} 기기 설정을 업데이트했어요"
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: 너무 많이 시도했어요. 잠시 후 다시 해주세요.
     invoice_not_found: 인보이스를 찾을 수 없음
@@ -426,7 +426,7 @@ ko:
       all: 전체
       bulk_destroy: 일괄 삭제
       dump: 덤프
-      id: ID
+      id:
       private_plugins: 비공개 플러그인
       source: 소스
       time: 시간
@@ -438,7 +438,7 @@ ko:
       design_system: 기본 디자인 시스템 활용하기
       design_system_docs: 디자인 시스템 문서
       dirty_confirm: 저장하지 않은 변경사항이 있어요. 이 페이지를 떠날까요?
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: 마크업 편집
       edit_markup_for_plugin: "%{plugin_setting_name} 마크업 편집"
       edit_markup_please_save_first: 마크업을 편집하기 전에 저장해주세요
@@ -463,7 +463,7 @@ ko:
       no_variables_detected: 변수를 찾을 수 없어요.
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: 2단계 인증 비활성화됨
@@ -512,12 +512,12 @@ ko:
       remove_from_playlist: 플레이리스트에서 삭제
       hide_playlist: 이 항목 숨기기
       show_playlist: 이 항목 표시하기
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
         default: 이 플러그인의 새로고침 주기는 설정할 수 없어요.
         external: 이 플러그인은 실시간으로 데이터를 가져오므로 새로고침 주기 설정이 적용되지 않아요.
@@ -546,7 +546,7 @@ ko:
       tagline: TRMNL에 무엇을 올릴까요?
       available: 사용 가능
       connected: 연결됨
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: 레시피
       recipes_hint: 커뮤니티 멤버가 만든 비공개 플러그인을 한번의 클릭으로 설치할 수 있어요. __자세히 알아보기__.
     search:
@@ -594,21 +594,21 @@ ko:
       one: 연결
       other: 연결
     forks:
-      one: Fork
-      other: Forks
-    forked: Recipe forked
+      one:
+      other:
+    forked:
     new:
       error: 레시피를 찾을 수 없어요
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: 활성
     copy_are_you_sure: 이 설정을 복사할까요?
     delete_are_you_sure: 이 설정을 삭제할까요?
     delete: 플러그인 설정을 완전히 삭제해요. 기기에서 플러그인을 숨기고 싶다면 플레이리스트에서 삭제하세요.
     inactive: 비활성
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: 플러그인 설정이 없어요.
     not_supported: 현재 기기에서 지원하지 않아요
     refreshing_now_please_wait: 새로고침 중이에요. 몇 초 후에 페이지를 다시 불러오세요.
@@ -632,9 +632,9 @@ ko:
       force_refresh_click_here: 여기를 눌러
       force_refresh_click_here_hint: 새 화면을 바로 생성하세요
       force_refresh_not_possible: TRMNL 서버가 이미지 처리를 하지 않아서 이 플러그인은 강제 새로고침할 수 없어요. 인스턴스 테스트 방법은 __여기서__ 알아보세요.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: 이 플러그인에 대해 설명서에서 알아보세요
       learn_more_fork: 이 플러그인은 레시피에서 포크됐어요.
       learn_more_fork_original: 원본 보기
@@ -678,7 +678,7 @@ ko:
       recipe_visibility_unlisted_hint: 링크가 있는 사람만 설치할 수 있어요.
       refresh_rate: 새로고침 주기
       refresh_rate_hint: 이 플러그인 인스턴스가 새 데이터를 가져오는 주기를 설정해요
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
+      refresh_rate_jit_hint:
       refresh_rate_not_configurable: "%{refresh_rate} 주기로 동기화 (변경 불가)"
       refreshed: 새로고침됨
       remove_plugin: 플러그인 삭제
@@ -686,7 +686,7 @@ ko:
       synced: 동기화됨
       refresh_paused: 새로고침 일시정지
       refresh_paused_hint: 자동 새로고침이 일시정지됐어요. 플레이리스트에 추가하면 다시 시작돼요.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
+      refresh_paused_hidden_hint:
       refresh_paused_mashup: 매시업 새로고침 중
       refresh_paused_mashup_hint: 전체 화면에서 자동 새로고침이 일시정지됐어요. 매시업은 업데이트 중이에요.
       refresh_stopped: 자동 새로고침이 중지됐어요. 플러그인 오류를 수정해주세요.
@@ -725,7 +725,7 @@ ko:
       some_schedule: 이 시간에만 표시…
       to:
       copy_prompt: 스케줄 복사…
-      no_days_error: Please select at least one day.
+      no_days_error:
   upgrade:
     index:
       title: '기기 업그레이드:'

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -2,11 +2,11 @@
 lt:
   locale_name: Lietuvių
   about: Apie
-  actions: Actions
+  actions:
   add: Pridėti
   add_new: Pridėti naują
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: Jau turiu paskyrą
   are_you_sure: Ar esate tikri?
   back: Atgal
@@ -35,7 +35,7 @@ lt:
   developer_edition_required: Norint įjungti šią funkciją, reikalinga kūrėjo versija.
   device_id: Įrenginio ID
   device: Įrenginys
-  discard: Discard
+  discard:
   edit: Redaguoti
   email_address: El. pašto adresas
   export: Eksportuoti
@@ -83,7 +83,7 @@ lt:
   subscribe: Prenumeruoti
   help_center: Pagalba
   terms: Sąlygos
-  unsaved_changes: You have unsaved changes
+  unsaved_changes:
   update: Atnaujinti
   view: Peržiūrėti
   collaboration_request: Norite bendradarbiauti?
@@ -92,7 +92,7 @@ lt:
   welcome: Sveiki
   time:
     formats:
-      shorter: "%-I:%M %p"
+      shorter:
     start_of_week: 1
   datetime:
     relative:
@@ -159,7 +159,7 @@ lt:
       email_address_hint: Naudojama prisijungimui prie TRMNL ir sistemos pranešimams gauti.
       first_name_hint: Mes naudojame jūsų vardą, kad TRMNL sąsaja būtų jaukesnė.
       last_name_hint: Mes naudojame jūsų pavardę, kad TRMNL sąsaja būtų jaukesnė.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: Naudojamas jūsų TRMNL paskyros apsaugai.
       enable_2fa: Įjungti 2FA?
       enable_2fa_hint: __Spustelėkite čia__, kad įjungtumėte OTP.
@@ -213,10 +213,10 @@ lt:
       title: Sutaupytas laikas
       cta: Skaityti apie
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: Labas rytas
       afternoon_salutation: Laba diena
@@ -231,9 +231,9 @@ lt:
       battery_consumption_hint: Taupykite energiją ir mėgaukitės ilgesniu baterijos veikimo laiku įjungdami miego režimą.
       battery_learn_more: Sužinokite daugiau apie baterijos įkrovimą __čia__.
       battery_refresh: Atnaujinti
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      click:
+      click_action:
+      controls:
       developer_perks: Privilegijos kūrėjams
       developer_perks_hint: Pasirinktinių įskiepių kūrimas, redaguojamas MAC adresas (tik BYOD), ankstyvosios programinės įrangos versijos ir API prieiga.
       device_credentials: Įrenginio kredencialai
@@ -258,8 +258,8 @@ lt:
       firmware: Programinė įranga
       firmware_updates_enabled: Atnaujinimai įjungti
       firmware_updates_disabled: Atnaujinimai išjungti
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family:
+      font_family_hint:
       guest_mode: Svečio režimas
       guest_mode_hint: Pasirinkite, ką rodyti (ir kiek laiko), kai įjungtas svečio režimas.
       guest_mode_item_placeholder: Pasirinkite elementą
@@ -269,16 +269,16 @@ lt:
       identify_device_hint: Spustelėkite žemiau esantį mygtuką, kad šio įrenginio ekrane būtų sugeneruotas vaizdas, padedantis jį atpažinti.
       logs: Žurnalai (Logs)
       logs_hint: Derinkite savo įrenginį ir įskiepius naudodami tiesioginį klaidų žurnalų srautą.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
       low_battery_email_notification: Pranešimas el. paštu apie senkančią bateriją
       low_battery_email_notification_hint: Gaukite pranešimą el. paštu, kai jūsų įrenginio baterija senka.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: Veidrodinis atspindys
       mirror_device: Atspindėti kitą įrenginį
       mirror_device_hint: Pateikite (bendrinamą) įrenginio ID, kad atspindėtumėte jo grojaraštį. Jūsų grojaraštis vis tiek bus rodomas.
@@ -292,12 +292,12 @@ lt:
       maximum_compatibility: Įjungti maksimalų suderinamumą
       maximum_compatibility_hint: Išsprendžia ekrano problemas, kurias sukelia tam tikros ePaper tvarkyklės. Išjungia greitąjį atnaujinimą. Reikalinga programinė įranga 1.6.0+.
       color_and_rotation: Spalvų ir ratavimas
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Ekranų ratavimas
       screen_rotation_not_supported: Ekranų ratavimas šiuo metu nepalaikomas jūsų įrenginyje.
       palette: Spalvų paletė
       palette_hint: Pasirinkite spalvų rinkinį, kuris bus naudojamas generuojant šio įrenginio ekranus. Didesnė paletė atrodo gražiau, tačiau mažesnė paletė ePaper ekrane piešiama greičiau. Atskiri grojaraščio elementai gali perrašyti šį nustatymą.
-      presentation: Presentation
+      presentation:
       sleep_mode: Miego režimas
       sleep_mode_hint: Sureguliuokite atnaujinimo dažnį, kad optimizuotumėte dėmesio sutelkimą ir baterijos veikimo laiką.
       sleep_screen: Miego ekranas
@@ -312,7 +312,7 @@ lt:
       touchbar_mode_hint: Į kokio tipo gestus turėtų reaguoti jūsų įrenginys?
       tidbyt_credentials: Tidbyt kredencialai
       tidbyt_credentials_hint: Įveskite savo Tidbyt įrenginio API kredencialus iš Tidbyt programėlės (skiltyje Settings → Developer → Get API Key).
-      tidbyt_api_key: Tidbyt API Key
+      tidbyt_api_key:
       tidbyt_credentials_invalid: Tidbyt API kredencialai negalioja. Patikrinkite ir bandykite dar kartą.
       tidbyt_device_id: Įrenginio ID
       tidbyt_device_api_key: API raktas
@@ -331,41 +331,41 @@ lt:
         warning_2: Suprantu, kad tai yra <strong>pavojingas</strong> veiksmas ir gali sugadinti mano įrenginį.
         cta: Atnaujinti į TRMNL OG (2-bit)
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Įrenginiai
       tagline: Jūsų TRMNL įrenginiai
       add_device_modal_title: Pridėti naują įrenginį
       add_first_device: Pradėkite pridėdami savo pirmąjį įrenginį!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: Pridėti naują įrenginį
       description: Įveskite savo Friendly ID, kad pridėtumėte naują įrenginį prie savo paskyros.
@@ -391,32 +391,32 @@ lt:
     switch:
       error: Klaida perjungiant įrenginį
       success: Įrenginys sėkmingai perjungtas
-      title: Switch to device
+      title:
     update:
       error: Klaida atnaujinant įrenginį
       success: "%{device} įrenginio nustatymai sėkmingai atnaujinti"
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: Per daug bandymų, palaukite ir bandykite dar kartą
     invoice_not_found: Sąskaita-faktūra nerasta
@@ -426,7 +426,7 @@ lt:
       all: Visi
       bulk_destroy: Masinis trynimas
       dump: Išrašas (Dump)
-      id: ID
+      id:
       private_plugins: Privatūs įskiepiai
       source: Šaltinis
       time: Laikas
@@ -438,7 +438,7 @@ lt:
       design_system: Pasinaudokite mūsų vietine dizaino sistema
       design_system_docs: Dizaino sistemos dokumentacija
       dirty_confirm: Turite neišsaugotų pakeitimų. Ar tikrai norite išeiti iš šio puslapio?
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: Redaguoti žymėjimą
       edit_markup_for_plugin: Redaguoti %{plugin_setting_name} žymėjimą
       edit_markup_please_save_first: Prieš redaguodami žymėjimą, išsaugokite
@@ -463,7 +463,7 @@ lt:
       no_variables_detected: Kintamųjų neaptikta.
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: 2FA išjungta
@@ -514,7 +514,7 @@ lt:
       show_playlist: Rodyti šį elementą
       duplicate: Dubliuoti
       duplicate_confirm: Tai sukurs šio elemento kopiją ir pridės ją prie jūsų grojaraščio apačios. Tęsti?
-      presentation: Presentation
+      presentation:
       color_palette: Spalvų paletė
       device_default: Įrenginio numatytasis (%{name})
       palette_unavailable: Galima tik įrenginiams su keliomis spalvų paletėmis
@@ -546,7 +546,7 @@ lt:
       tagline: Ką įkelsite į savo TRMNL?
       available: Prieinami
       connected: Prijungti
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: Receptai
       recipes_hint: Bendruomenės narių privatūs įskiepiai, kuriuos galima įdiegti 1 spustelėjimu. __Sužinokite daugiau__.
     search:
@@ -600,15 +600,15 @@ lt:
     new:
       error: Receptas nerastas
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: Aktyvus
     copy_are_you_sure: Ar tikrai norite nukopijuoti šį nustatymą?
     delete_are_you_sure: Ar tikrai norite ištrinti šį nustatymą?
     delete: Tai visiškai pašalins įskiepio nustatymus. Norėdami tiesiog paslėpti šį įskiepį savo įrenginyje, ištrinkite jį iš savo grojaraščio.
     inactive: Neaktyvus
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: Įskiepio nustatymų nerasta.
     not_supported: Nepalaikoma dabartiniame įrenginyje
     refreshing_now_please_wait: Dabar atnaujinama, perkraukite šį puslapį po kelių sekundžių.
@@ -632,9 +632,9 @@ lt:
       force_refresh_click_here: Spustelėkite čia
       force_refresh_click_here_hint: kad iškart sugeneruotumėte naują ekraną
       force_refresh_not_possible: Šio įskiepio negalima atnaujinti priverstinai, nes TRMNL serveris neatlieka vaizdo apdorojimo. Sužinokite, kaip išbandyti savo instanciją __čia__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: Sužinokite apie šį įskiepį mūsų žinių bazėje
       learn_more_fork: Šis įskiepis buvo atšakotas iš recepto.
       learn_more_fork_original: Žiūrėti originalą
@@ -678,7 +678,7 @@ lt:
       recipe_visibility_unlisted_hint: Įsidiegti gali visi, kas turi nuorodą.
       refresh_rate: Atnaujinimo dažnis
       refresh_rate_hint: Nustatykite, kaip dažnai ši įskiepio instancija nuskaito šviežius duomenis
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
+      refresh_rate_jit_hint:
       refresh_rate_not_configurable: Sinchronizuojama %{refresh_rate} (nekonfigūruojama)
       refreshed: Atnaujinta
       remove_plugin: Pašalinti įskiepį
@@ -686,7 +686,7 @@ lt:
       synced: Sinchronizuota
       refresh_paused: Atnaujinimas sustabdytas
       refresh_paused_hint: Automatinis atnaujinimas pristabdytas. Pridėkite prie grojaraščio, kad paleistumėte vėl.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
+      refresh_paused_hidden_hint:
       refresh_paused_mashup: Atnaujinami mišiniai (Mashups)
       refresh_paused_mashup_hint: Automatinis atnaujinimas pristabdytas viso ekrano režimui. Mišiniai atnaujinami.
       refresh_stopped: Automatinis atnaujinimas sustabdytas. Norėdami tęsti, ištaisykite įskiepio klaidą.
@@ -725,7 +725,7 @@ lt:
       some_schedule: Rodyti šį ekraną tik šiuo metu…
       to: iki
       copy_prompt: Kopijuoti tvarkaraštį iš…
-      no_days_error: Please select at least one day.
+      no_days_error:
   upgrade:
     index:
       title: 'Atnaujinamas įrenginys:'

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -1,25 +1,25 @@
 ---
 nl:
   locale_name: Dutch
-  about: About
-  actions: Actions
+  about:
+  actions:
   add: Toevoegen
   add_new: Nieuwe toevoegen
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: Ik heb al een account
-  are_you_sure: Are you sure?
+  are_you_sure:
   back: Terug
   back_to_all_blog_posts: Terug naar alle berichten
-  blog: Blog
-  brand: Brand
+  blog:
+  brand:
   buy_now: Nu kopen
   cancel: Annuleren
   change_password: Wachtwoord wijzigen
   charge_level: Laadniveau
   charged: opgeladen
-  charging: Charging
-  claim_plus_trial: Claim 6 Months Free
+  charging:
+  claim_plus_trial:
   close: Sluiten
   confirm_change_password: Mijn wachtwoord wijzigen
   confirm_password: Bevestig nieuwe wachtwoord
@@ -31,33 +31,33 @@ nl:
   current_device: Huidig apparaat
   days: dagen
   delete: Verwijder
-  developers: Developers
+  developers:
   developer_edition_required: Developer-editie is vereist om deze functie in the schakelen.
   device_id: Apparaat ID
   device: Apparaat
-  discard: Discard
+  discard:
   edit: Bewerken
   email_address: Emailadres
-  export: Export
+  export:
   fetching: Ophalen
   first_name: Voornaam
   forgot_password: Wachtwoord vergeten
   forgot_password_title: Hier gaan we weer
-  friendly_id: Friendly ID
+  friendly_id:
   get_started: Laten we beginnen!
-  hidden: hidden
+  hidden:
   identify: Identificeren
-  import: Import
-  import_new: Import new
+  import:
+  import_new:
   integrations: Integraties
   keep_me_signed_in: Blijf ingelogd
   knowledge_base: Kennisbank
   last_name: Achternaam
-  learn_more: Learn more
+  learn_more:
   loading: Laden
   login: Inloggen
   log_out: Uitloggen
-  manage: Manage
+  manage:
   minimum_characters: karakters minimaal
   mins: min.
   my_playlist: Mijn afspeellijst
@@ -65,30 +65,30 @@ nl:
   password: Wachtwoord
   please_wait: Even geduld...
   plugin_not_found: Plugin niet gevonden
-  preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
+  preview:
+  privacy:
+  refresh_rate:
   refresh_rates_hint: Leer __hier__ hoe verversingssnelheden werken
   reset_password: Vraag nieuw wachtwoord op
-  reset_to_defaults: Reset to defaults
-  required: Required
+  reset_to_defaults:
+  required:
   save: Opslaan
-  shown: shown
+  shown:
   section: Sectie
-  settings: Settings
+  settings:
   sign_in: Inloggen
   sign_up: Registreren
   something_went_wrong: Er is iets misgegaan
-  status: Status
-  subscribe: Subscribe
-  help_center: Support
-  terms: Terms
-  unsaved_changes: You have unsaved changes
+  status:
+  subscribe:
+  help_center:
+  terms:
+  unsaved_changes:
   update: Bijwerken
   view: Bekijk
-  collaboration_request: Wanna collaborate?
-  collaboration_request_hint: Partnerships, group sales, special projects, your call.
-  collaboration_request_cta: Let's talk
+  collaboration_request:
+  collaboration_request_hint:
+  collaboration_request_cta:
   welcome: Welkom
   time:
     formats:
@@ -135,19 +135,19 @@ nl:
           other: bijna %{count} jaar
   account:
     index:
-      title: Account
+      title:
       tagline: Accountinstellingen beheren
       api_key_confirm: Weet je zeker dat je een nieuwe API key wil genereren? De oude is dan niet meer geldig.
       api_key_hint: Bekijk __de documentatie__ om meer te weten te komen hoe je een lokale ontwikkelomgeving kan instellen.
       api_key_label: Gegevens voor authenticatie van de lokale ontwikkelomgeving
-      api_key_not_generated: "(none yet)"
+      api_key_not_generated:
       api_key_reset: Hergenereer
       api_key: API Key
-      beta_features: Beta Features
-      beta_features_hint: Try out new stuff here. Options may disappear at any time.
-      discord_community: Discord Community
-      discord_username: What's your Discord username?
-      discord_username_hint: May be used for support, attribution on published Recipes, etc.
+      beta_features:
+      beta_features_hint:
+      discord_community:
+      discord_username:
+      discord_username_hint:
       email_address: Emailadres
       refer_and_earn: Verwijs en verdien
       refer_and_earn_hint: Deel TRMNL via een gepersonaliseerde coupon. Verdien per gebruik, maandelijks uitbetaald.
@@ -159,21 +159,21 @@ nl:
       email_address_hint: Gebruikt om in te loggen bij TRMNL en systeemberichten te ontvangen.
       first_name_hint: We gebruiken jouw naam om de TRMNL interface persoonlijker te maken.
       last_name_hint: We gebruiken jouw naam om de TRMNL interface persoonlijker te maken.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: Wordt gebruikt om jouw TRMNL account te beveiligen.
       enable_2fa: 2FA inschakelen?
       enable_2fa_hint: __Klik hier__ om OTP in te schakelen.
       disable_2fa: 2FA uitschakelen
       disable_2fa_hint: Geef een geldig OTP en het huidige wachtwoord hierboven op om deze functie in te schakelen.
-      plus_subscription: TRMNL+ Subscription
-      plus_subscription_trial_until: You're on a free trial until %{plus_trial_end_at}.
-      plus_subscription_hint: Unlock faster refresh rates and higher rate limits. __Learn more__.
-      plus_subscription_modify: Want to update your payment method or cancel?
+      plus_subscription:
+      plus_subscription_trial_until:
+      plus_subscription_hint:
+      plus_subscription_modify:
       session: Sessie
       session_hint: Je bent ingelogd als %{user}
-      show_title_bar: Show title bar
-      show_title_bar_hint: If disabled, native (non global) and third party plugins will be more minimal.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
+      show_title_bar:
+      show_title_bar_hint:
+      theme_hint:
       time_zone: Tijdzone
       time_zone_hint: Bepaalt de refresh rates en apparaat slaapmodus.
       locale: Landinstelling
@@ -184,7 +184,7 @@ nl:
       success: API key is succesvol gegenereerd
   dashboard:
     index:
-      title: Dashboard
+      title:
       last_7_days: Laatste 7 dagen
       last_30_days: Laatste 30 dagen
       last_90_days: Laatste 90 dagen
@@ -202,21 +202,21 @@ nl:
       cta: Ga naar afspeellijsten
       pieces_of_content_displayed: Aantal content elementen die getoond worden
     plugins:
-      title: Plugins
+      title:
       cta: Ga naar plugins
       connected: Verbonden
       new_and_popular: Nieuw en populair
     shop:
       title: Winkel
-      need_another: Need another TRMNL?
+      need_another:
     time_saved:
       title: Tijd bespaard
       cta: Lees meer
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: Goedemorgen
       afternoon_salutation: Goedemiddag
@@ -226,40 +226,40 @@ nl:
       accepts_beta_firmware: Beta firmware-release
       accepts_beta_firmware_hint: Schakel in om de nieuwste beta firmwareverbeteringen voor je apparaat te ontvangen.
       back_to_devices: Terug naar apparaten
-      battery_and_sleep: Battery & Sleep
+      battery_and_sleep:
       battery_consumption: Batterijgebruik
       battery_consumption_hint: Bespaar energie en geniet van een langere batterijduur door slaapmodus te activeren.
       battery_learn_more: Meer over het opladen van je batterij lees je __hier__.
-      battery_refresh: Refresh
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      battery_refresh:
+      click:
+      click_action:
+      controls:
       developer_perks: Ontwikkelaarsvoordelen
       developer_perks_hint: De onderstaande opties vereisen de __ontwikkelaars-add-on__.
       device_credentials: Apparaatgegevens
       device_credentials_hint: Beijk __hier__ wat je met deze gegevens kunt doen.
       device_name: Apparaatnaam
       device_name_hint: We gebruiken dit om de TRMNL interface persoonlijker te maken
-      device_model: Device Model
+      device_model:
       device_model_hint: Jouw hardware Model
       device_model_switch_warning: Dit is een gevaarlijke actie, lees __hier__ meer
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
-      display_calibration: Display Calibration
-      display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
-      display_calibration_pixel_ratio: Pixel Ratio
-      display_calibration_pixel_ratio_hint: 'Image zoom level (0.5–3.0). Default:'
-      display_calibration_ui_scale: UI Scale
-      display_calibration_ui_scale_hint: 'Text and element sizes (0.5–2.0). Default:'
+      device_info:
+      current_firmware:
+      last_ping:
+      unknown:
+      never:
+      display_calibration:
+      display_calibration_hint:
+      display_calibration_pixel_ratio:
+      display_calibration_pixel_ratio_hint:
+      display_calibration_ui_scale:
+      display_calibration_ui_scale_hint:
       edit_device: Apparaat bewerken
-      firmware: Firmware
-      firmware_updates_enabled: Updates enabled
-      firmware_updates_disabled: Updates disabled
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
+      firmware:
+      firmware_updates_enabled:
+      firmware_updates_disabled:
+      font_family:
+      font_family_hint:
       guest_mode: Gast Modus
       guest_mode_hint: Kies wat je wil tonen (en voor hoe lang) in gast modus.
       guest_mode_item_placeholder: Kies een item
@@ -269,55 +269,55 @@ nl:
       identify_device_hint: Klik op onderstaande knop om een scherm op dit apparaat te tonen om het makkelijk te identificeren.
       logs: Logboeken
       logs_hint: Debug je apparaat en plugins met een live-feed van de foutlogboeken.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
       low_battery_email_notification: Lege Batterij Email Notificatie
-      low_battery_email_notification_hint: Get notified via email when your device battery is running low.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      low_battery_email_notification_hint:
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: Spiegelen
       mirror_device: Spiegel een ander apparaat
       mirror_device_hint: Geef een (deelbaar) apparaat ID op om zijn afspeellijst te spiegelen. Jouw afspeellijst wordt nog steeds getoond.
-      mirror_disabled: Mirroring disabled
-      mirror_enabled: Mirroring
-      mirror_stop: Disconnect Mirroring
-      mirror_sync: Sync Screens
+      mirror_disabled:
+      mirror_enabled:
+      mirror_stop:
+      mirror_sync:
       ota_enabled: OTA-updates ingeschakeld
       ota_enabled_hint: Installeer automatisch nieuwe firmware. Deactiveer als je je je eigen firmware wil gebruiken.
-      ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
+      ota_byod_not_supported:
       maximum_compatibility: Activeer Maximale Compatibiliteit
       maximum_compatibility_hint: Los scherm issues op met bepaalde ePaper driver chips. Zet snelle verversing uit. Firmware 1.6.0+ benodigd.
       color_and_rotation: Kleur en rotatie
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Schermrotatie
       screen_rotation_not_supported: Schermrotatie is momenteel niet ondersteund op je apparaat.
-      palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
-      presentation: Presentation
+      palette:
+      palette_hint:
+      presentation:
       sleep_mode: Slaapmodus
       sleep_mode_hint: Pas de refresh rate aan om focus en batterijduur te optimaliseren.
       sleep_screen: Slaapscherm
-      sleep_screen_tooltip: Enable Sleep Mode to use this feature
-      sleep_screen_hint: Display a sleep screen during sleep mode hours.
+      sleep_screen_tooltip:
+      sleep_screen_hint:
       special_function: Speciale functie
       special_function_hint: Stel een dubbelklikfunctie in voor de knop aan de achterkant van je apparaat.
       special_function_learn_more: Lees __hier__ meer over speciale functies.
-      temperature_profile: Temperature Profile
-      temperature_profile_hint: Don't change unless instructed. For displays with washed out images.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
-      tidbyt_credentials: Tidbyt Credentials
-      tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
-      tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
-      tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
+      temperature_profile:
+      temperature_profile_hint:
+      touchbar_mode:
+      touchbar_mode_hint:
+      tidbyt_credentials:
+      tidbyt_credentials_hint:
+      tidbyt_api_key:
+      tidbyt_credentials_invalid:
+      tidbyt_device_id:
+      tidbyt_device_api_key:
       unlink: Ontkoppelen
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm:
       unlink_device: Apparaat ontkoppelen
       unlink_device_hint: Door een TRMNL apparaat te ontkoppelen kun je hem veilig verkopen of aan iemand anders geven.
       unlink_device_learn_more: Volg __hier__ de volledige handleiding.
@@ -331,41 +331,41 @@ nl:
         warning_2: Ik snap dat dit een <strong>gevaarlijke</strong> actie is en dat ik mijn device onbruikmaar kan maken (bricken).
         cta: Upgrade naar TRMNL OG (2-bit)
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Apparaten
       tagline: Jouw TRMNL apparaten
       add_device_modal_title: Nieuw apparaat toevoegen
       add_first_device: Begin door jouw eerste apparaat toe te voegen!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: Nieuw apparaat toevoegen
       description: Voer je Apparaat ID in om een nieuw TRMNL apparaat aan je account toe te voegen.
@@ -377,8 +377,8 @@ nl:
       error: Fout bij ontkoppelen apparaat
       success: Apparaat succesvol ontkoppeld
     external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
+      error:
+      success:
     identify:
       error: Fout bij updaten apparaat
       success: Apparaatidentificatie aangevraagd
@@ -391,32 +391,32 @@ nl:
     switch:
       error: Fout bij wisselen apparaat
       success: Apparaat succesvol gewisseld
-      title: Switch to device
+      title:
     update:
       error: Fout bij updaten apparaat
       success: "%{device} apparaatinstellingen succesvol bijgewerkt"
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: Te vaak geprobeerd. Wacht even en probeer het laten nog eens
     invoice_not_found: Factuur niet gevonden
@@ -424,38 +424,38 @@ nl:
     index:
       title: Logboeken
       all: Alles
-      bulk_destroy: Bulk Destroy
+      bulk_destroy:
       dump: Verwijderen
-      id: ID
+      id:
       private_plugins: Privé-plugins
       source: Bron
       time: Tijd
   markups:
     console_logs:
-      js_logs: JS Logs
+      js_logs:
     form:
       back_to_plugin_settings: Terug naar plugin-instellingen
       design_system: Maak gebruik van ons native ontwerp-systeem
       design_system_docs: Documentatie van het ontwerp-systeem
       dirty_confirm: Je hebt niet-opgeslagen wijzigingen. Weet je zeker dat je deze pagina wilt verlaten?
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: Markup bewerken
       edit_markup_for_plugin: Markup voor %{plugin_setting_name} bewerken
       edit_markup_please_save_first: Sla op voordat je de markup bewerkt
       edit_markup_without_preview: Markup bewerken (zonder voorbeeldweergave)
       error_rendering_markup: Fout bij het weergeven van de markup
       fix_indentation: Inspringing corrigeren
-      go_to_preview: Go To Preview
+      go_to_preview:
       live_preview: Live voorbeeld
       no_changes_to_save: Geen wijzigingen om op te slaan
-      pop_out_preview: Pop Out Preview
+      pop_out_preview:
       quickstart_examples: Snelstartvoorbeelden
       quickstart_example_applied: Toegepast!
       quickstart_use_this_example: Gebruik dit voorbeeld
       revert: Terugzetten
       revert_confirm: Weet je zeker dat je wilt terugzetten? All niet-opgeslagen wijzigingen gaan verloren.
       save_changes: Wijzigingen opslaan (⌘﹢S)
-      separate_preview: Preview is open in a separate window
+      separate_preview:
     merge_variables:
       your_variables: Jouw variabelen
     no_merge_variables:
@@ -463,7 +463,7 @@ nl:
       no_variables_detected: Geen variabelen gedetecteerd.
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: 2FA uitschaekeld
@@ -492,7 +492,7 @@ nl:
       add_first_device_cta: Begin door jouw eerste TRMNL apparaat __toe te voegen__!
       add_to_playlist: Toevoegen aan afspeellijst
       create_first_playlist_cta: Maak jouw afspeellijst nadat je jouw eerst plugin __verbindt__!
-      custom: Custom
+      custom:
       device_default: Device standaard
       display_period_from: Weergeven van
       display_period_to: tot
@@ -512,18 +512,18 @@ nl:
       remove_from_playlist: Verwijderen van afspeellijst
       hide_playlist: Verberg dit item
       show_playlist: Toon dit item
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default:
+        external:
+        global:
+        mashup:
+        readonly:
     create:
       error: Bijwerken van afspeellijst is mislukt
       success: Afspeellijst is bijgewerkt
@@ -531,22 +531,22 @@ nl:
       error: Fout bij het verwijderen van afspeellijst
       success: Plugin verwijderd van afspeellijst
     toggle_visibility:
-      success: Playlist item %{change}
+      success:
     duplicate:
       success: Playlist duplicated
     sort:
-      success: Playlist order updated
+      success:
     set_preferences:
       success: Smart playlist preference updated
     update:
       success: Volgorde afspeellijst bijgewerkt
   plugins:
     index:
-      title: Plugins
+      title:
       tagline: Wat ga jij op jouw TRMNL zetten?
       available: Beschikbaar
       connected: Verbonden
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: Recepten
       recipes_hint: Privé-plugins van communityleden die met één klik kunnen worden geïnstalleerd. __Lees meer__.
     search:
@@ -580,8 +580,8 @@ nl:
       management_url_hint: Lees __hier__ meer over het beheerprocess.
       markup_url: Plugin-markup-URL
       markup_url_hint: Lees __hier__ meer over schermgeneratie.
-      no_screen_padding: No Screen Padding
-      no_screen_padding_hint: Removes the outermost padding in fullscreen mode.
+      no_screen_padding:
+      no_screen_padding_hint:
       uninstallation_webhook_url: Webhook-URL voor deïnstallatie
     edit:
       title: Plugin bewerken
@@ -591,106 +591,106 @@ nl:
   plugin_recipes:
     connected: Recept verbonden
     connections:
-      one: Connection
-      other: Connections
+      one:
+      other:
     forks:
-      one: Fork
-      other: Forks
-    forked: Recipe forked
+      one:
+      other:
+    forked:
     new:
       error: Recept niet gevonden
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: Actief
     copy_are_you_sure: Weet je zeker dat je deze instelling wilt kopiëren?
     delete_are_you_sure: Weet je zeker dat je deze instelling wilt verwijderen?
     delete: Hiermee verwijder je de instellingen van de plugin volledig. Om deze plugin simpelweg te verbergen verwijder je deze uit jouw afspeellijst.
     inactive: Inactief
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: Geen plugininstellingen gevonden.
-    not_supported: Not supported on current device
+    not_supported:
     refreshing_now_please_wait: Plugin wordt ververst, herlaad de pagina over een paar seconden.
     reset_credentials: "%{plugin_name} account succesvol hersteld"
     form:
       active_hint: Toon of verberg deze plugin op je apparaat
       advanced_settings: Geavanceerde Instellingen
-      back_to_playlist: Back to Playlist
+      back_to_playlist:
       back_to_plugin: Terug naar %{plugin}
       back_to_plugins: Terug naar plugins
       connect_with: Verbinden met %{plugin}
-      debug_logs: Debug Logs
+      debug_logs:
       debug_logs_click_here: Klik hier
       debug_logs_click_here_hint: om debug logs in te zien voor deze plugin.
       debug_logs_enabled: Debug logs actief voor %{hours} uur.
-      debug_logs_enabled_link: View logs
+      debug_logs_enabled_link:
       disconnect_account: Account loskoppelen
       manage_plugin: Configureer %{plugin}
       force_refresh: Forceer verversen
       force_refresh_hint: Deze functie is alleen ontworpen voor testdoeleinden - maak er geen misbruik van.
       force_refresh_click_here: Klik hier
       force_refresh_click_here_hint: om direct een nieuw scherm te genereren
-      force_refresh_not_possible: This plugin cannot be force-refreshed because the TRMNL server does not perform image processing. Learn how to test your instance __here__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      force_refresh_not_possible:
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: Kom meer te weten over deze plugin in onze kennisbank
       learn_more_fork: Deze plugin is een fork van een recept.
       learn_more_fork_original: Bekijk het origineel
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long:
+      learn_more_native_short:
       learn_more_recipe_author: Hulp nodig? Neem contact op met %{recipe_author} via Discord.
       learn_more_recipe_long: Deze plugin is een recept uit de community, en wordt niet onderhouden door TRMNL.
       learn_more_recipe_short: 'Noot: deze plugin is een recept'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long:
+      learn_more_third_party_short:
       linked_account: Gekoppeld account
       linked_account_success: Succesvol gekoppeld met %{plugin_name}
       link_oauth: Account koppelen
       link_oauth_hint: Voordat je verder gaat, volg het veilige authenticatieproces van %{plugin}
-      mirrored: Mirrored
+      mirrored:
       multiple_instances_hint: Deze plugin ondersteunt meerdere instanties.
       name: Naam
       name_hint: Voer een naam in om het makkelijk te herkennen in de toekomst
       parse: Analyseer
       parse_save_first: Analyseer (Sla je plugin eerst op)
       parsed: Geanalyseerd
-      plugin_uuid: Plugin UUID
+      plugin_uuid:
       plugin_uuid_hint: Gebruik dit om Webhook API requests te maken.
       preview: Voorbeeld - jouw apparaat zal echte data tonen
       recipe_cta_heading_published: Deze plugin is een recept
-      recipe_cta_heading_unlisted: This plugin is unlisted
+      recipe_cta_heading_unlisted:
       recipe_cta_heading_in_review: Recept onder beoordeling
       recipe_cta_heading_not_published: Publiceer als recept?
       recipe_cta_body_published: Veranderingen worden doorgevoerd bij bestaande installaties en toekomstige installaties en forks.
       recipe_cta_body_in_review: De plugin is ingediend bij het team. Nog even geduld.
       recipe_cta_body_not_published: Verstuur de plugin zodat anderen deze ook kunnen gebruiken. __Lees hier meer over__.
       recipe_cta_confirm: Weet je het zeker? Ons team zal je plugin reviewen en bij je terugkomen met mogelijke vragen. Je kan ondertussen wijzigingen blijven doorvoeren.
-      recipe_mirrored: This screen is mirrored from the recipe.
-      recipe_visibility_title: How would you like to publish?
-      recipe_visibility_edit_title: Edit Submission
-      recipe_visibility_public: Public
-      recipe_visibility_public_hint: Anyone can find and install.
-      recipe_visibility_private: Private
-      recipe_visibility_private_hint: Breaks external installs.
-      recipe_visibility_unlisted: Unlisted
-      recipe_visibility_unlisted_hint: Anyone with the link can install.
+      recipe_mirrored:
+      recipe_visibility_title:
+      recipe_visibility_edit_title:
+      recipe_visibility_public:
+      recipe_visibility_public_hint:
+      recipe_visibility_private:
+      recipe_visibility_private_hint:
+      recipe_visibility_unlisted:
+      recipe_visibility_unlisted_hint:
       refresh_rate: Verversingssnelheid
       refresh_rate_hint: Bepaal hoe vaak deze plugin instantie verse data ophaalt
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
-      refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
+      refresh_rate_jit_hint:
+      refresh_rate_not_configurable:
       refreshed: Ververst
       remove_plugin: Plugin verwijderen
       remove_plugin_hint: Het verwijderen van een plugin zal deze ook uit je afspeellijst verwijderen
       synced: Gesynchroniseerd
       refresh_paused: Verversen gepauzeerd
       refresh_paused_hint: Auto-verversen is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
+      refresh_paused_hidden_hint:
       refresh_paused_mashup: Mashups worden ververst
       refresh_paused_mashup_hint: Auto-verversen gepauzeerd voor fullscreen. Mashups worden geupdate.
       refresh_stopped: Auto-verversen gestopt. Los de plugin fouten op om door te gaan.
-      view_recipe: View Recipe
+      view_recipe:
       visit_docs: Bekijk documentatie
     import:
       archive_too_large: ZIP bestand is te groot (%{max_mb} MB max)
@@ -716,7 +716,7 @@ nl:
       oldest_to_newest: Oud naar nieuw
       most_popular: Populairste
       install: Installeer
-      fork: Fork
+      fork:
   schedules:
     form:
       add: Voeg een op-maat schema toe
@@ -725,7 +725,7 @@ nl:
       some_schedule: Toon enkel tijdens…
       to: naar
       copy_prompt: Kopieër schema van…
-      no_days_error: Please select at least one day.
+      no_days_error:
   upgrade:
     index:
       title: 'Apparaat upgraden:'

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -1,25 +1,25 @@
 ---
 'no':
   locale_name: Norwegian
-  about: About
-  actions: Actions
+  about:
+  actions:
   add: Legg til
   add_new: Legg til ny
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: Jeg har allerede en konto
-  are_you_sure: Are you sure?
+  are_you_sure:
   back: Tilbake
   back_to_all_blog_posts: Tilbake til alle innlegg
   blog: Blogg
-  brand: Brand
+  brand:
   buy_now: Kjøp nå
   cancel: Avbryt
   change_password: Endre passord
   charge_level: Ladestatus
   charged: ladet
-  charging: Charging
-  claim_plus_trial: Claim 6 Months Free
+  charging:
+  claim_plus_trial:
   close: Lukk
   confirm_change_password: Endre mitt passord
   confirm_password: Bekreft nytt passord
@@ -31,11 +31,11 @@
   current_device: Nåværende enhet
   days: dager
   delete: Slett
-  developers: Developers
+  developers:
   developer_edition_required: Utviklerutgaven kreves for å aktivere denne funksjonen.
   device_id: Enhets-ID
   device: Enhet
-  discard: Discard
+  discard:
   edit: Innstillinger
   email_address: E-postadresse
   export: Eksporter
@@ -43,9 +43,9 @@
   first_name: Fornavn
   forgot_password: Jeg glemte passordet mitt
   forgot_password_title: Her går vi igjen
-  friendly_id: Friendly ID
+  friendly_id:
   get_started: La oss komme i gang!
-  hidden: hidden
+  hidden:
   identify: Identifiser
   import: Importer
   import_new: Importer ny
@@ -53,11 +53,11 @@
   keep_me_signed_in: Hold meg pålogget
   knowledge_base: Kunnskapsbase
   last_name: Etternavn
-  learn_more: Learn more
+  learn_more:
   loading: Laster
   login: Logg inn
   log_out: Logg ut
-  manage: Manage
+  manage:
   minimum_characters: minimum antall tegn
   mins: min
   my_playlist: Min spilleliste
@@ -65,30 +65,30 @@
   password: Passord
   please_wait: Vennligst vent...
   plugin_not_found: Plugin ikke funnet
-  preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
+  preview:
+  privacy:
+  refresh_rate:
   refresh_rates_hint: Lær hvordan oppdateringsfrekvenser fungerer __her__.
   reset_password: Tilbakestill passordet mitt
-  reset_to_defaults: Reset to defaults
-  required: Required
+  reset_to_defaults:
+  required:
   save: Lagre
-  shown: shown
+  shown:
   section: Seksjon
-  settings: Settings
+  settings:
   sign_in: Logg inn
   sign_up: Registrer deg
   something_went_wrong: Noe gikk galt
-  status: Status
-  subscribe: Subscribe
-  help_center: Support
-  terms: Terms
-  unsaved_changes: You have unsaved changes
+  status:
+  subscribe:
+  help_center:
+  terms:
+  unsaved_changes:
   update: Oppdater
   view: Vis
-  collaboration_request: Wanna collaborate?
-  collaboration_request_hint: Partnerships, group sales, special projects, your call.
-  collaboration_request_cta: Let's talk
+  collaboration_request:
+  collaboration_request_hint:
+  collaboration_request_cta:
   welcome: Velkommen
   time:
     formats:
@@ -137,17 +137,17 @@
     index:
       title: Konto
       tagline: Administrer kontoinnstillingene dine
-      api_key_confirm: Are you sure you want to regenerate your API Key? The old key will be invalidated.
-      api_key_hint: See __the docs__ to learn how to configure your local environment.
-      api_key_label: The credential for authenticating local development tools
-      api_key_not_generated: "(none yet)"
-      api_key_reset: Regenerate
+      api_key_confirm:
+      api_key_hint:
+      api_key_label:
+      api_key_not_generated:
+      api_key_reset:
       api_key: API Key
-      beta_features: Beta Features
-      beta_features_hint: Try out new stuff here. Options may disappear at any time.
-      discord_community: Discord Community
-      discord_username: What's your Discord username?
-      discord_username_hint: May be used for support, attribution on published Recipes, etc.
+      beta_features:
+      beta_features_hint:
+      discord_community:
+      discord_username:
+      discord_username_hint:
       email_address: E-postadresse
       refer_and_earn: Henvis og tjen
       refer_and_earn_hint: Gi gaven av TRMNL med en personlig kupong. Tjen per bruk, betalt månedlig.
@@ -159,21 +159,21 @@
       email_address_hint: Brukes for å logge inn på TRMNL og motta systemmeldinger.
       first_name_hint: Vi bruker navnet ditt for å gjøre TRMNL-grensesnittet mer personlig.
       last_name_hint: Vi bruker navnet ditt for å gjøre TRMNL-grensesnittet mer personlig.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: Brukes for å beskytte TRMNL-kontoen din.
       enable_2fa: Aktiver 2FA?
       enable_2fa_hint: __Klikk her__ for å aktivere OTP.
       disable_2fa: Deaktiver 2FA
       disable_2fa_hint: Oppgi gyldig OTP og nåværende passord ovenfor for å deaktivere denne funksjonen.
-      plus_subscription: TRMNL+ Subscription
-      plus_subscription_trial_until: You're on a free trial until %{plus_trial_end_at}.
-      plus_subscription_hint: Unlock faster refresh rates and higher rate limits. __Learn more__.
-      plus_subscription_modify: Want to update your payment method or cancel?
+      plus_subscription:
+      plus_subscription_trial_until:
+      plus_subscription_hint:
+      plus_subscription_modify:
       session: Økt
       session_hint: Du er logget inn som %{user}
-      show_title_bar: Show title bar
-      show_title_bar_hint: If disabled, native (non global) and third party plugins will be more minimal.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
+      show_title_bar:
+      show_title_bar_hint:
+      theme_hint:
       time_zone: Tidssone
       time_zone_hint: Bestemmer oppdateringsfrekvenser og enhetens hviletid.
       locale: Språk
@@ -181,7 +181,7 @@
     update:
       success: Profil oppdatert
     reset_api_key:
-      success: API key was regenerated successfully
+      success:
   dashboard:
     index:
       title: Oversikt
@@ -202,21 +202,21 @@
       cta: Rediger spilleliste
       pieces_of_content_displayed: Antall viste innholdselementer
     plugins:
-      title: Plugins
+      title:
       cta: Gå til Plugins
       connected: Tilkoblet
       new_and_popular: Nye og populære
     shop:
       title: Butikk
-      need_another: Need another TRMNL?
+      need_another:
     time_saved:
       title: Tid spart
       cta: Les om
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: God morgen
       afternoon_salutation: God ettermiddag
@@ -226,146 +226,146 @@
       accepts_beta_firmware: Tidlig utgivelse av fastvare
       accepts_beta_firmware_hint: Slå på for å få de nyeste fastvareoppdateringene før andre brukere.
       back_to_devices: Tilbake til enheter
-      battery_and_sleep: Battery & Sleep
+      battery_and_sleep:
       battery_consumption: Batteriforbruk
       battery_consumption_hint: Spar strøm og få lengre batterilevetid ved å aktivere dvalemodus.
-      battery_learn_more: Learn more about battery charging __here__.
-      battery_refresh: Refresh
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      battery_learn_more:
+      battery_refresh:
+      click:
+      click_action:
+      controls:
       developer_perks: Utviklerfordeler
       developer_perks_hint: Valgene nedenfor krever __Utviklertillegget__.
       device_credentials: Enhetslegitimasjon
       device_credentials_hint: Se hva du kan gjøre med denne legitimasjonen __her__
       device_name: Enhetsnavn
       device_name_hint: Vi bruker dette for å gjøre TRMNL-grensesnittet mer brukervennlig
-      device_model: Device Model
-      device_model_hint: Your hardware Model
-      device_model_switch_warning: This is a dangerous operation, learn more __here__
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
-      display_calibration: Display Calibration
-      display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
-      display_calibration_pixel_ratio: Pixel Ratio
-      display_calibration_pixel_ratio_hint: 'Image zoom level (0.5–3.0). Default:'
-      display_calibration_ui_scale: UI Scale
-      display_calibration_ui_scale_hint: 'Text and element sizes (0.5–2.0). Default:'
+      device_model:
+      device_model_hint:
+      device_model_switch_warning:
+      device_info:
+      current_firmware:
+      last_ping:
+      unknown:
+      never:
+      display_calibration:
+      display_calibration_hint:
+      display_calibration_pixel_ratio:
+      display_calibration_pixel_ratio_hint:
+      display_calibration_ui_scale:
+      display_calibration_ui_scale_hint:
       edit_device: Rediger enhet
-      firmware: Firmware
-      firmware_updates_enabled: Updates enabled
-      firmware_updates_disabled: Updates disabled
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
-      guest_mode: Guest Mode
-      guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
-      guest_mode_item_placeholder: Choose an item
-      guest_mode_duration_placeholder: Choose a duration
+      firmware:
+      firmware_updates_enabled:
+      firmware_updates_disabled:
+      font_family:
+      font_family_hint:
+      guest_mode:
+      guest_mode_hint:
+      guest_mode_item_placeholder:
+      guest_mode_duration_placeholder:
       identify: Identifiser
       identify_device: Identifiser enhet
       identify_device_hint: Klikk på knappen nedenfor for å generere en skjerm på denne enheten som hjelper med å identifisere den.
       logs: Logger
       logs_hint: Feilsøk enheten og plugins med en live feed av rå feillogger.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
-      low_battery_email_notification: Low Battery Email Notification
-      low_battery_email_notification_hint: Get notified via email when your device battery is running low.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
+      low_battery_email_notification:
+      low_battery_email_notification_hint:
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: Speil
       mirror_device: Speil en annen enhet
       mirror_device_hint: Oppgi en (delbar) enhets-ID for å speile dens spilleliste. Din spilleliste vil fortsatt vises.
-      mirror_disabled: Mirroring disabled
-      mirror_enabled: Mirroring
-      mirror_stop: Disconnect Mirroring
-      mirror_sync: Sync Screens
+      mirror_disabled:
+      mirror_enabled:
+      mirror_stop:
+      mirror_sync:
       ota_enabled: OTA-oppdateringer aktivert
       ota_enabled_hint: Installerer automatisk ny fastvare. Deaktiver for å bruke din egen fastvare.
-      ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
-      maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      ota_byod_not_supported:
+      maximum_compatibility:
+      maximum_compatibility_hint:
       color_and_rotation: Farge og rotasjon
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Skjermrotasjon
       screen_rotation_not_supported: Skjermrotasjon er ikke understøttet på din enhet.
-      palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
-      presentation: Presentation
+      palette:
+      palette_hint:
+      presentation:
       sleep_mode: Dvalemodus
       sleep_mode_hint: Juster oppdateringsfrekvensen for å optimalisere fokus og batterilevetid.
       sleep_screen: Dvaleskjerm
-      sleep_screen_tooltip: Enable Sleep Mode to use this feature
-      sleep_screen_hint: Display a sleep screen during sleep mode hours.
+      sleep_screen_tooltip:
+      sleep_screen_hint:
       special_function: Spesiell funksjon
       special_function_hint: Angi en dobbeltklikk-funksjon for knappen på baksiden av enheten.
       special_function_learn_more: Les mer om spesialfunksjoner __her__.
-      temperature_profile: Temperature Profile
-      temperature_profile_hint: Don't change unless instructed. For displays with washed out images.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
-      tidbyt_credentials: Tidbyt Credentials
-      tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
-      tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
-      tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
+      temperature_profile:
+      temperature_profile_hint:
+      touchbar_mode:
+      touchbar_mode_hint:
+      tidbyt_credentials:
+      tidbyt_credentials_hint:
+      tidbyt_api_key:
+      tidbyt_credentials_invalid:
+      tidbyt_device_id:
+      tidbyt_device_api_key:
       unlink: Koble fra
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm:
       unlink_device: Koble fra enhet
       unlink_device_hint: Å koble fra en TRMNL-enhet gjør den trygg å selge videre eller gi bort.
-      unlink_device_learn_more: Follow the full guide __here__.
+      unlink_device_learn_more:
       visibility: Synlighet
       visibility_hint: Gjør TRMNL-enheten din speilbar ved å endre innstillingene nedenfor.
       your_device: Din TRMNL
       upgrade_og:
-        title: Upgrade to 2-bit Display Available
-        sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
-        warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
-        warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
-        cta: Upgrade to TRMNL OG (2-bit)
+        title:
+        sub_title:
+        warning_1:
+        warning_2:
+        cta:
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Enheter
       tagline: Dine TRMNL-enheter
       add_device_modal_title: Legg til en ny enhet
       add_first_device: Start med å legge til din første enhet!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: Legg til en ny enhet
       description: Skriv inn din enhets-ID for å legge til en ny TRMNL-enhet til kontoen din.
@@ -377,8 +377,8 @@
       error: Feil ved frakobling av enhet
       success: Enheten ble frakoblet
     external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
+      error:
+      success:
     identify:
       error: Feil ved oppdatering av enhet
       success: Forespørsel om enhetsidentifikasjon sendt
@@ -391,32 +391,32 @@
     switch:
       error: Feil ved bytting av enhet
       success: Enheten ble byttet
-      title: Switch to device
+      title:
     update:
       error: Feil ved oppdatering av enhet
       success: "%{device} enhetsinnstillingene ble oppdatert"
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: For mange forsøk, vennligst vent og prøv igjen
     invoice_not_found: Faktura ikke funnet
@@ -424,38 +424,38 @@
     index:
       title: Logger
       all: Alle
-      bulk_destroy: Bulk Destroy
-      dump: Dump
-      id: ID
+      bulk_destroy:
+      dump:
+      id:
       private_plugins: Private plugins
       source: Kilde
       time: Tid
   markups:
     console_logs:
-      js_logs: JS Logs
+      js_logs:
     form:
       back_to_plugin_settings: Tilbake til plugin-innstillinger
       design_system: Dra nytte av vårt innebygde designsystem
       design_system_docs: Dokumentasjon for designsystem
       dirty_confirm: Du har uspurte endringer. Er du sikker på at du vil forlate denne siden?
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: Rediger markup
       edit_markup_for_plugin: Rediger markup for %{plugin_setting_name}
       edit_markup_please_save_first: Vennligst lagre før du redigerer markup
       edit_markup_without_preview: Rediger markup (uten forhåndsvisning)
       error_rendering_markup: Feil ved gjengivelse av markup
       fix_indentation: Fiks innrykk
-      go_to_preview: Go To Preview
+      go_to_preview:
       live_preview: Direkte forhåndsvisning
       no_changes_to_save: Ingen endringer å lagre
-      pop_out_preview: Pop Out Preview
+      pop_out_preview:
       quickstart_examples: Raskstartseksempler
       quickstart_example_applied: Anvendt!
       quickstart_use_this_example: Bruk dette eksempelet
       revert: Angre
       revert_confirm: Er du sikker på at du vil angre? Alle uspurte endringer vil gå tapt.
       save_changes: Lagre endringer (⌘﹢S)
-      separate_preview: Preview is open in a separate window
+      separate_preview:
     merge_variables:
       your_variables: Dine variabler
     no_merge_variables:
@@ -463,7 +463,7 @@
       no_variables_detected: Ingen variabler oppdaget.
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: 2FA deaktivert
@@ -479,8 +479,8 @@
       error: Ugyldig OTP-kode
     verify_otp:
       verify: Verifiser
-      reset: Reset MFA
-      reset_instructions: Click the button on the back of your TRMNL to generate a reset code
+      reset:
+      reset_instructions:
       success: 2FA vellykket
       error: Ugyldig OTP-kode
   playlist_items:
@@ -492,38 +492,38 @@
       add_first_device_cta: Start med å __legge til__ din første TRMNL-enhet!
       add_to_playlist: Legg til i spilleliste
       create_first_playlist_cta: Lag spillelisten din etter å ha __koblet til__ din første plugin!
-      custom: Custom
-      device_default: Device default
+      custom:
+      device_default:
       display_period_from: Vis fra
       display_period_to: til
-      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
-      never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
+      display_period_validation:
+      every:
+      never_skip:
+      smart_playlist:
+      smart_playlist_hint:
       skip_after:
-        one: Skip stale screens after 1 day
-        other: Skip stale screens after %{count} days
+        one:
+        other:
     playlist_item:
-      adjust_schedule: Adjust schedule
+      adjust_schedule:
       delete: Er du sikker på at du vil fjerne dette elementet? Pluginen vil fortsatt være tilkoblet, men ikke vist på enheten din.
       displayed_now: Vises nå
       not_displayed_yet: Venter
       remove_from_playlist: Fjern fra spilleliste
-      hide_playlist: Hide this item
-      show_playlist: Show this item
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      hide_playlist:
+      show_playlist:
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default:
+        external:
+        global:
+        mashup:
+        readonly:
     create:
       error: Kunne ikke oppdatere spillelisten
       success: Spilleliste oppdatert
@@ -531,22 +531,22 @@
       error: Feil ved fjerning av element fra spilleliste
       success: Plugin fjernet fra spilleliste
     toggle_visibility:
-      success: Playlist item %{change}
+      success:
     duplicate:
       success: Playlist duplicated
     sort:
-      success: Playlist order updated
+      success:
     set_preferences:
       success: Smart playlist preference updated
     update:
       success: Rekkefølgen i spillelisten er oppdatert
   plugins:
     index:
-      title: Plugins
+      title:
       tagline: Hva vil du vise på din TRMNL?
       available: Tilgjengelig
       connected: Tilkoblet
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: Oppskrifter
       recipes_hint: Private plugins fra fellesskapet som kan installeres med ett klikk. __Les mer__.
     search:
@@ -565,9 +565,9 @@
       tagline: Andre brukere vil kunne installere din plugin.
       name: Navn
       category: Kategori
-      category_hint: Hold cmd or ctrl to choose up to 3
-      refresh_every: Supported Refresh Interval
-      refresh_every_hint: The fastest refresh interval your plugin can support.
+      category_hint:
+      refresh_every:
+      refresh_every_hint:
       description: Beskrivelse
       description_hint: Maksimum 50 tegn
       icon: Ikon
@@ -580,8 +580,8 @@
       management_url_hint: Les mer om administrasjonsflyten __her__.
       markup_url: Plugin Markup-URL
       markup_url_hint: Les mer om skjermgenerering __her__.
-      no_screen_padding: No Screen Padding
-      no_screen_padding_hint: Removes the outermost padding in fullscreen mode.
+      no_screen_padding:
+      no_screen_padding_hint:
       uninstallation_webhook_url: Webhook-URL for avinstallasjon
     edit:
       title: Rediger plugin
@@ -589,108 +589,108 @@
       name: Navn
       description: Beskrivelse
   plugin_recipes:
-    connected: Recipe connected
+    connected:
     connections:
-      one: Connection
-      other: Connections
+      one:
+      other:
     forks:
-      one: Fork
-      other: Forks
-    forked: Recipe forked
+      one:
+      other:
+    forked:
     new:
       error: Oppskrift ikke funnet
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: Aktiv
     copy_are_you_sure: Er du sikker på at du vil kopiere denne innstillingen?
     delete_are_you_sure: Er du sikker på at du vil slette denne innstillingen?
     delete: Dette vil fullstendig fjerne plugin-innstillingene. For kun å skjule pluginen fra enheten din, fjern den fra spillelisten i stedet.
     inactive: Inaktiv
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: Ingen plugin-innstillinger funnet.
-    not_supported: Not supported on current device
+    not_supported:
     refreshing_now_please_wait: Oppdaterer nå, last siden på nytt om noen sekunder.
     reset_credentials: "%{plugin_name} konto ble tilbakestilt"
     form:
       active_hint: Vis eller skjul denne plugin-instansen på enheten din
-      advanced_settings: Advanced Settings
-      back_to_playlist: Back to Playlist
+      advanced_settings:
+      back_to_playlist:
       back_to_plugin: Tilbake til %{plugin}
       back_to_plugins: Tilbake til plugins
       connect_with: Koble til %{plugin}
-      debug_logs: Debug Logs
-      debug_logs_click_here: Click here
-      debug_logs_click_here_hint: to enable debug logs for this plugin instance.
-      debug_logs_enabled: Debug logs enabled for %{hours} hours.
-      debug_logs_enabled_link: View logs
+      debug_logs:
+      debug_logs_click_here:
+      debug_logs_click_here_hint:
+      debug_logs_enabled:
+      debug_logs_enabled_link:
       disconnect_account: Koble fra konto
       manage_plugin: Konfigurer %{plugin}
       force_refresh: Tving oppdatering
       force_refresh_hint: Denne funksjonen er kun designet for testing - vennligst ikke misbruk den.
       force_refresh_click_here: Klikk her
       force_refresh_click_here_hint: for å generere en ny skjerm umiddelbart
-      force_refresh_not_possible: This plugin cannot be force-refreshed because the TRMNL server does not perform image processing. Learn how to test your instance __here__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      force_refresh_not_possible:
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: Les om denne pluginen i vår kunnskapsbase
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
-      learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_fork:
+      learn_more_fork_original:
+      learn_more_native_long:
+      learn_more_native_short:
+      learn_more_recipe_author:
+      learn_more_recipe_long:
+      learn_more_recipe_short:
+      learn_more_third_party_long:
+      learn_more_third_party_short:
       linked_account: Koblet konto
       linked_account_success: Koblet til %{plugin_name} med hell
       link_oauth: Koble konto
       link_oauth_hint: Før du fortsetter, følg den sikre autorisasjonsprosessen gitt av %{plugin}
-      mirrored: Mirrored
+      mirrored:
       multiple_instances_hint: Denne pluginen støtter flere instanser.
       name: Navn
       name_hint: Gi den et navn for enkel referanse
-      parse: Parse
-      parse_save_first: Parse (Save plugin first)
-      parsed: Parsed
-      plugin_uuid: Plugin UUID
+      parse:
+      parse_save_first:
+      parsed:
+      plugin_uuid:
       plugin_uuid_hint: Bruk dette for å gjøre Webhook API-forespørsler.
       preview: Forhåndsvisning - enheten din vil vise faktiske data
       recipe_cta_heading_published: This plugin is a Recipe
-      recipe_cta_heading_unlisted: This plugin is unlisted
+      recipe_cta_heading_unlisted:
       recipe_cta_heading_in_review: Recipe in review
       recipe_cta_heading_not_published: Publish as a Recipe?
-      recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
-      recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
-      recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
-      recipe_mirrored: This screen is mirrored from the recipe.
-      recipe_visibility_title: How would you like to publish?
-      recipe_visibility_edit_title: Edit Submission
-      recipe_visibility_public: Public
-      recipe_visibility_public_hint: Anyone can find and install.
-      recipe_visibility_private: Private
-      recipe_visibility_private_hint: Breaks external installs.
-      recipe_visibility_unlisted: Unlisted
-      recipe_visibility_unlisted_hint: Anyone with the link can install.
+      recipe_cta_body_published:
+      recipe_cta_body_in_review:
+      recipe_cta_body_not_published:
+      recipe_cta_confirm:
+      recipe_mirrored:
+      recipe_visibility_title:
+      recipe_visibility_edit_title:
+      recipe_visibility_public:
+      recipe_visibility_public_hint:
+      recipe_visibility_private:
+      recipe_visibility_private_hint:
+      recipe_visibility_unlisted:
+      recipe_visibility_unlisted_hint:
       refresh_rate: Oppdateringsfrekvens
       refresh_rate_hint: Definer hvor ofte denne plugin-instansen henter nye data
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
-      refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
+      refresh_rate_jit_hint:
+      refresh_rate_not_configurable:
       refreshed: Oppdatert
       remove_plugin: Fjern plugin
       remove_plugin_hint: Fjerning av en plugin vil også fjerne den fra spillelisten din
       synced: Synkronisert
-      refresh_paused: Refresh Paused
-      refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
-      refresh_paused_mashup: Refreshing Mashups
-      refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
-      refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.
-      view_recipe: View Recipe
+      refresh_paused:
+      refresh_paused_hint:
+      refresh_paused_hidden_hint:
+      refresh_paused_mashup:
+      refresh_paused_mashup_hint:
+      refresh_stopped:
+      view_recipe:
       visit_docs: Besøk dokumentasjonen
     import:
       archive_too_large: ZIP-filen er for stor (maksimum %{max_mb} MB)
@@ -712,20 +712,20 @@
       request_received: Forespørsel mottatt, sjekk innboksen din
   recipes:
     index:
-      newest_to_oldest: Newest to Oldest
-      oldest_to_newest: Oldest to Newest
-      most_popular: Most Popular
-      install: Install
-      fork: Fork
+      newest_to_oldest:
+      oldest_to_newest:
+      most_popular:
+      install:
+      fork:
   schedules:
     form:
-      add: Add a custom schedule
-      append: And during…
-      no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
-      to: to
-      copy_prompt: Copy schedule from…
-      no_days_error: Please select at least one day.
+      add:
+      append:
+      no_schedule:
+      some_schedule:
+      to:
+      copy_prompt:
+      no_days_error:
   upgrade:
     index:
       title: 'Oppgraderer enhet:'

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -2,16 +2,16 @@
 pl:
   locale_name: Polski
   about: O nas
-  actions: Actions
+  actions:
   add: Dodaj
   add_new: Dodaj nowy
-  ai_assistant: Agent
+  ai_assistant:
   ai_assistant_hint: Włącz obsługę edycji znaczników przez agenta w edytorze wtyczek.
   already_have_account: Mam już konto
   are_you_sure: Czy na pewno?
   back: Wstecz
   back_to_all_blog_posts: Powrót do wszystkich postów
-  blog: Blog
+  blog:
   brand: Marka
   buy_now: Kup teraz
   cancel: Anuluj
@@ -67,7 +67,7 @@ pl:
   plugin_not_found: Nie znaleziono pluginu
   preview: Podgląd
   privacy: Prywatność
-  refresh_rate: Refresh rate
+  refresh_rate:
   refresh_rates_hint: __Tutaj__ dowiesz się więcej o częstotliwościach odświeżania.
   reset_password: Zresetuj hasło
   reset_to_defaults: Przywróć ustawienia fabryczne
@@ -79,7 +79,7 @@ pl:
   sign_in: Zaloguj się
   sign_up: Zarejestruj się
   something_went_wrong: Ups, coś poszło nie tak
-  status: Status
+  status:
   subscribe: Subskrybuj
   help_center: Wsparcie techniczne
   terms: Warunki
@@ -181,7 +181,7 @@ pl:
       email_address_hint: Używany do logowania do TRMNL i odbioru wiadomości systemowych.
       first_name_hint: Używamy Twojego imienia, aby uczynić korzystanie z TRMNL przyjemniejszym.
       last_name_hint: Używamy Twojego nazwiska, aby uczynić korzystanie z TRMNL przyjemniejszym.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: Służy do ochrony Twojego konta TRMNL.
       enable_2fa: Włączyć uwierzytelnianie dwuskładnikowe (2FA)?
       enable_2fa_hint: __Kliknij tutaj__ by włączyć hasła jednorazowe (OTP).
@@ -195,7 +195,7 @@ pl:
       session_hint: Zalogowano jako %{user}
       show_title_bar: Wyświetlaj pasek tytułowy
       show_title_bar_hint: Gdy opcja jest wyłączona, pluginy oficjalne (nie globalne) oraz stworzone przez społeczność będą miały bardziej minimalistyczną formę.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
+      theme_hint:
       time_zone: Strefa czasowa
       time_zone_hint: Wpływa na czasy odświeżania oraz tryb uśpienia urządzenia.
       locale: Język
@@ -235,10 +235,10 @@ pl:
       title: Zaoszczędzony czas
       cta: Dowiedz się więcej
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: Dzień dobry
       afternoon_salutation: Dzień dobry
@@ -274,10 +274,10 @@ pl:
       display_calibration_hint: Dostosuj renderowanie na swoim wyświetlaczu. Zostaw puste, aby użyć wartości domyślnych.
       display_calibration_pixel_ratio: Proporcja pikseli
       display_calibration_pixel_ratio_hint: 'Wartość przybliżenia (0.5–3.0). Domyślne:'
-      display_calibration_ui_scale: UI Scale
+      display_calibration_ui_scale:
       display_calibration_ui_scale_hint: 'Rozmiar tekstu i elementów (0.5–2.0). Domyślne:'
       edit_device: Edytuj urządzenie
-      firmware: Firmware
+      firmware:
       firmware_updates_enabled: Aktualizacje włączone
       firmware_updates_disabled: Aktualizacje wyłączone
       font_family: Rodzina czcionek
@@ -297,8 +297,8 @@ pl:
       longest_press_action: Miękki reset
       low_battery_email_notification: Powiadomienie e-mail o niskim stanie baterii
       low_battery_email_notification_hint: Otrzymaj powiadomienie, gdy w Twoim urządzeniu zacznie wyczerpywać się bateria.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
       medium_press: Krótkie naciśnięcie (1–2s)
       medium_press_action: Funkcja specjalna (patrz wyżej)
       mirror: Kopia lustrzana
@@ -314,7 +314,7 @@ pl:
       maximum_compatibility: Włącz maksymalną kompatybilność
       maximum_compatibility_hint: Rozwiązuje problemy z wyświetlaniem na niektórych wyświetlaczach ePaper. Wyłącza szybkie odświeżanie. Wymaga oprogramowania 1.6.0 lub nowszego.
       color_and_rotation: Kolor i obrót
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Obrót ekranu
       screen_rotation_not_supported: Obrót ekranu nie jest obecnie obsługiwany na Twoim urządzeniu.
       palette: Paleta kolorów
@@ -334,12 +334,12 @@ pl:
       touchbar_mode_hint: Na jakie gesty ma reagować Twoje urządzenie?
       tidbyt_credentials: Poświadczenia Tidbyt
       tidbyt_credentials_hint: Wprowadź poświadczenia API swojego urządzenia Tidbyt. Znajdziesz je w aplikacji Tidbyt w menu Settings → Developer → Get API Key
-      tidbyt_api_key: Tidbyt API Key
+      tidbyt_api_key:
       tidbyt_credentials_invalid: Niepoprawne poświadczenia Tidbyt API. Sprawdź ich poprawność i spróbuj ponownie.
       tidbyt_device_id: ID urządzenia
       tidbyt_device_api_key: Klucz API
       unlink: Odłącz
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm:
       unlink_device: Odłącz urządzenie
       unlink_device_hint: Odłączenie urządzenia TRMNL od konta sprawia, że można bezpiecznie je sprzedać lub komuś podarować.
       unlink_device_learn_more: Szczegółowe informacje znajdziesz __tutaj__.
@@ -353,41 +353,41 @@ pl:
         warning_2: Rozumiem, że ten proces jest <strong>niebezpieczny</strong> i może on uszkodzić moje urządzenie.
         cta: Aktualizuj do TRMNL OG (2-bit)
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Urządzenia
       tagline: Twoje urządzenia TRMNL
       add_device_modal_title: Dodaj nowe urządzenie
       add_first_device: Zacznij, dodając swoje pierwsze urządzenie!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: Dodaj nowe urządzenie
       description: Wprowadź swoje Przyjazne ID, aby przypisać nowe urządzenie do tego konta.
@@ -413,32 +413,32 @@ pl:
     switch:
       error: Błąd przy przełączaniu urządzenia
       success: Pomyślnie przełączono urządzenie
-      title: Switch to device
+      title:
     update:
       error: Błąd podczas aktualizacji urządzenia
       success: Ustawienia urządzenia %{device} zostały pomyślnie zaktualizowane
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: Zbyt wiele prób, odczekaj chwilę i spróbuj ponownie
     invoice_not_found: Nie odnaleziono faktury
@@ -448,7 +448,7 @@ pl:
       all: Wszystkie
       bulk_destroy: Usuń wszystko
       dump: Zrzut
-      id: ID
+      id:
       private_plugins: Prywatne pluginy
       source: Źródło
       time: Czas
@@ -460,7 +460,7 @@ pl:
       design_system: Skorzystaj z naszego natywnego systemu projektowania
       design_system_docs: Dokumentacja systemu projektowania
       dirty_confirm: Masz niezapisane zmiany. Czy na pewno chcesz opuścić tę stronę?
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: Edytuj kod szablonu
       edit_markup_for_plugin: 'Edytuj kod szablonu: %{plugin_setting_name}'
       edit_markup_please_save_first: Zapisz zmiany przed rozpoczęciem edycji kodu szablonu
@@ -485,7 +485,7 @@ pl:
       no_variables_detected: Nie wykryto żadnych zmiennych.
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: Uwierzytelnianie dwuskładnikowe (2FA) wyłączone
@@ -536,7 +536,7 @@ pl:
       show_playlist: Pokaż ten element
       duplicate: Duplikuj
       duplicate_confirm: Funkcja ta zduplikuje obiekt i umieści go na końcu playlisty. Kontynować?
-      presentation: Presentation
+      presentation:
       color_palette: Paleta kolorów
       device_default: Domyślne dla urządzenia (%{name})
       palette_unavailable: Dostępne tylko dla urządzeń obsługujących palety kolorów
@@ -568,7 +568,7 @@ pl:
       tagline: Co umieścisz na swoim TRMNL?
       available: Dostępne
       connected: Połączone
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: Receptury
       recipes_hint: Prywatne pluginy stworzone przez społeczność, które mogą być zainstalowane jednym kliknięciem. __Więcej informacji__.
     search:
@@ -700,7 +700,7 @@ pl:
       recipe_visibility_unlisted_hint: Tylko osoby posiadające link mogą zainstalować.
       refresh_rate: Częstotliwość odświeżania
       refresh_rate_hint: Określ, jak często ta instancja pluginu ma pobierać świeże dane.
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
+      refresh_rate_jit_hint:
       refresh_rate_not_configurable: Odświeżanie %{refresh_rate} (niekonfigurowalne)
       refreshed: Odświeżony
       remove_plugin: Usuń plugin
@@ -708,7 +708,7 @@ pl:
       synced: Zsynchronizowany
       refresh_paused: Odświeżanie wstrzymane
       refresh_paused_hint: Automatyczne odświeżanie jest wstrzymane. Dodaj do playlisty, aby włączyć je z powrotem.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
+      refresh_paused_hidden_hint:
       refresh_paused_mashup: Odświeżanie szablonów
       refresh_paused_mashup_hint: Automatyczne odświeżanie wstrzymane w trybie pełnoekranowym. Szablony się odświeżają.
       refresh_stopped: Automatyczne odświeżanie wstrzymane. Należy naprawić błędy w pluginie, nim będzie można kontynuować.

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -2,16 +2,16 @@
 pt-BR:
   locale_name: Portuguese (Brazil)
   about: Sobre
-  actions: Actions
+  actions:
   add: Adicionar
   add_new: Adicionar novo
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: Já tenho uma conta
   are_you_sure: Tem certeza?
   back: Voltar
   back_to_all_blog_posts: Voltar
-  blog: Blog
+  blog:
   brand: Marca
   buy_now: Comprar Agora
   cancel: Cancelar
@@ -19,7 +19,7 @@ pt-BR:
   charge_level: Nível de Carga
   charged: carregado
   charging: Carregando
-  claim_plus_trial: Claim 6 Months Free
+  claim_plus_trial:
   close: Fechar
   confirm_change_password: Mudar minha senha
   confirm_password: Confirmar nova senha
@@ -35,7 +35,7 @@ pt-BR:
   developer_edition_required: Você precisa da Edição de Desenvolvedor para ativar essa função.
   device_id: ID do Dispositivo
   device: Dispositivo
-  discard: Discard
+  discard:
   edit: Configurações
   email_address: E-mail
   export: Exportar
@@ -43,9 +43,9 @@ pt-BR:
   first_name: Nome
   forgot_password: Esqueci minha senha
   forgot_password_title: Lá vamos nós de novo
-  friendly_id: Friendly ID
+  friendly_id:
   get_started: Vamos começar!
-  hidden: hidden
+  hidden:
   identify: Identificar
   import: Importar
   import_new: Importar novo
@@ -59,31 +59,31 @@ pt-BR:
   log_out: Sair
   manage: Gerenciar
   minimum_characters: caracteres pelo menos
-  mins: mins
+  mins:
   my_playlist: Minha Playlist
   new_password: Nova senha
   password: Senha
   please_wait: Aguarde...
   plugin_not_found: Plugin não encontrado
-  preview: Preview
+  preview:
   privacy: Privacidade
-  refresh_rate: Refresh rate
+  refresh_rate:
   refresh_rates_hint: Saiba mais sobre taxas de atualização __aqui__.
   reset_password: Redefinir minha senha
-  reset_to_defaults: Reset to defaults
-  required: Required
+  reset_to_defaults:
+  required:
   save: Salvar
-  shown: shown
+  shown:
   section: Seção
   settings: Configurações
   sign_in: Entrar
   sign_up: Cadastrar
   something_went_wrong: Algo deu errado
-  status: Status
+  status:
   subscribe: Assine
   help_center: Suporte
   terms: Termos
-  unsaved_changes: You have unsaved changes
+  unsaved_changes:
   update: Atualizar
   view: Visualizar
   collaboration_request: Quer colaborar?
@@ -93,7 +93,7 @@ pt-BR:
   time:
     formats:
       shorter: "%-H:%M"
-    start_of_week: 0
+    start_of_week:
   datetime:
     relative:
       past: há %{time}
@@ -159,21 +159,21 @@ pt-BR:
       email_address_hint: Usado para entrar no TRMNL e receber mensagens do sistema.
       first_name_hint: Nós usamos o seu nome para tornar a interface do TRMNL mais confortável.
       last_name_hint: Nós usamos o seu nome para tornar a interface do TRMNL mais confortável.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: Usada para proteger sua conta TRMNL.
       enable_2fa: Ativar 2FA?
       enable_2fa_hint: __Clique aqui__ para ativar o OTP.
       disable_2fa: Desativar 2FA
       disable_2fa_hint: Forneça um OTP válido e sua senha acima para desativar essa funcionalidade.
       plus_subscription: Assinatura TRMNL+
-      plus_subscription_trial_until: You're on a free trial until %{plus_trial_end_at}.
+      plus_subscription_trial_until:
       plus_subscription_hint: Destrave taxas de atualização mais rápidas e maiores limites de chamadas de API. __Saiba mais__.
       plus_subscription_modify: Quer atualizar seu método de pagamento ou cancelar?
       session: Sessão
       session_hint: Você está logado como %{user}
       show_title_bar: Exibir barra de título
       show_title_bar_hint: Se desativado, plugins nativos e de terceiros serão mais minimalistas.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
+      theme_hint:
       time_zone: Fuso Horário
       time_zone_hint: Determina as taxas de atualização e horários de descanso do dispositivo.
       locale: Idioma
@@ -184,7 +184,7 @@ pt-BR:
       success: Chave de API regerada com sucesso
   dashboard:
     index:
-      title: Dashboard
+      title:
       last_7_days: Últimos 7 dias
       last_30_days: Últimos 30 dias
       last_90_days: Últimos 90 dias
@@ -198,11 +198,11 @@ pt-BR:
       title: Notícias
       cta: Ver Tudo
     playlist_items:
-      title: Playlist
+      title:
       cta: Editar Playlist
       pieces_of_content_displayed: Telas exibidas
     plugins:
-      title: Plugins
+      title:
       cta: Ir para Plugins
       connected: Conectados
       new_and_popular: Novos e Populares
@@ -213,10 +213,10 @@ pt-BR:
       title: Tempo economizado
       cta: Ler sobre
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: Bom dia
       afternoon_salutation: Boa tarde
@@ -226,14 +226,14 @@ pt-BR:
       accepts_beta_firmware: Versões Antecipadas de Firmware
       accepts_beta_firmware_hint: Ative para obter as últimas versões do firmware de dispositivo antes dos outros usuários.
       back_to_devices: Voltar para Dispositivos
-      battery_and_sleep: Battery & Sleep
+      battery_and_sleep:
       battery_consumption: Consumo da Bateria
       battery_consumption_hint: Economize energia desfrute de mais bateria ativando o Modo de Suspensão.
       battery_learn_more: Saiba mais sobre carregamento da bateria __aqui__.
-      battery_refresh: Refresh
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      battery_refresh:
+      click:
+      click_action:
+      controls:
       developer_perks: Vantagens de Desenvolvedor
       developer_perks_hint: Opções abaixo requerem o __Add-on de Desenvolvedor__.
       device_credentials: Credenciais do Dispositivo
@@ -243,23 +243,23 @@ pt-BR:
       device_model: Modelo do Dispositivo
       device_model_hint: Modelo do seu hardware
       device_model_switch_warning: Essa é uma operação perigosa, saiba mais __aqui__
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
-      display_calibration: Display Calibration
-      display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
-      display_calibration_pixel_ratio: Pixel Ratio
-      display_calibration_pixel_ratio_hint: 'Image zoom level (0.5–3.0). Default:'
-      display_calibration_ui_scale: UI Scale
-      display_calibration_ui_scale_hint: 'Text and element sizes (0.5–2.0). Default:'
+      device_info:
+      current_firmware:
+      last_ping:
+      unknown:
+      never:
+      display_calibration:
+      display_calibration_hint:
+      display_calibration_pixel_ratio:
+      display_calibration_pixel_ratio_hint:
+      display_calibration_ui_scale:
+      display_calibration_ui_scale_hint:
       edit_device: Alterar Dispositivo
-      firmware: Firmware
-      firmware_updates_enabled: Updates enabled
-      firmware_updates_disabled: Updates disabled
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
+      firmware:
+      firmware_updates_enabled:
+      firmware_updates_disabled:
+      font_family:
+      font_family_hint:
       guest_mode: Modo Convidado
       guest_mode_hint: Escolha o que exibir (e por quanto tempo) quando o modo convidado está ativado.
       guest_mode_item_placeholder: Escolha um item
@@ -267,23 +267,23 @@ pt-BR:
       identify: Identificar
       identify_device: Identificar Dispositivo
       identify_device_hint: Clique no botão abaixo para mostrar uma tela no dispositivo que ajuda a identificá-lo.
-      logs: Logs
+      logs:
       logs_hint: Depure seu dispositivo e plugins com os logs de erro.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
       low_battery_email_notification: Email de Notificação de Bateria Fraca
       low_battery_email_notification_hint: Seja notificado por email quando a bateria do seu dispositivo estiver acabando.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: Espelhar
       mirror_device: Espelhar outro Dispositivo
       mirror_device_hint: Forneça um ID de Dispositivo (compartilhável) para espelhar sua playlist. Sua playlist ainda será exibida.
-      mirror_disabled: Mirroring disabled
-      mirror_enabled: Mirroring
+      mirror_disabled:
+      mirror_enabled:
       mirror_stop: Desconectar Espelhamento
       mirror_sync: Sincronizar Telas
       ota_enabled: Ativar Atualizações OTA
@@ -291,13 +291,13 @@ pt-BR:
       ota_byod_not_supported: OTA não é suportado em dispositivos BYOD. Instale uma versão compatível diretamente de trmnl.com/flash
       maximum_compatibility: Habilitar Compatibilidade Máxima
       maximum_compatibility_hint: Resolve problemas de exibição causados por determinados chips ePaper. Desabilida a atualização rápida. Requer o firmware 1.6.0+.
-      color_and_rotation: Color & Rotation
-      image_rotation: Image Rotation
-      screen_rotation: Screen Rotation
+      color_and_rotation:
+      image_rotation:
+      screen_rotation:
       screen_rotation_not_supported: A rotação da tela não é suportada no seu dispositivo.
-      palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
-      presentation: Presentation
+      palette:
+      palette_hint:
+      presentation:
       sleep_mode: Modo de Descanso
       sleep_mode_hint: Ajuste sua taxa de atualização para otimizar foco e duração da bateria.
       sleep_screen: Tela de Descanso
@@ -308,16 +308,16 @@ pt-BR:
       special_function_learn_more: Saiba mais sobre funções especiais __aqui__.
       temperature_profile: Perfil de Temperatura
       temperature_profile_hint: Não altere a não ser que tenha sido instruído. Para dispositivos com imagens desbotadas.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
-      tidbyt_credentials: Tidbyt Credentials
-      tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
-      tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
-      tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
+      touchbar_mode:
+      touchbar_mode_hint:
+      tidbyt_credentials:
+      tidbyt_credentials_hint:
+      tidbyt_api_key:
+      tidbyt_credentials_invalid:
+      tidbyt_device_id:
+      tidbyt_device_api_key:
       unlink: Desconectar
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm:
       unlink_device: Desconectar Dispositivo
       unlink_device_hint: Desconectar um TRMNL permite revendê-lo ou dá-lo a outra pessoa com segurança.
       unlink_device_learn_more: Siga o guia completo __aqui__.
@@ -331,41 +331,41 @@ pt-BR:
         warning_2: Entendo que essa ação é <strong>perigosa</strong> e pode inutilizar meu dispositivo.
         cta: Atualizar para o TRMNL OG (2 bits)
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Dispositivos
       tagline: Seus dispositivos TRMNL
       add_device_modal_title: Adicionar novo dispositivo
       add_first_device: Comece adicionando seu primeiro dispositivo!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: Adicionar novo dispositivo
       description: Coloque o ID do Dispositivo para adicionar um novo TRMNL à sua conta.
@@ -377,8 +377,8 @@ pt-BR:
       error: Erro ao desconectar dispositivo
       success: Dispositivo desconectado com sucesso
     external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
+      error:
+      success:
     identify:
       error: Erro ao atualizar dispositivo
       success: Identificação do dispositivo solicitada
@@ -391,61 +391,61 @@ pt-BR:
     switch:
       error: Erro ao trocar dispositivo
       success: Dispositivo trocado com sucesso
-      title: Switch to device
+      title:
     update:
       error: Erro ao atualizar dispositivo
       success: Configurações do dispositivo %{device} atualizadas com sucesso
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: Muitas tentativas, por favor espere e tente novamente
     invoice_not_found: Fatura não encontrada
   logs:
     index:
-      title: Logs
+      title:
       all: Todos
       bulk_destroy: Remover em Massa
       dump: Conteúdo
-      id: ID
+      id:
       private_plugins: Plugins Privados
       source: Fonte
       time: Data
   markups:
     console_logs:
-      js_logs: JS Logs
+      js_logs:
     form:
       back_to_plugin_settings: Voltar para configurações do plugin
       design_system: Utilize o nosso design system
       design_system_docs: Documentação do Design System
       dirty_confirm: Você tem alterações não salvas. Tem certeza que deseja sair dessa página?
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: Editar Markup
       edit_markup_for_plugin: Editar markup de %{plugin_setting_name}
       edit_markup_please_save_first: Por favor salve antes de editar o markup
       edit_markup_without_preview: Editar Markup (sem pré-visualização)
       error_rendering_markup: Erro ao renderizar o markup
       fix_indentation: Corrigir indentação
-      go_to_preview: Go To Preview
+      go_to_preview:
       live_preview: Pré-visualização
       no_changes_to_save: Não há alterações para salvar
       pop_out_preview: Destacar Pré-visualização
@@ -463,7 +463,7 @@ pt-BR:
       no_variables_detected: Nenhuma variável detectada.
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: 2FA Desativado
@@ -485,7 +485,7 @@ pt-BR:
       error: Código OTP inválido
   playlist_items:
     index:
-      title: Playlist
+      title:
       tagline: Escolha o que é exibido no
       add_a_group: Adicionar um Grupo
       add_a_plugin: Adicionar um Plugin
@@ -499,7 +499,7 @@ pt-BR:
       display_period_validation: Hora de início deve ser anterior a hora de fim. Crie um novo grupo para abrenger o período noturno.
       every: Cada
       never_skip: Nunca esconda telas
-      smart_playlist: Smart Playlist
+      smart_playlist:
       smart_playlist_hint: Esconda telas cujo conteúdo não foi alterado durante algum tempo.
       skip_after:
         one: Esconda telas após 1 dia
@@ -512,18 +512,18 @@ pt-BR:
       remove_from_playlist: Remover da playlist
       hide_playlist: Esconder esse item
       show_playlist: Exibir esse item
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default:
+        external:
+        global:
+        mashup:
+        readonly:
     create:
       error: Falha ao atualizar a playlist
       success: Playlist atualizada
@@ -542,11 +542,11 @@ pt-BR:
       success: Ordem da Playlist atualizada
   plugins:
     index:
-      title: Plugins
+      title:
       tagline: O que você vai colocar no seu TRMNL?
       available: Disponíveis
       connected: Conectados
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: Receitas
       recipes_hint: Plugins criados por membros da comunidade que podem ser instalados com 1 clique. __Saiba mais__.
     search:
@@ -596,19 +596,19 @@ pt-BR:
     forks:
       one: Derivação
       other: Derivações
-    forked: Recipe forked
+    forked:
     new:
       error: Receita não encontrada
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: Ativo
     copy_are_you_sure: Tem certeza que deseja copiar esta configuração?
     delete_are_you_sure: Tem certeza que deseja deletar essa configuração?
     delete: Isso irá remover completamente as condfigurações do plugin. Para esconder o plugin do dispositivo, simplesmente remova-o da Playlist.
     inactive: Inativo
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: Nenhuma configuração encontrada.
     not_supported: Não suportado no dispositivo atual
     refreshing_now_please_wait: Atualizando agora, reabra essa página em alguns segundos.
@@ -616,7 +616,7 @@ pt-BR:
     form:
       active_hint: Exibir ou esconder este plugin no seu dispositivo
       advanced_settings: Configurações Avançadas
-      back_to_playlist: Back to Playlist
+      back_to_playlist:
       back_to_plugin: Voltar para %{plugin}
       back_to_plugins: Voltar para Plugins
       connect_with: Conectar com %{plugin}
@@ -632,24 +632,24 @@ pt-BR:
       force_refresh_click_here: Clique aqui
       force_refresh_click_here_hint: para gerar uma nova tela imediatamente
       force_refresh_not_possible: Esse plugin não pode ser atualizado pois o servidor TRMNL não realiza processamento de imagens. Saiba como testar sua instância __aqui__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: Saiba mais sobre esse plugin em nossa base de conhecimento
       learn_more_fork: Esse plugin foi derivado de uma Receita.
       learn_more_fork_original: Ver Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long:
+      learn_more_native_short:
       learn_more_recipe_author: Precisa de ajuda? Fale com %{recipe_author} no Discord.
       learn_more_recipe_long: Esse plugin é uma Receita da comunidade e não é mantido pelo TRMNL.
       learn_more_recipe_short: 'Nota: esse plugin é uma Receita.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long:
+      learn_more_third_party_short:
       linked_account: Conta Vinculada
       linked_account_success: Conta vinculada com sucesso com %{plugin_name}
       link_oauth: Vincular Conta
       link_oauth_hint: Antes de continuar, siga o processo de autorização segura fornecido por %{plugin}
-      mirrored: Mirrored
+      mirrored:
       multiple_instances_hint: Esse plugin suporta múltiplas instâncias.
       name: Nome
       name_hint: Dê um nome para se lembrar facilmente
@@ -667,7 +667,7 @@ pt-BR:
       recipe_cta_body_in_review: Esse plugin foi submetido para nosso time. Aguarde.
       recipe_cta_body_not_published: Submeta esse plugin para que outros possam instalá-lo. __Saiba mais__.
       recipe_cta_confirm: Tem certeza? Nosso time irá revisar e te retornar em alguns dias. Você pode continuar efetuando mudanças.
-      recipe_mirrored: This screen is mirrored from the recipe.
+      recipe_mirrored:
       recipe_visibility_title: Como você gostaria de publicar?
       recipe_visibility_edit_title: Alterar Submissão
       recipe_visibility_public: Público
@@ -678,7 +678,7 @@ pt-BR:
       recipe_visibility_unlisted_hint: Apenas quem possuir o link pode instalar.
       refresh_rate: Taxa de atualização
       refresh_rate_hint: Defina com que frequência esse plugin obtém novos dados
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
+      refresh_rate_jit_hint:
       refresh_rate_not_configurable: Atualiza %{refresh_rate} (não configurável)
       refreshed: Atualizado
       remove_plugin: Remover plugin
@@ -686,11 +686,11 @@ pt-BR:
       synced: Sincronizado
       refresh_paused: Atualização Pausada
       refresh_paused_hint: Atualização pausada. Adicione na playlist para reiniciar.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
+      refresh_paused_hidden_hint:
       refresh_paused_mashup: Atualizando Mashups
       refresh_paused_mashup_hint: Atualização pausada para tela cheia. Os mashups estão atualizando.
       refresh_stopped: Atualização desativada. Por favor corrija o erro do plugin para continuar.
-      view_recipe: View Recipe
+      view_recipe:
       visit_docs: Visitar Documentação
     import:
       archive_too_large: O arquivo ZIP é muito grande (máximo de %{max_mb} MB)
@@ -699,7 +699,7 @@ pt-BR:
       malformed: "%{filename} está corrompido"
     create:
       success: Plugin criado e adicionado à sua
-      playlist: playlist
+      playlist:
     destroy:
       success: Plugin removido
     handle_canceled_consent: Consentimento cancelado, tente novamente
@@ -725,7 +725,7 @@ pt-BR:
       some_schedule: Exiba essa tela apenas durante…
       to: para
       copy_prompt: Copiar agenda de…
-      no_days_error: Please select at least one day.
+      no_days_error:
   upgrade:
     index:
       title: 'Fazendo upgrade do dispositivo:'

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -2,17 +2,17 @@
 ro:
   locale_name: Română
   about: Despre
-  actions: Actions
+  actions:
   add: Adaugă
   add_new: Adaugă nou
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: Am deja un cont
   are_you_sure: Ești sigur?
   back: Înapoi
   back_to_all_blog_posts: Înapoi la toate postările
-  blog: Blog
-  brand: Brand
+  blog:
+  brand:
   buy_now: Cumpără acum
   cancel: Anulează
   change_password: Schimbă parola
@@ -35,7 +35,7 @@ ro:
   developer_edition_required: Ediția pentru dezvoltatori este necesară pentru a activa această funcție.
   device_id: ID dispozitiv
   device: Dispozitiv
-  discard: Discard
+  discard:
   edit: Editează
   email_address: Adresă de email
   export: Exportă
@@ -83,7 +83,7 @@ ro:
   subscribe: Abonează-te
   help_center: Asistență
   terms: Termeni
-  unsaved_changes: You have unsaved changes
+  unsaved_changes:
   update: Actualizează
   view: Vizualizează
   collaboration_request: Vrei să colaborezi?
@@ -159,7 +159,7 @@ ro:
       email_address_hint: Folosit pentru autentificarea în TRMNL și primirea mesajelor de sistem.
       first_name_hint: Folosim numele tău pentru a face interfața TRMNL mai confortabilă.
       last_name_hint: Folosim numele tău pentru a face interfața TRMNL mai confortabilă.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: Folosit pentru a proteja contul tău TRMNL.
       enable_2fa: Activează 2FA?
       enable_2fa_hint: __Apasă aici__ pentru a activa OTP.
@@ -213,10 +213,10 @@ ro:
       title: Timp economisit
       cta: Citește despre
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: Bună dimineața
       afternoon_salutation: Bună ziua
@@ -231,9 +231,9 @@ ro:
       battery_consumption_hint: Economisește energie și bucură-te de o durată de viață mai lungă a bateriei activând Modul repaus.
       battery_learn_more: Află mai mult despre încărcarea bateriei __aici__.
       battery_refresh: Reîmprospătează
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      click:
+      click_action:
+      controls:
       developer_perks: Avantaje dezvoltator
       developer_perks_hint: Dezvoltare plugin-uri personalizate, adresă MAC editabilă (doar BYOD), lansare anticipată firmware și acces API
       device_credentials: Credențiale dispozitiv
@@ -255,11 +255,11 @@ ro:
       display_calibration_ui_scale: Scală UI
       display_calibration_ui_scale_hint: 'Dimensiuni text și elemente (0.5–2.0). Implicit:'
       edit_device: Editează dispozitivul
-      firmware: Firmware
+      firmware:
       firmware_updates_enabled: Actualizări activate
       firmware_updates_disabled: Actualizări dezactivate
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family:
+      font_family_hint:
       guest_mode: Mod oaspete
       guest_mode_hint: Alege ce să afișezi (și pentru cât timp) ori de câte ori modul oaspete este activat.
       guest_mode_item_placeholder: Alege un element
@@ -269,16 +269,16 @@ ro:
       identify_device_hint: Apasă butonul de mai jos pentru a genera un ecran pe acest dispozitiv care ajută la identificarea lui.
       logs: Jurnale
       logs_hint: Depanează dispozitivul și plugin-urile cu un flux live de jurnale de erori brute.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
       low_battery_email_notification: Notificare email baterie descărcată
       low_battery_email_notification_hint: Primește notificări prin email când bateria dispozitivului este pe terminate.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: Oglindire
       mirror_device: Oglindește alt dispozitiv
       mirror_device_hint: Furnizează un ID de dispozitiv (partajabil) pentru a oglindi lista sa de redare. Lista ta va fi în continuare afișată.
@@ -292,12 +292,12 @@ ro:
       maximum_compatibility: Activează compatibilitate maximă
       maximum_compatibility_hint: Rezolvă problemele de afișare cauzate de anumite chipuri de driver ePaper. Dezactivează reîmprospătarea rapidă. Necesită firmware 1.6.0+.
       color_and_rotation: Culoare și rotație
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Rotație ecran
       screen_rotation_not_supported: Rotația ecranului nu este în prezent suportată pe dispozitivul tău.
       palette: Paletă de culori
       palette_hint: Selectează setul de culori de folosit la generarea ecranelor pentru acest dispozitiv. O paletă mai mare arată mai bine, dar una mai mică se desenează mai rapid pe ePaper. Elementele individuale din listă pot suprascrie această setare.
-      presentation: Presentation
+      presentation:
       sleep_mode: Mod repaus
       sleep_mode_hint: Ajustează rata de reîmprospătare pentru a optimiza concentrarea și durata bateriei.
       sleep_screen: Ecran de repaus
@@ -308,11 +308,11 @@ ro:
       special_function_learn_more: Află mai mult despre funcțiile speciale __aici__.
       temperature_profile: Profil temperatură
       temperature_profile_hint: Nu modifica dacă nu ți s-a indicat. Pentru afișaje cu imagini șterse.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
+      touchbar_mode:
+      touchbar_mode_hint:
       tidbyt_credentials: Credențiale Tidbyt
       tidbyt_credentials_hint: Introdu credențialele API ale dispozitivului tău Tidbyt din aplicația Tidbyt sub Setări → Dezvoltator → Obține cheie API.
-      tidbyt_api_key: Tidbyt API Key
+      tidbyt_api_key:
       tidbyt_credentials_invalid: Credențialele API Tidbyt sunt invalide. Verifică și încearcă din nou.
       tidbyt_device_id: ID dispozitiv
       tidbyt_device_api_key: Cheie API
@@ -331,41 +331,41 @@ ro:
         warning_2: Înțeleg că aceasta este o acțiune <strong>periculoasă</strong> și îmi poate deteriora dispozitivul.
         cta: Upgrade la TRMNL OG (2-bit)
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Dispozitive
       tagline: Dispozitivele tale TRMNL
       add_device_modal_title: Adaugă un dispozitiv nou
       add_first_device: Începe prin a adăuga primul tău dispozitiv!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: Adaugă un dispozitiv nou
       description: Introdu ID-ul prietenos pentru a adăuga un dispozitiv nou în contul tău.
@@ -391,32 +391,32 @@ ro:
     switch:
       error: Eroare la schimbarea dispozitivului
       success: Dispozitiv schimbat cu succes
-      title: Switch to device
+      title:
     update:
       error: Eroare la actualizarea dispozitivului
       success: Setările dispozitivului %{device} actualizate cu succes
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: Prea multe încercări, așteptați și încercați din nou
     invoice_not_found: Factură negăsită
@@ -426,7 +426,7 @@ ro:
       all: Toate
       bulk_destroy: Ștergere în masă
       dump: Descarcă
-      id: ID
+      id:
       private_plugins: Plugin-uri private
       source: Sursă
       time: Timp
@@ -438,7 +438,7 @@ ro:
       design_system: Folosește sistemul nostru nativ de design
       design_system_docs: Documentație sistem design
       dirty_confirm: Ai modificări nesalvate. Ești sigur că vrei să părăsești această pagină?
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: Editează markup
       edit_markup_for_plugin: Editează markup pentru %{plugin_setting_name}
       edit_markup_please_save_first: Salvează înainte de a edita markup-ul
@@ -463,7 +463,7 @@ ro:
       no_variables_detected: Nicio variabilă detectată.
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: 2FA dezactivat
@@ -514,7 +514,7 @@ ro:
       show_playlist: Afișează acest element
       duplicate: Duplică
       duplicate_confirm: Aceasta va crea o copie a acestui element și o va adăuga la sfârșitul listei tale. Continui?
-      presentation: Presentation
+      presentation:
       color_palette: Paletă de culori
       device_default: Implicit dispozitiv (%{name})
       palette_unavailable: Disponibil doar pentru dispozitive cu mai multe palete de culori
@@ -546,7 +546,7 @@ ro:
       tagline: Ce vei pune pe TRMNL-ul tău?
       available: Disponibile
       connected: Conectate
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: Rețetare
       recipes_hint: Plugin-uri private create de membrii comunității care pot fi instalate cu un singur clic. __Află mai mult__.
     search:
@@ -596,19 +596,19 @@ ro:
     forks:
       one: Fork
       other: Fork-uri
-    forked: Recipe forked
+    forked:
     new:
       error: Rețetar negăsit
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: Activ
     copy_are_you_sure: Ești sigur că vrei să copiezi această setare?
     delete_are_you_sure: Ești sigur că vrei să ștergi această setare?
     delete: Aceasta va elimina complet setările plugin-ului. Pentru a ascunde pur și simplu acest plugin de pe dispozitivul tău, șterge-l din lista de redare.
     inactive: Inactiv
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: Nu au fost găsite setări de plugin.
     not_supported: Nesuportat pe dispozitivul curent
     refreshing_now_please_wait: Se reîmprospătează acum, reîncarcă această pagină în câteva secunde.
@@ -632,9 +632,9 @@ ro:
       force_refresh_click_here: Apasă aici
       force_refresh_click_here_hint: pentru a genera un ecran nou imediat
       force_refresh_not_possible: Acest plugin nu poate fi reîmprospătat forțat deoarece serverul TRMNL nu efectuează procesarea imaginilor. Află cum să testezi instanța ta __aici__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: Află despre acest plugin în baza noastră de cunoștințe
       learn_more_fork: Acest plugin a fost bifurcat dintr-un Rețetar.
       learn_more_fork_original: Vezi originalul
@@ -670,7 +670,7 @@ ro:
       recipe_mirrored: Acest ecran este oglindit din rețetar.
       recipe_visibility_title: Cum ai dori să publici?
       recipe_visibility_edit_title: Editează trimiterea
-      recipe_visibility_public: Public
+      recipe_visibility_public:
       recipe_visibility_public_hint: Oricine poate găsi și instala.
       recipe_visibility_private: Privat
       recipe_visibility_private_hint: Întrerupe instalările externe.
@@ -678,7 +678,7 @@ ro:
       recipe_visibility_unlisted_hint: Oricine cu link-ul poate instala.
       refresh_rate: Rată de reîmprospătare
       refresh_rate_hint: Definește cât de frecvent preia date această instanță de plugin
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
+      refresh_rate_jit_hint:
       refresh_rate_not_configurable: Sincronizează %{refresh_rate} (neconfigurabil)
       refreshed: Reîmprospătat
       remove_plugin: Elimină plugin-ul
@@ -686,7 +686,7 @@ ro:
       synced: Sincronizat
       refresh_paused: Reîmprospătare pausată
       refresh_paused_hint: Reîmprospătarea automată este pausată. Adaugă în lista de redare pentru a reporni.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
+      refresh_paused_hidden_hint:
       refresh_paused_mashup: Reîmprospătare mashup-uri
       refresh_paused_mashup_hint: Reîmprospătarea automată pausată pentru ecran complet. Mashup-urile se actualizează.
       refresh_stopped: Reîmprospătarea automată oprită. Rezolvă eroarea plugin-ului pentru a continua.
@@ -725,7 +725,7 @@ ro:
       some_schedule: Afișează acest ecran doar în timpul…
       to: până la
       copy_prompt: Copiază programul de la…
-      no_days_error: Please select at least one day.
+      no_days_error:
   upgrade:
     index:
       title: 'Actualizare dispozitiv:'

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -1,25 +1,25 @@
 ---
 ru:
   locale_name: Русский
-  about: About
-  actions: Actions
+  about:
+  actions:
   add: Добавить
   add_new: Добавить новый
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: У меня уже есть учётная запись
-  are_you_sure: Are you sure?
+  are_you_sure:
   back: Назад
   back_to_all_blog_posts: Назад ко всем записям в блоге
   blog: Блог
-  brand: Brand
+  brand:
   buy_now: Купить сейчас
   cancel: Отмена
   change_password: Изменить пароль
   charge_level: Уровень заряда
   charged: заряжено
   charging: Зарядка
-  claim_plus_trial: Claim 6 Months Free
+  claim_plus_trial:
   close: Закрыть
   confirm_change_password: Изменить мой пароль
   confirm_password: Подтвердите новый пароль
@@ -31,11 +31,11 @@ ru:
   current_device: Текущее устройство
   days: дней
   delete: Удалить
-  developers: Developers
+  developers:
   developer_edition_required: Для включения этой функции требуется версия для разработчиков.
   device_id: ID устройства
   device: Устройство
-  discard: Discard
+  discard:
   edit: Редактировать
   email_address: Адрес электронной почты
   export: Экспорт
@@ -45,7 +45,7 @@ ru:
   forgot_password_title: И вот опять
   friendly_id: Дружелюбный ID
   get_started: Давайте начнём!
-  hidden: hidden
+  hidden:
   identify: Идентифицировать
   import: Импорт
   import_new: Импортировать новый
@@ -65,34 +65,34 @@ ru:
   password: Пароль
   please_wait: Пожалуйста, подождите…
   plugin_not_found: Плагин не найден
-  preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
+  preview:
+  privacy:
+  refresh_rate:
   refresh_rates_hint: Узнайте, как работает частота обновления __здесь__.
   reset_password: Сбросить мой пароль
-  reset_to_defaults: Reset to defaults
-  required: Required
+  reset_to_defaults:
+  required:
   save: Сохранить
-  shown: shown
+  shown:
   section: Раздел
   settings: Настройки
   sign_in: Войти
   sign_up: Зарегистрироваться
   something_went_wrong: Что-то пошло не так
-  status: Status
+  status:
   subscribe: Подписаться
   help_center: Поддержка
-  terms: Terms
-  unsaved_changes: You have unsaved changes
+  terms:
+  unsaved_changes:
   update: Обновить
   view: Просмотр
-  collaboration_request: Wanna collaborate?
-  collaboration_request_hint: Partnerships, group sales, special projects, your call.
-  collaboration_request_cta: Let's talk
+  collaboration_request:
+  collaboration_request_hint:
+  collaboration_request_cta:
   welcome: Добро пожаловать
   time:
     formats:
-      shorter: "%-I:%M %p"
+      shorter:
     start_of_week: 1
   datetime:
     relative:
@@ -181,21 +181,21 @@ ru:
       email_address_hint: Используется для входа в TRMNL и получения системных сообщений.
       first_name_hint: Мы используем ваше имя, чтобы сделать интерфейс TRMNL более удобным.
       last_name_hint: Мы используем вашу фамилию, чтобы сделать интерфейс TRMNL более удобным.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: Используется для защиты вашей учётной записи TRMNL.
       enable_2fa: Включить 2FA?
       enable_2fa_hint: __Нажмите здесь__, чтобы включить OTP.
       disable_2fa: Отключить 2FA
       disable_2fa_hint: Введите действительный OTP и текущий пароль выше, чтобы отключить эту функцию.
       plus_subscription: Подписка TRMNL+
-      plus_subscription_trial_until: You're on a free trial until %{plus_trial_end_at}.
+      plus_subscription_trial_until:
       plus_subscription_hint: Разблокируйте более высокую частоту обновления и ограничения. __Узнать больше__.
       plus_subscription_modify: Хотите обновить способ оплаты или отменить?
       session: Сессия
       session_hint: Вы вошли как %{user}
       show_title_bar: Показать строку заголовка
       show_title_bar_hint: Если отключено, нативные (не глобальные) и сторонние плагины будут более минималистичными.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
+      theme_hint:
       time_zone: Часовой пояс
       time_zone_hint: Определяет частоту обновления и время сна устройства.
       locale: Язык
@@ -235,10 +235,10 @@ ru:
       title: Сэкономленное время
       cta: Читать о
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: Доброе утро
       afternoon_salutation: Добрый день
@@ -248,14 +248,14 @@ ru:
       accepts_beta_firmware: Ранний доступ к прошивке
       accepts_beta_firmware_hint: Включите, чтобы получать последние улучшения прошивки устройства раньше других пользователей.
       back_to_devices: Назад к устройствам
-      battery_and_sleep: Battery & Sleep
+      battery_and_sleep:
       battery_consumption: Потребление батареи
       battery_consumption_hint: Сэкономьте энергию и продлите время работы батареи, включив спящий режим.
       battery_learn_more: Узнайте больше о зарядке батареи __здесь__.
-      battery_refresh: Refresh
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      battery_refresh:
+      click:
+      click_action:
+      controls:
       developer_perks: Преимущества для разработчиков
       developer_perks_hint: Для следующих опций требуется __дополнение для разработчиков__.
       device_credentials: Учётные данные устройства
@@ -265,23 +265,23 @@ ru:
       device_model: Модель устройства
       device_model_hint: Ваша аппаратная модель
       device_model_switch_warning: Это опасная операция, узнайте больше __здесь__
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
-      display_calibration: Display Calibration
-      display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
-      display_calibration_pixel_ratio: Pixel Ratio
-      display_calibration_pixel_ratio_hint: 'Image zoom level (0.5–3.0). Default:'
-      display_calibration_ui_scale: UI Scale
-      display_calibration_ui_scale_hint: 'Text and element sizes (0.5–2.0). Default:'
+      device_info:
+      current_firmware:
+      last_ping:
+      unknown:
+      never:
+      display_calibration:
+      display_calibration_hint:
+      display_calibration_pixel_ratio:
+      display_calibration_pixel_ratio_hint:
+      display_calibration_ui_scale:
+      display_calibration_ui_scale_hint:
       edit_device: Редактировать устройство
-      firmware: Firmware
-      firmware_updates_enabled: Updates enabled
-      firmware_updates_disabled: Updates disabled
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
+      firmware:
+      firmware_updates_enabled:
+      firmware_updates_disabled:
+      font_family:
+      font_family_hint:
       guest_mode: Гостевой режим
       guest_mode_hint: Выберите, что отображать (и на какой срок) при включении гостевого режима.
       guest_mode_item_placeholder: Выберите элемент
@@ -291,21 +291,21 @@ ru:
       identify_device_hint: Нажмите кнопку ниже, чтобы сгенерировать экран на этом устройстве, который поможет его идентифицировать.
       logs: Журналы
       logs_hint: Отлаживайте свое устройство и плагины с помощью живой ленты необработанных журналов ошибок.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
       low_battery_email_notification: Уведомление о низком заряде батареи по электронной почте
       low_battery_email_notification_hint: Получайте уведомления по электронной почте, когда батарея вашего устройства разряжена.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: Зеркалирование
       mirror_device: Зеркалировать другое устройство
       mirror_device_hint: Укажите (общий) идентификатор устройства для зеркалирования его плейлиста. Ваш плейлист по-прежнему будет отображаться.
-      mirror_disabled: Mirroring disabled
-      mirror_enabled: Mirroring
+      mirror_disabled:
+      mirror_enabled:
       mirror_stop: Отключить зеркалирование
       mirror_sync: Синхронизировать экраны
       ota_enabled: Обновления OTA включены
@@ -313,13 +313,13 @@ ru:
       ota_byod_not_supported: OTA не поддерживается для устройств BYOD. Прошейте совместимую версию прямо с trmnl.com/flash
       maximum_compatibility: Включить максимальную совместимость
       maximum_compatibility_hint: Устраняет проблемы с отображением, вызванные некоторыми чипами драйверов ePaper. Отключает быстрое обновление. Требуется прошивка 1.6.0+.
-      color_and_rotation: Color & Rotation
-      image_rotation: Image Rotation
-      screen_rotation: Screen Rotation
+      color_and_rotation:
+      image_rotation:
+      screen_rotation:
       screen_rotation_not_supported: Вращение экрана в настоящее время не поддерживается на вашем устройстве.
-      palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
-      presentation: Presentation
+      palette:
+      palette_hint:
+      presentation:
       sleep_mode: Спящий режим
       sleep_mode_hint: Настройте частоту обновления для оптимизации фокусировки и времени автономной работы.
       sleep_screen: Экран сна
@@ -330,16 +330,16 @@ ru:
       special_function_learn_more: Узнайте больше о специальных функциях __здесь__.
       temperature_profile: Температурный профиль
       temperature_profile_hint: Не изменяйте, если не указано иное. Для дисплеев с выцветшими изображениями.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
-      tidbyt_credentials: Tidbyt Credentials
-      tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
-      tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
-      tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
+      touchbar_mode:
+      touchbar_mode_hint:
+      tidbyt_credentials:
+      tidbyt_credentials_hint:
+      tidbyt_api_key:
+      tidbyt_credentials_invalid:
+      tidbyt_device_id:
+      tidbyt_device_api_key:
       unlink: Отвязать
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm:
       unlink_device: Отвязать устройство
       unlink_device_hint: Отвязка TRMNL делает его безопасным для перепродажи или передачи кому-либо ещё.
       unlink_device_learn_more: Следуйте полному руководству __здесь__.
@@ -353,41 +353,41 @@ ru:
         warning_2: Я понимаю, что это <strong>опасное</strong> действие и может привести к «окирпичиванию» моего устройства.
         cta: Обновить до TRMNL OG (2-бит)
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Устройства
       tagline: Ваши устройства TRMNL
       add_device_modal_title: Добавить новое устройство
       add_first_device: Начните с добавления вашего первого устройства!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: Добавить новое устройство
       description: Введите свой Дружелюбный ID, чтобы добавить новое устройство в свою учётную запись.
@@ -399,8 +399,8 @@ ru:
       error: Ошибка отключения устройства
       success: Устройство успешно отвязано
     external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
+      error:
+      success:
     identify:
       error: Ошибка обновления устройства
       success: Запрошена идентификация устройства
@@ -413,32 +413,32 @@ ru:
     switch:
       error: Ошибка переключения устройства
       success: Устройство успешно переключено
-      title: Switch to device
+      title:
     update:
       error: Ошибка обновления устройства
       success: Настройки устройства "%{device}" успешно обновлены
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: Слишком много попыток, подождите и попробуйте ещё раз
     invoice_not_found: Счёт-фактура не найдена
@@ -448,7 +448,7 @@ ru:
       all: Все
       bulk_destroy: Массовое удаление
       dump: Дамп
-      id: ID
+      id:
       private_plugins: Приватные плагины
       source: Источник
       time: Время
@@ -460,7 +460,7 @@ ru:
       design_system: Используйте нашу нативную систему дизайна
       design_system_docs: Документация по системе дизайна
       dirty_confirm: У вас есть несохраненные изменения. Вы уверены, что хотите покинуть эту страницу?
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: Редактировать разметку
       edit_markup_for_plugin: Редактировать разметку для %{plugin_setting_name}
       edit_markup_please_save_first: Пожалуйста, сохраните перед редактированием разметки
@@ -485,7 +485,7 @@ ru:
       no_variables_detected: Переменные не обнаружены.
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: 2FA отключена
@@ -534,18 +534,18 @@ ru:
       remove_from_playlist: Удалить из плейлиста
       hide_playlist: Скрыть этот элемент
       show_playlist: Показать этот элемент
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default:
+        external:
+        global:
+        mashup:
+        readonly:
     create:
       error: Не удалось обновить плейлист
       success: Плейлист обновлен
@@ -561,14 +561,14 @@ ru:
     set_preferences:
       success: Настройки умного плейлиста обновлены
     update:
-      success: Playlist order updated
+      success:
   plugins:
     index:
       title: Плагины
       tagline: Что вы разместите на своем TRMNL?
       available: Доступно
       connected: Подключено
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: Рецепты
       recipes_hint: Приватные плагины от участников сообщества, которые можно установить в 1 клик. __Узнать больше__.
     search:
@@ -618,19 +618,19 @@ ru:
     forks:
       one: Форк
       other: Форки
-    forked: Recipe forked
+    forked:
     new:
       error: Рецепт не найден
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: Активен
     copy_are_you_sure: Вы уверены, что хотите скопировать эту настройку?
     delete_are_you_sure: Вы уверены, что хотите удалить эту настройку?
     delete: Это полностью удалит настройки плагина. Чтобы просто скрыть этот плагин на вашем устройстве, удалите его из плейлиста.
     inactive: Неактивен
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: Настройки плагина не найдены.
     not_supported: Не поддерживается на текущем устройстве
     refreshing_now_please_wait: Обновление, перезагрузите страницу через несколько секунд.
@@ -638,7 +638,7 @@ ru:
     form:
       active_hint: Показать или скрыть этот экземпляр плагина на вашем устройстве
       advanced_settings: Расширенные настройки
-      back_to_playlist: Back to Playlist
+      back_to_playlist:
       back_to_plugin: Назад к %{plugin}
       back_to_plugins: Назад к плагинам
       connect_with: Подключиться с помощью %{plugin}
@@ -653,25 +653,25 @@ ru:
       force_refresh_hint: Эта функция предназначена только для тестирования - пожалуйста, не злоупотребляйте ей.
       force_refresh_click_here: Нажмите здесь
       force_refresh_click_here_hint: чтобы немедленно сгенерировать новый экран
-      force_refresh_not_possible: This plugin cannot be force-refreshed because the TRMNL server does not perform image processing. Learn how to test your instance __here__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      force_refresh_not_possible:
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: Узнайте больше об этом плагине в нашей базе знаний
       learn_more_fork: Этот плагин был форкнут из рецепта.
       learn_more_fork_original: Посмотреть оригинал
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long:
+      learn_more_native_short:
       learn_more_recipe_author: Нужна помощь? Свяжитесь с %{recipe_author} в Discord.
       learn_more_recipe_long: Этот плагин является рецептом сообщества и не поддерживается TRMNL.
       learn_more_recipe_short: 'Примечание: этот плагин является рецептом.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long:
+      learn_more_third_party_short:
       linked_account: Связанная учётная запись
       linked_account_success: Успешно связано с %{plugin_name}
       link_oauth: Связать учётную запись
       link_oauth_hint: Прежде чем продолжить, следуйте безопасному процессу авторизации, предоставленному %{plugin}
-      mirrored: Mirrored
+      mirrored:
       multiple_instances_hint: Этот плагин поддерживает несколько экземпляров.
       name: Название
       name_hint: Дайте ему название для удобства
@@ -689,7 +689,7 @@ ru:
       recipe_cta_body_in_review: Этот плагин был отправлен нашей команде. Ожидайте.
       recipe_cta_body_not_published: Отправьте этот плагин, чтобы другие могли его установить. __Узнать больше__.
       recipe_cta_confirm: Вы уверены? Наша команда рассмотрит и свяжется с вами в течение нескольких дней. Вы можете продолжать вносить изменения.
-      recipe_mirrored: This screen is mirrored from the recipe.
+      recipe_mirrored:
       recipe_visibility_title: Как бы вы хотели опубликовать?
       recipe_visibility_edit_title: Редактировать отправку
       recipe_visibility_public: Публичный
@@ -700,7 +700,7 @@ ru:
       recipe_visibility_unlisted_hint: Любой, у кого есть ссылка, может установить.
       refresh_rate: Частота обновления
       refresh_rate_hint: Определите, как часто этот экземпляр плагина будет запрашивать свежие данные
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
+      refresh_rate_jit_hint:
       refresh_rate_not_configurable: Синхронизируется %{refresh_rate} (не настраивается)
       refreshed: Обновлено
       remove_plugin: Удалить плагин
@@ -708,11 +708,11 @@ ru:
       synced: Синхронизировано
       refresh_paused: Обновление приостановлено
       refresh_paused_hint: Автоматическое обновление приостановлено. Добавьте в плейлист, чтобы начать снова.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
+      refresh_paused_hidden_hint:
       refresh_paused_mashup: Обновление мэшапов
       refresh_paused_mashup_hint: Автоматическое обновление приостановлено для полноэкранного режима. Мэшапы обновляются.
       refresh_stopped: Автоматическое обновление остановлено. Исправьте ошибку плагина, чтобы продолжить.
-      view_recipe: View Recipe
+      view_recipe:
       visit_docs: Посетить документацию
     import:
       archive_too_large: ZIP-файл слишком большой (максимум %{max_mb} МБ)
@@ -747,7 +747,7 @@ ru:
       some_schedule: Показывать этот экран только в это время…
       to: по
       copy_prompt: Копировать расписание из…
-      no_days_error: Please select at least one day.
+      no_days_error:
   upgrade:
     index:
       title: 'Обновление устройства:'

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -1,103 +1,103 @@
 ---
 sk:
   locale_name: Slovak
-  about: About
-  actions: Actions
-  add: Add
-  add_new: Add new
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
-  already_have_account: I already have an account
-  are_you_sure: Are you sure?
-  back: Back
-  back_to_all_blog_posts: Back to all posts
-  blog: Blog
-  brand: Brand
-  buy_now: Buy Now
-  cancel: Cancel
-  change_password: Change Password
-  charge_level: Charge Level
-  charged: charged
-  charging: Charging
-  claim_plus_trial: Claim 6 Months Free
-  close: Close
-  confirm_change_password: Change my password
-  confirm_password: Confirm new password
-  copy: Copy
-  copied_to_clipboard: Copied!
-  copy_to_clipboard: Copy to clipboard
-  created: Created
-  create_an_account: Create an account
-  current_device: Current device
-  days: days
-  delete: Delete
-  developers: Developers
-  developer_edition_required: Developer edition is required to enable this feature.
-  device_id: Device ID
-  device: Device
-  discard: Discard
-  edit: Edit
-  email_address: Email address
-  export: Export
-  fetching: Fetching
-  first_name: First Name
-  forgot_password: I forgot my password
-  forgot_password_title: Here we go again
-  friendly_id: Friendly ID
-  get_started: Let's get you started!
-  hidden: hidden
-  identify: Identify
-  import: Import
-  import_new: Import new
-  integrations: Integrations
-  keep_me_signed_in: Keep me signed in
-  knowledge_base: Knowledge base
-  last_name: Last Name
-  learn_more: Learn more
-  loading: Loading
-  login: Login
-  log_out: Log out
-  manage: Manage
-  minimum_characters: characters minimum
-  mins: mins
-  my_playlist: My Playlist
-  new_password: New password
-  password: Password
-  please_wait: Please Wait...
-  plugin_not_found: Plugin not found
-  preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
-  refresh_rates_hint: Learn how refresh rates work __here__.
-  reset_password: Reset my password
-  reset_to_defaults: Reset to defaults
-  required: Required
-  save: Save
-  shown: shown
-  section: Section
-  settings: Settings
-  sign_in: Sign in
-  sign_up: Sign up
-  something_went_wrong: Something went wrong
-  status: Status
-  subscribe: Subscribe
-  help_center: Support
-  terms: Terms
-  unsaved_changes: You have unsaved changes
-  update: Update
-  view: View
-  collaboration_request: Wanna collaborate?
-  collaboration_request_hint: Partnerships, group sales, special projects, your call.
-  collaboration_request_cta: Let's talk
-  welcome: Welcome
+  about:
+  actions:
+  add:
+  add_new:
+  ai_assistant:
+  ai_assistant_hint:
+  already_have_account:
+  are_you_sure:
+  back:
+  back_to_all_blog_posts:
+  blog:
+  brand:
+  buy_now:
+  cancel:
+  change_password:
+  charge_level:
+  charged:
+  charging:
+  claim_plus_trial:
+  close:
+  confirm_change_password:
+  confirm_password:
+  copy:
+  copied_to_clipboard:
+  copy_to_clipboard:
+  created:
+  create_an_account:
+  current_device:
+  days:
+  delete:
+  developers:
+  developer_edition_required:
+  device_id:
+  device:
+  discard:
+  edit:
+  email_address:
+  export:
+  fetching:
+  first_name:
+  forgot_password:
+  forgot_password_title:
+  friendly_id:
+  get_started:
+  hidden:
+  identify:
+  import:
+  import_new:
+  integrations:
+  keep_me_signed_in:
+  knowledge_base:
+  last_name:
+  learn_more:
+  loading:
+  login:
+  log_out:
+  manage:
+  minimum_characters:
+  mins:
+  my_playlist:
+  new_password:
+  password:
+  please_wait:
+  plugin_not_found:
+  preview:
+  privacy:
+  refresh_rate:
+  refresh_rates_hint:
+  reset_password:
+  reset_to_defaults:
+  required:
+  save:
+  shown:
+  section:
+  settings:
+  sign_in:
+  sign_up:
+  something_went_wrong:
+  status:
+  subscribe:
+  help_center:
+  terms:
+  unsaved_changes:
+  update:
+  view:
+  collaboration_request:
+  collaboration_request_hint:
+  collaboration_request_cta:
+  welcome:
   time:
     formats:
-      shorter: "%-I:%M %p"
-    start_of_week: 0
+      shorter:
+    start_of_week:
   datetime:
     relative:
-      past: "%{time} ago"
-      future: in %{time}
+      past:
+      future:
       distance_in_words:
         half_a_minute: pol minútou
         less_than_x_seconds:
@@ -146,602 +146,602 @@ sk:
           few: takmer %{count} rokmi
   account:
     index:
-      title: Account
-      tagline: Manage your account settings
-      api_key_confirm: Are you sure you want to regenerate your API Key? The old key will be invalidated.
-      api_key_hint: See __the docs__ to learn how to configure your local environment.
-      api_key_label: The credential for authenticating local development tools
-      api_key_not_generated: "(none yet)"
-      api_key_reset: Regenerate
+      title:
+      tagline:
+      api_key_confirm:
+      api_key_hint:
+      api_key_label:
+      api_key_not_generated:
+      api_key_reset:
       api_key: API Key
-      beta_features: Beta Features
-      beta_features_hint: Try out new stuff here. Options may disappear at any time.
-      discord_community: Discord Community
-      discord_username: What's your Discord username?
-      discord_username_hint: May be used for support, attribution on published Recipes, etc.
-      email_address: Email Address
-      refer_and_earn: Refer and Earn
-      refer_and_earn_hint: Give the gift of TRMNL with a personalized coupon. Earn per use, paid monthly.
-      refer_and_earn_redemptions: Redemptions
-      refer_and_earn_request_code: Request a Code
-      device_invoice: Device Invoice
-      device_invoice_label: Download commercial documents for your accountant or (weird) PDF collection.
-      device_invoice_hint: Find this on your package tracking page or shipment notification email.
-      email_address_hint: Used to sign into TRMNL and receive system messages.
-      first_name_hint: We use your name to make the TRMNL interface more comfortable.
-      last_name_hint: We use your name to make the TRMNL interface more comfortable.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
-      password_hint: Used to protect your TRMNL account.
-      enable_2fa: Enable 2FA?
-      enable_2fa_hint: __Click here__ to enable OTP.
-      disable_2fa: Disable 2FA
-      disable_2fa_hint: Provide valid OTP and current password above to disable this feature.
-      plus_subscription: TRMNL+ Subscription
-      plus_subscription_trial_until: You're on a free trial until %{plus_trial_end_at}.
-      plus_subscription_hint: Unlock faster refresh rates and higher rate limits. __Learn more__.
-      plus_subscription_modify: Want to update your payment method or cancel?
-      session: Session
-      session_hint: You're logged in as %{user}
-      show_title_bar: Show title bar
-      show_title_bar_hint: If disabled, native (non global) and third party plugins will be more minimal.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
-      time_zone: Time Zone
-      time_zone_hint: Determines refresh rates and device sleep time.
-      locale: Locale
-      locale_hint: What language and localization do you prefer? __Go here__.
+      beta_features:
+      beta_features_hint:
+      discord_community:
+      discord_username:
+      discord_username_hint:
+      email_address:
+      refer_and_earn:
+      refer_and_earn_hint:
+      refer_and_earn_redemptions:
+      refer_and_earn_request_code:
+      device_invoice:
+      device_invoice_label:
+      device_invoice_hint:
+      email_address_hint:
+      first_name_hint:
+      last_name_hint:
+      github_username_hint:
+      password_hint:
+      enable_2fa:
+      enable_2fa_hint:
+      disable_2fa:
+      disable_2fa_hint:
+      plus_subscription:
+      plus_subscription_trial_until:
+      plus_subscription_hint:
+      plus_subscription_modify:
+      session:
+      session_hint:
+      show_title_bar:
+      show_title_bar_hint:
+      theme_hint:
+      time_zone:
+      time_zone_hint:
+      locale:
+      locale_hint:
     update:
-      success: Profile updated successfully
+      success:
     reset_api_key:
-      success: API key was regenerated successfully
+      success:
   dashboard:
     index:
-      title: Dashboard
-      last_7_days: Last 7 days
-      last_30_days: Last 30 days
-      last_90_days: Last 90 days
-      today: Today
-      yesterday: Yesterday
+      title:
+      last_7_days:
+      last_30_days:
+      last_90_days:
+      today:
+      yesterday:
     health:
-      bad: Plugins are experiencing issues
-      good: Plugins are healthy
-      next_steps: We will inform you if anything changes
+      bad:
+      good:
+      next_steps:
     news:
-      title: News
-      cta: View All
+      title:
+      cta:
     playlist_items:
-      title: Playlist
-      cta: Edit Playlist
-      pieces_of_content_displayed: Pieces of content displayed
+      title:
+      cta:
+      pieces_of_content_displayed:
     plugins:
-      title: Plugins
-      cta: Go to Plugins
-      connected: Connected
-      new_and_popular: New and Popular
+      title:
+      cta:
+      connected:
+      new_and_popular:
     shop:
-      title: Shop
-      need_another: Need another TRMNL?
+      title:
+      need_another:
     time_saved:
-      title: Time saved
-      cta: Read about
+      title:
+      cta:
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
-      morning_salutation: Good morning
-      afternoon_salutation: Good afternoon
-      evening_salutation: Good evening
+      morning_salutation:
+      afternoon_salutation:
+      evening_salutation:
   devices:
     edit:
-      accepts_beta_firmware: Firmware Early Release
-      accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
-      back_to_devices: Back to Devices
-      battery_and_sleep: Battery & Sleep
-      battery_consumption: Battery Consumption
-      battery_consumption_hint: Save power and enjoy a longer battery life by enabling Sleep Mode.
-      battery_learn_more: Learn more about battery charging __here__.
-      battery_refresh: Refresh
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
-      developer_perks: Developer Perks
+      accepts_beta_firmware:
+      accepts_beta_firmware_hint:
+      back_to_devices:
+      battery_and_sleep:
+      battery_consumption:
+      battery_consumption_hint:
+      battery_learn_more:
+      battery_refresh:
+      click:
+      click_action:
+      controls:
+      developer_perks:
       developer_perks_hint: Options below require the __Developer add-on__.
-      device_credentials: Device Credentials
-      device_credentials_hint: See what you can do with these credentials __here__
-      device_name: Device Name
-      device_name_hint: We use this to make the TRMNL interface more comfortable
-      device_model: Device Model
-      device_model_hint: Your hardware Model
-      device_model_switch_warning: This is a dangerous operation, learn more __here__
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
-      display_calibration: Display Calibration
-      display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
-      display_calibration_pixel_ratio: Pixel Ratio
-      display_calibration_pixel_ratio_hint: 'Image zoom level (0.5–3.0). Default:'
-      display_calibration_ui_scale: UI Scale
-      display_calibration_ui_scale_hint: 'Text and element sizes (0.5–2.0). Default:'
-      edit_device: Edit Device
-      firmware: Firmware
-      firmware_updates_enabled: Updates enabled
-      firmware_updates_disabled: Updates disabled
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
-      guest_mode: Guest Mode
-      guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
-      guest_mode_item_placeholder: Choose an item
-      guest_mode_duration_placeholder: Choose a duration
-      identify: Identify
-      identify_device: Identify Device
-      identify_device_hint: Click the button below to generate a screen on this device that helps identify it.
-      logs: Logs
-      logs_hint: Debug your device and plugins with a live feed of raw error logs.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
-      low_battery_email_notification: Low Battery Email Notification
-      low_battery_email_notification_hint: Get notified via email when your device battery is running low.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
-      mirror: Mirror
-      mirror_device: Mirror another Device
-      mirror_device_hint: Provide a (shareable) Device ID to mirror its playlist. Your playlist will still be displayed.
-      mirror_disabled: Mirroring disabled
-      mirror_enabled: Mirroring
-      mirror_stop: Disconnect Mirroring
-      mirror_sync: Sync Screens
-      ota_enabled: OTA Updates Enabled
-      ota_enabled_hint: Automatically install new firmware. Disable to use your own firmware.
-      ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
-      maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      device_credentials:
+      device_credentials_hint:
+      device_name:
+      device_name_hint:
+      device_model:
+      device_model_hint:
+      device_model_switch_warning:
+      device_info:
+      current_firmware:
+      last_ping:
+      unknown:
+      never:
+      display_calibration:
+      display_calibration_hint:
+      display_calibration_pixel_ratio:
+      display_calibration_pixel_ratio_hint:
+      display_calibration_ui_scale:
+      display_calibration_ui_scale_hint:
+      edit_device:
+      firmware:
+      firmware_updates_enabled:
+      firmware_updates_disabled:
+      font_family:
+      font_family_hint:
+      guest_mode:
+      guest_mode_hint:
+      guest_mode_item_placeholder:
+      guest_mode_duration_placeholder:
+      identify:
+      identify_device:
+      identify_device_hint:
+      logs:
+      logs_hint:
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
+      low_battery_email_notification:
+      low_battery_email_notification_hint:
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
+      mirror:
+      mirror_device:
+      mirror_device_hint:
+      mirror_disabled:
+      mirror_enabled:
+      mirror_stop:
+      mirror_sync:
+      ota_enabled:
+      ota_enabled_hint:
+      ota_byod_not_supported:
+      maximum_compatibility:
+      maximum_compatibility_hint:
       color_and_rotation: Farba a otáčanie
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Otáčanie obrazovky
       screen_rotation_not_supported: Otáčanie obrazovky nie je momentálne podporované na vašom zariadení.
-      palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
-      presentation: Presentation
-      sleep_mode: Sleep Mode
-      sleep_mode_hint: Adjust your refresh rate to optimize focus and battery life.
-      sleep_screen: Sleep Screen
-      sleep_screen_tooltip: Enable Sleep Mode to use this feature
-      sleep_screen_hint: Display a sleep screen during sleep mode hours.
-      special_function: Special Function
-      special_function_hint: Set a custom feature for the button on the back of your device.
+      palette:
+      palette_hint:
+      presentation:
+      sleep_mode:
+      sleep_mode_hint:
+      sleep_screen:
+      sleep_screen_tooltip:
+      sleep_screen_hint:
+      special_function:
+      special_function_hint:
       special_function_learn_more: Learn more about special functions __here__.
-      temperature_profile: Temperature Profile
-      temperature_profile_hint: Don't change unless instructed. For displays with washed out images.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
-      tidbyt_credentials: Tidbyt Credentials
-      tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
-      tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
-      tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
-      unlink: Unlink
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
-      unlink_device: Unlink Device
-      unlink_device_hint: Unlinking a TRMNL makes it safe to re-sell or give to someone else.
-      unlink_device_learn_more: Follow the full guide __here__.
-      visibility: Visibility
-      visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
-      your_device: Your TRMNL
+      temperature_profile:
+      temperature_profile_hint:
+      touchbar_mode:
+      touchbar_mode_hint:
+      tidbyt_credentials:
+      tidbyt_credentials_hint:
+      tidbyt_api_key:
+      tidbyt_credentials_invalid:
+      tidbyt_device_id:
+      tidbyt_device_api_key:
+      unlink:
+      unlink_confirm:
+      unlink_device:
+      unlink_device_hint:
+      unlink_device_learn_more:
+      visibility:
+      visibility_hint:
+      your_device:
       upgrade_og:
-        title: Upgrade to 2-bit Display Available
-        sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
-        warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
-        warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
-        cta: Upgrade to TRMNL OG (2-bit)
+        title:
+        sub_title:
+        warning_1:
+        warning_2:
+        cta:
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
-      title: Devices
-      tagline: Your TRMNL devices
-      add_device_modal_title: Add a new device
-      add_first_device: Start by adding your first device!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      title:
+      tagline:
+      add_device_modal_title:
+      add_first_device:
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
-      title: Add a new device
-      description: Enter your Friendly ID to add a new device to your account.
-      add_device: Add new device
+      title:
+      description:
+      add_device:
     associate:
-      error: Error linking device
-      success: Device successfully linked
+      error:
+      success:
     dissociate:
-      error: Error disconnecting device
-      success: Device successfully unlinked
+      error:
+      success:
     external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
+      error:
+      success:
     identify:
-      error: Error updating device
-      success: Device identification requested
+      error:
+      success:
     mirror:
-      error: Error mirroring device
-      error_not_shared: Provided Device ID is not shareable
-      error_oneself: Can't mirror oneself
-      success: Device %{friendly_id} successfully mirrored
-      success_removed: Mirroring Removed
+      error:
+      error_not_shared:
+      error_oneself:
+      success:
+      success_removed:
     switch:
-      error: Error switching device
-      success: Device switched successfully
-      title: Switch to device
+      error:
+      success:
+      title:
     update:
-      error: Error updating device
-      success: "%{device} device settings updated successfully"
+      error:
+      success:
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
-    rate_limit: Too many attempts, please wait and try again
-    invoice_not_found: Invoice not found
+    rate_limit:
+    invoice_not_found:
   logs:
     index:
-      title: Logs
-      all: All
-      bulk_destroy: Bulk Destroy
-      dump: Dump
-      id: ID
-      private_plugins: Private Plugins
-      source: Source
-      time: Time
+      title:
+      all:
+      bulk_destroy:
+      dump:
+      id:
+      private_plugins:
+      source:
+      time:
   markups:
     console_logs:
-      js_logs: JS Logs
+      js_logs:
     form:
-      back_to_plugin_settings: Back to plugin settings
-      design_system: Leverage our native design system
-      design_system_docs: Design System Docs
-      dirty_confirm: You have unsaved changes. Are you sure you want to leave this page?
-      edit_composition: Edit Composition
-      edit_markup: Edit Markup
-      edit_markup_for_plugin: Edit markup for %{plugin_setting_name}
-      edit_markup_please_save_first: Please save before editing markup
-      edit_markup_without_preview: Edit Markup (without preview)
-      error_rendering_markup: Error rendering that markup
-      fix_indentation: Fix indentation
-      go_to_preview: Go To Preview
-      live_preview: Live Preview
-      no_changes_to_save: No changes to save
-      pop_out_preview: Pop Out Preview
-      quickstart_examples: Quick-start Examples
-      quickstart_example_applied: Applied!
-      quickstart_use_this_example: Use this example
-      revert: Revert
-      revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
-      save_changes: Save Changes (⌘﹢S)
-      separate_preview: Preview is open in a separate window
+      back_to_plugin_settings:
+      design_system:
+      design_system_docs:
+      dirty_confirm:
+      edit_composition:
+      edit_markup:
+      edit_markup_for_plugin:
+      edit_markup_please_save_first:
+      edit_markup_without_preview:
+      error_rendering_markup:
+      fix_indentation:
+      go_to_preview:
+      live_preview:
+      no_changes_to_save:
+      pop_out_preview:
+      quickstart_examples:
+      quickstart_example_applied:
+      quickstart_use_this_example:
+      revert:
+      revert_confirm:
+      save_changes:
+      separate_preview:
     merge_variables:
-      your_variables: Your variables
+      your_variables:
     no_merge_variables:
-      force_refresh: If you've provided variables but they aren't being detected, try a __force refresh__.
-      no_variables_detected: No variables detected.
+      force_refresh:
+      no_variables_detected:
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
-      success: 2FA Disabled
-      invalid_otp: Invalid OTP
-      invalid_password: Invalid Password
-      invalid_otp_and_password: Invalid OTP and Password
+      success:
+      invalid_otp:
+      invalid_password:
+      invalid_otp_and_password:
     enable_otp:
-      input_otp: Enter OTP
-      submit: Verify and Enable
-      already_enabled: 2FA is already enabled
+      input_otp:
+      submit:
+      already_enabled:
     enable_otp_verify:
-      success: 2FA Enabled
-      error: Invalid OTP code
+      success:
+      error:
     verify_otp:
-      verify: Verify
-      reset: Reset MFA
-      reset_instructions: Click the button on the back of your TRMNL to generate a reset code
-      success: 2FA successful
-      error: Invalid OTP code
+      verify:
+      reset:
+      reset_instructions:
+      success:
+      error:
   playlist_items:
     index:
-      title: Playlist
-      tagline: Choose what's shown on
-      add_a_group: Add a Group
-      add_a_plugin: Add a Plugin
-      add_first_device_cta: Start by __adding__ your first TRMNL device!
+      title:
+      tagline:
+      add_a_group:
+      add_a_plugin:
+      add_first_device_cta:
       add_to_playlist: Add to Playlist
       create_first_playlist_cta: Create your playlist after __connecting__ your first plugin!
-      custom: Custom
-      device_default: Device default
-      display_period_from: Display from
-      display_period_to: to
-      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
-      never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
+      custom:
+      device_default:
+      display_period_from:
+      display_period_to:
+      display_period_validation:
+      every:
+      never_skip:
+      smart_playlist:
+      smart_playlist_hint:
       skip_after:
-        one: Skip stale screens after 1 day
-        other: Skip stale screens after %{count} days
+        one:
+        other:
     playlist_item:
-      adjust_schedule: Adjust schedule
-      delete: Are you sure you want to remove this item? The plugin will remain connected, just not shown on your device.
-      displayed_now: Displayed now
-      not_displayed_yet: Not displayed yet
-      remove_from_playlist: Remove from playlist
-      hide_playlist: Hide this item
-      show_playlist: Show this item
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      adjust_schedule:
+      delete:
+      displayed_now:
+      not_displayed_yet:
+      remove_from_playlist:
+      hide_playlist:
+      show_playlist:
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default:
+        external:
+        global:
+        mashup:
+        readonly:
     create:
       error: Failed to update playlist
-      success: Playlist updated
+      success:
     destroy:
-      error: Error removing item from playlist
+      error:
       success: Plugin removed from Playlist
     toggle_visibility:
-      success: Playlist item %{change}
+      success:
     duplicate:
       success: Playlist duplicated
     sort:
-      success: Playlist order updated
+      success:
     set_preferences:
       success: Smart playlist preference updated
     update:
-      success: Playlist order updated
+      success:
   plugins:
     index:
-      title: Plugins
-      tagline: What will you put on your TRMNL?
-      available: Available
-      connected: Connected
-      supported_by_this_device: Supported by this device
-      recipes: Recipes
-      recipes_hint: Private plugins by community members that can be installed in 1 click. __Learn more__.
+      title:
+      tagline:
+      available:
+      connected:
+      supported_by_this_device:
+      recipes:
+      recipes_hint:
     search:
-      placeholder: Search Plugins
+      placeholder:
     my:
       index:
-        title: My Plugins
-        tagline: Develop Plugins for the public marketplace
+        title:
+        tagline:
       card:
-        connections: connections
-        install: Install
-        review_are_you_sure: Are you sure? The TRMNL team will test it and email you any questions.
-        submit_for_review: Submit for Review
+        connections:
+        install:
+        review_are_you_sure:
+        submit_for_review:
     new:
-      title: Create New Plugin
-      tagline: Other users will be able to install your plugin.
-      name: Name
-      category: Category
-      category_hint: Hold cmd or ctrl to choose up to 3
-      refresh_every: Supported Refresh Interval
-      refresh_every_hint: The fastest refresh interval your plugin can support.
-      description: Description
-      description_hint: Maximum 50 characters
-      icon: Icon
-      icon_hint: 512x512px recommended
-      installation_url: Installation URL
-      installation_url_hint: Learn more about the installation flow __here__.
-      installation_success_webhook_url: Installation Success Webhook URL
-      knowledge_base_url: Knowledge Base URL
-      management_url: Plugin Management URL
-      management_url_hint: Learn more about the management flow __here__.
-      markup_url: Plugin Markup URL
-      markup_url_hint: Learn more about screen generation __here__.
-      no_screen_padding: No Screen Padding
-      no_screen_padding_hint: Removes the outermost padding in fullscreen mode.
-      uninstallation_webhook_url: Uninstallation Webhook URL
+      title:
+      tagline:
+      name:
+      category:
+      category_hint:
+      refresh_every:
+      refresh_every_hint:
+      description:
+      description_hint:
+      icon:
+      icon_hint:
+      installation_url:
+      installation_url_hint:
+      installation_success_webhook_url:
+      knowledge_base_url:
+      management_url:
+      management_url_hint:
+      markup_url:
+      markup_url_hint:
+      no_screen_padding:
+      no_screen_padding_hint:
+      uninstallation_webhook_url:
     edit:
-      title: Edit Plugin
-      tagline: Update your plugin details.
-      name: Name
-      description: Description
+      title:
+      tagline:
+      name:
+      description:
   plugin_recipes:
-    connected: Recipe connected
+    connected:
     connections:
-      one: Connection
-      other: Connections
+      one:
+      other:
     forks:
-      one: Fork
-      other: Forks
-    forked: Recipe forked
+      one:
+      other:
+    forked:
     new:
-      error: Recipe not found
+      error:
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
-    active: Active
-    copy_are_you_sure: Are you sure you want to copy this setting?
-    delete_are_you_sure: Are you sure you want to delete this setting?
+    active:
+    copy_are_you_sure:
+    delete_are_you_sure:
     delete: This will completely remove the plugin's settings. To simply hide this plugin from your device, delete it from your Playlist instead.
-    inactive: Inactive
-    no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: No plugin settings found.
-    not_supported: Not supported on current device
-    refreshing_now_please_wait: Refreshing now, reload this page in a few seconds.
-    reset_credentials: "%{plugin_name} account reset successfully"
+    inactive:
+    no_matches_found:
+    no_plugin_settings_found:
+    not_supported:
+    refreshing_now_please_wait:
+    reset_credentials:
     form:
-      active_hint: Show or hide this plugin instance on your device
-      advanced_settings: Advanced Settings
-      back_to_playlist: Back to Playlist
-      back_to_plugin: Back to %{plugin}
-      back_to_plugins: Back to Plugins
-      connect_with: Connect with %{plugin}
-      debug_logs: Debug Logs
-      debug_logs_click_here: Click here
-      debug_logs_click_here_hint: to enable debug logs for this plugin instance.
-      debug_logs_enabled: Debug logs enabled for %{hours} hours.
-      debug_logs_enabled_link: View logs
-      disconnect_account: Disconnect Account
-      manage_plugin: Configure %{plugin}
-      force_refresh: Force Refresh
-      force_refresh_hint: This feature is designed for testing only - please do not abuse it.
-      force_refresh_click_here: Click here
-      force_refresh_click_here_hint: to generate a new screen immediately
-      force_refresh_not_possible: This plugin cannot be force-refreshed because the TRMNL server does not perform image processing. Learn how to test your instance __here__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
-      learn_more: Learn about this plugin in our knowledge base
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
-      learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
-      linked_account: Linked Account
-      linked_account_success: Successfully linked with %{plugin_name}
-      link_oauth: Link Account
-      link_oauth_hint: Before you continue, follow the secure authorization process provided by %{plugin}
-      mirrored: Mirrored
-      multiple_instances_hint: This plugin supports multiple instances.
-      name: Name
-      name_hint: Give it a name for easy reference
-      parse: Parse
-      parse_save_first: Parse (Save plugin first)
-      parsed: Parsed
-      plugin_uuid: Plugin UUID
-      plugin_uuid_hint: Use this to make Webhook API requests.
-      preview: Preview - your device will show actual data
+      active_hint:
+      advanced_settings:
+      back_to_playlist:
+      back_to_plugin:
+      back_to_plugins:
+      connect_with:
+      debug_logs:
+      debug_logs_click_here:
+      debug_logs_click_here_hint:
+      debug_logs_enabled:
+      debug_logs_enabled_link:
+      disconnect_account:
+      manage_plugin:
+      force_refresh:
+      force_refresh_hint:
+      force_refresh_click_here:
+      force_refresh_click_here_hint:
+      force_refresh_not_possible:
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
+      learn_more:
+      learn_more_fork:
+      learn_more_fork_original:
+      learn_more_native_long:
+      learn_more_native_short:
+      learn_more_recipe_author:
+      learn_more_recipe_long:
+      learn_more_recipe_short:
+      learn_more_third_party_long:
+      learn_more_third_party_short:
+      linked_account:
+      linked_account_success:
+      link_oauth:
+      link_oauth_hint:
+      mirrored:
+      multiple_instances_hint:
+      name:
+      name_hint:
+      parse:
+      parse_save_first:
+      parsed:
+      plugin_uuid:
+      plugin_uuid_hint:
+      preview:
       recipe_cta_heading_published: This plugin is a Recipe
-      recipe_cta_heading_unlisted: This plugin is unlisted
+      recipe_cta_heading_unlisted:
       recipe_cta_heading_in_review: Recipe in review
       recipe_cta_heading_not_published: Publish as a Recipe?
-      recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
-      recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
-      recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
-      recipe_mirrored: This screen is mirrored from the recipe.
-      recipe_visibility_title: How would you like to publish?
-      recipe_visibility_edit_title: Edit Submission
-      recipe_visibility_public: Public
-      recipe_visibility_public_hint: Anyone can find and install.
-      recipe_visibility_private: Private
-      recipe_visibility_private_hint: Breaks external installs.
-      recipe_visibility_unlisted: Unlisted
-      recipe_visibility_unlisted_hint: Anyone with the link can install.
-      refresh_rate: Refresh rate
-      refresh_rate_hint: Define how frequently this plugin instance fetches fresh data
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
-      refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
-      refreshed: Refreshed
-      remove_plugin: Remove plugin
-      remove_plugin_hint: Removing a plugin will also remove it from your playlist
-      synced: Synced
-      refresh_paused: Refresh Paused
-      refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
-      refresh_paused_mashup: Refreshing Mashups
-      refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
-      refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.
-      view_recipe: View Recipe
-      visit_docs: Visit Docs
+      recipe_cta_body_published:
+      recipe_cta_body_in_review:
+      recipe_cta_body_not_published:
+      recipe_cta_confirm:
+      recipe_mirrored:
+      recipe_visibility_title:
+      recipe_visibility_edit_title:
+      recipe_visibility_public:
+      recipe_visibility_public_hint:
+      recipe_visibility_private:
+      recipe_visibility_private_hint:
+      recipe_visibility_unlisted:
+      recipe_visibility_unlisted_hint:
+      refresh_rate:
+      refresh_rate_hint:
+      refresh_rate_jit_hint:
+      refresh_rate_not_configurable:
+      refreshed:
+      remove_plugin:
+      remove_plugin_hint:
+      synced:
+      refresh_paused:
+      refresh_paused_hint:
+      refresh_paused_hidden_hint:
+      refresh_paused_mashup:
+      refresh_paused_mashup_hint:
+      refresh_stopped:
+      view_recipe:
+      visit_docs:
     import:
-      archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
-      missing_entry: The ZIP file does not contain %{filename}
-      entry_too_large: "%{filename} is too large"
-      malformed: "%{filename} is malformed"
+      archive_too_large:
+      missing_entry:
+      entry_too_large:
+      malformed:
     create:
-      success: Plugin created and added to your
-      playlist: playlist
+      success:
+      playlist:
     destroy:
-      success: Plugin deleted
-    handle_canceled_consent: Consent canceled, please try again
+      success:
+    handle_canceled_consent:
     update:
-      success: Plugin configuration updated successfully
+      success:
     add_to_playlist:
       success: Plugin added to Playlist
   referral_code:
     create:
-      request_received: Request received, check your inbox
+      request_received:
   recipes:
     index:
-      newest_to_oldest: Newest to Oldest
-      oldest_to_newest: Oldest to Newest
-      most_popular: Most Popular
-      install: Install
-      fork: Fork
+      newest_to_oldest:
+      oldest_to_newest:
+      most_popular:
+      install:
+      fork:
   schedules:
     form:
-      add: Add a custom schedule
-      append: And during…
-      no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
-      to: to
-      copy_prompt: Copy schedule from…
-      no_days_error: Please select at least one day.
+      add:
+      append:
+      no_schedule:
+      some_schedule:
+      to:
+      copy_prompt:
+      no_days_error:
   upgrade:
     index:
-      title: 'Upgrading device:'
-      tagline: Unlock custom plugins and __more__.
-      pay: Pay
-      error: Device %{device_name} is already upgraded, switch to another device
+      title:
+      tagline:
+      pay:
+      error:
     confirm:
-      success: Developer edition add-on is now enabled
+      success:

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -1,95 +1,95 @@
 ---
 sv:
   locale_name: Swedish
-  about: About
-  actions: Actions
-  add: Add
-  add_new: Add new
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
-  already_have_account: I already have an account
-  are_you_sure: Are you sure?
-  back: Back
-  back_to_all_blog_posts: Back to all posts
-  blog: Blog
-  brand: Brand
-  buy_now: Buy Now
-  cancel: Cancel
-  change_password: Change Password
-  charge_level: Charge Level
-  charged: charged
-  charging: Charging
-  claim_plus_trial: Claim 6 Months Free
-  close: Close
-  confirm_change_password: Change my password
-  confirm_password: Confirm new password
-  copy: Copy
-  copied_to_clipboard: Copied!
-  copy_to_clipboard: Copy to clipboard
-  created: Created
-  create_an_account: Create an account
-  current_device: Current device
-  days: days
-  delete: Delete
-  developers: Developers
-  developer_edition_required: Developer edition is required to enable this feature.
-  device_id: Device ID
-  device: Device
-  discard: Discard
-  edit: Edit
-  email_address: Email address
-  export: Export
-  fetching: Fetching
-  first_name: First Name
-  forgot_password: I forgot my password
-  forgot_password_title: Here we go again
-  friendly_id: Friendly ID
-  get_started: Let's get you started!
-  hidden: hidden
-  identify: Identify
-  import: Import
-  import_new: Import new
-  integrations: Integrations
-  keep_me_signed_in: Keep me signed in
-  knowledge_base: Knowledge base
-  last_name: Last Name
-  learn_more: Learn more
-  loading: Loading
-  login: Login
-  log_out: Log out
-  manage: Manage
-  minimum_characters: characters minimum
-  mins: mins
-  my_playlist: My Playlist
-  new_password: New password
-  password: Password
-  please_wait: Please Wait...
-  plugin_not_found: Plugin not found
-  preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
-  refresh_rates_hint: Learn how refresh rates work __here__.
-  reset_password: Reset my password
-  reset_to_defaults: Reset to defaults
-  required: Required
-  save: Save
-  shown: shown
-  section: Section
-  settings: Settings
-  sign_in: Sign in
-  sign_up: Sign up
-  something_went_wrong: Something went wrong
-  status: Status
-  subscribe: Subscribe
-  help_center: Support
-  terms: Terms
-  unsaved_changes: You have unsaved changes
-  update: Update
-  view: View
-  collaboration_request: Wanna collaborate?
-  collaboration_request_hint: Partnerships, group sales, special projects, your call.
-  collaboration_request_cta: Let's talk
-  welcome: Welcome
+  about:
+  actions:
+  add:
+  add_new:
+  ai_assistant:
+  ai_assistant_hint:
+  already_have_account:
+  are_you_sure:
+  back:
+  back_to_all_blog_posts:
+  blog:
+  brand:
+  buy_now:
+  cancel:
+  change_password:
+  charge_level:
+  charged:
+  charging:
+  claim_plus_trial:
+  close:
+  confirm_change_password:
+  confirm_password:
+  copy:
+  copied_to_clipboard:
+  copy_to_clipboard:
+  created:
+  create_an_account:
+  current_device:
+  days:
+  delete:
+  developers:
+  developer_edition_required:
+  device_id:
+  device:
+  discard:
+  edit:
+  email_address:
+  export:
+  fetching:
+  first_name:
+  forgot_password:
+  forgot_password_title:
+  friendly_id:
+  get_started:
+  hidden:
+  identify:
+  import:
+  import_new:
+  integrations:
+  keep_me_signed_in:
+  knowledge_base:
+  last_name:
+  learn_more:
+  loading:
+  login:
+  log_out:
+  manage:
+  minimum_characters:
+  mins:
+  my_playlist:
+  new_password:
+  password:
+  please_wait:
+  plugin_not_found:
+  preview:
+  privacy:
+  refresh_rate:
+  refresh_rates_hint:
+  reset_password:
+  reset_to_defaults:
+  required:
+  save:
+  shown:
+  section:
+  settings:
+  sign_in:
+  sign_up:
+  something_went_wrong:
+  status:
+  subscribe:
+  help_center:
+  terms:
+  unsaved_changes:
+  update:
+  view:
+  collaboration_request:
+  collaboration_request_hint:
+  collaboration_request_cta:
+  welcome:
   time:
     formats:
       shorter: "%-H.%M"
@@ -135,602 +135,602 @@ sv:
           other: nästan %{count} år
   account:
     index:
-      title: Account
-      tagline: Manage your account settings
-      api_key_confirm: Are you sure you want to regenerate your API Key? The old key will be invalidated.
-      api_key_hint: See __the docs__ to learn how to configure your local environment.
-      api_key_label: The credential for authenticating local development tools
-      api_key_not_generated: "(none yet)"
-      api_key_reset: Regenerate
+      title:
+      tagline:
+      api_key_confirm:
+      api_key_hint:
+      api_key_label:
+      api_key_not_generated:
+      api_key_reset:
       api_key: API Key
-      beta_features: Beta Features
-      beta_features_hint: Try out new stuff here. Options may disappear at any time.
-      discord_community: Discord Community
-      discord_username: What's your Discord username?
-      discord_username_hint: May be used for support, attribution on published Recipes, etc.
-      email_address: Email Address
-      refer_and_earn: Refer and Earn
-      refer_and_earn_hint: Give the gift of TRMNL with a personalized coupon. Earn per use, paid monthly.
-      refer_and_earn_redemptions: Redemptions
-      refer_and_earn_request_code: Request a Code
-      device_invoice: Device Invoice
-      device_invoice_label: Download commercial documents for your accountant or (weird) PDF collection.
-      device_invoice_hint: Find this on your package tracking page or shipment notification email.
-      email_address_hint: Used to sign into TRMNL and receive system messages.
-      first_name_hint: We use your name to make the TRMNL interface more comfortable.
-      last_name_hint: We use your name to make the TRMNL interface more comfortable.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
-      password_hint: Used to protect your TRMNL account.
-      enable_2fa: Enable 2FA?
-      enable_2fa_hint: __Click here__ to enable OTP.
-      disable_2fa: Disable 2FA
-      disable_2fa_hint: Provide valid OTP and current password above to disable this feature.
-      plus_subscription: TRMNL+ Subscription
-      plus_subscription_trial_until: You're on a free trial until %{plus_trial_end_at}.
-      plus_subscription_hint: Unlock faster refresh rates and higher rate limits. __Learn more__.
-      plus_subscription_modify: Want to update your payment method or cancel?
-      session: Session
-      session_hint: You're logged in as %{user}
-      show_title_bar: Show title bar
-      show_title_bar_hint: If disabled, native (non global) and third party plugins will be more minimal.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
-      time_zone: Time Zone
-      time_zone_hint: Determines refresh rates and device sleep time.
-      locale: Locale
-      locale_hint: What language and localization do you prefer? __Go here__.
+      beta_features:
+      beta_features_hint:
+      discord_community:
+      discord_username:
+      discord_username_hint:
+      email_address:
+      refer_and_earn:
+      refer_and_earn_hint:
+      refer_and_earn_redemptions:
+      refer_and_earn_request_code:
+      device_invoice:
+      device_invoice_label:
+      device_invoice_hint:
+      email_address_hint:
+      first_name_hint:
+      last_name_hint:
+      github_username_hint:
+      password_hint:
+      enable_2fa:
+      enable_2fa_hint:
+      disable_2fa:
+      disable_2fa_hint:
+      plus_subscription:
+      plus_subscription_trial_until:
+      plus_subscription_hint:
+      plus_subscription_modify:
+      session:
+      session_hint:
+      show_title_bar:
+      show_title_bar_hint:
+      theme_hint:
+      time_zone:
+      time_zone_hint:
+      locale:
+      locale_hint:
     update:
-      success: Profile updated successfully
+      success:
     reset_api_key:
-      success: API key was regenerated successfully
+      success:
   dashboard:
     index:
-      title: Dashboard
-      last_7_days: Last 7 days
-      last_30_days: Last 30 days
-      last_90_days: Last 90 days
-      today: Today
-      yesterday: Yesterday
+      title:
+      last_7_days:
+      last_30_days:
+      last_90_days:
+      today:
+      yesterday:
     health:
-      bad: Plugins are experiencing issues
-      good: Plugins are healthy
-      next_steps: We will inform you if anything changes
+      bad:
+      good:
+      next_steps:
     news:
-      title: News
-      cta: View All
+      title:
+      cta:
     playlist_items:
-      title: Playlist
-      cta: Edit Playlist
-      pieces_of_content_displayed: Pieces of content displayed
+      title:
+      cta:
+      pieces_of_content_displayed:
     plugins:
-      title: Plugins
-      cta: Go to Plugins
-      connected: Connected
-      new_and_popular: New and Popular
+      title:
+      cta:
+      connected:
+      new_and_popular:
     shop:
-      title: Shop
-      need_another: Need another TRMNL?
+      title:
+      need_another:
     time_saved:
-      title: Time saved
-      cta: Read about
+      title:
+      cta:
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
-      morning_salutation: Good morning
-      afternoon_salutation: Good afternoon
-      evening_salutation: Good evening
+      morning_salutation:
+      afternoon_salutation:
+      evening_salutation:
   devices:
     edit:
-      accepts_beta_firmware: Firmware Early Release
-      accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
-      back_to_devices: Back to Devices
-      battery_and_sleep: Battery & Sleep
-      battery_consumption: Battery Consumption
-      battery_consumption_hint: Save power and enjoy a longer battery life by enabling Sleep Mode.
-      battery_learn_more: Learn more about battery charging __here__.
-      battery_refresh: Refresh
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
-      developer_perks: Developer Perks
+      accepts_beta_firmware:
+      accepts_beta_firmware_hint:
+      back_to_devices:
+      battery_and_sleep:
+      battery_consumption:
+      battery_consumption_hint:
+      battery_learn_more:
+      battery_refresh:
+      click:
+      click_action:
+      controls:
+      developer_perks:
       developer_perks_hint: Options below require the __Developer add-on__.
-      device_credentials: Device Credentials
-      device_credentials_hint: See what you can do with these credentials __here__
-      device_name: Device Name
-      device_name_hint: We use this to make the TRMNL interface more comfortable
-      device_model: Device Model
-      device_model_hint: Your hardware Model
-      device_model_switch_warning: This is a dangerous operation, learn more __here__
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
-      display_calibration: Display Calibration
-      display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
-      display_calibration_pixel_ratio: Pixel Ratio
-      display_calibration_pixel_ratio_hint: 'Image zoom level (0.5–3.0). Default:'
-      display_calibration_ui_scale: UI Scale
-      display_calibration_ui_scale_hint: 'Text and element sizes (0.5–2.0). Default:'
-      edit_device: Edit Device
-      firmware: Firmware
-      firmware_updates_enabled: Updates enabled
-      firmware_updates_disabled: Updates disabled
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
-      guest_mode: Guest Mode
-      guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
-      guest_mode_item_placeholder: Choose an item
-      guest_mode_duration_placeholder: Choose a duration
-      identify: Identify
-      identify_device: Identify Device
-      identify_device_hint: Click the button below to generate a screen on this device that helps identify it.
-      logs: Logs
-      logs_hint: Debug your device and plugins with a live feed of raw error logs.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
-      low_battery_email_notification: Low Battery Email Notification
-      low_battery_email_notification_hint: Get notified via email when your device battery is running low.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
-      mirror: Mirror
-      mirror_device: Mirror another Device
-      mirror_device_hint: Provide a (shareable) Device ID to mirror its playlist. Your playlist will still be displayed.
-      mirror_disabled: Mirroring disabled
-      mirror_enabled: Mirroring
-      mirror_stop: Disconnect Mirroring
-      mirror_sync: Sync Screens
-      ota_enabled: OTA Updates Enabled
-      ota_enabled_hint: Automatically install new firmware. Disable to use your own firmware.
-      ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
-      maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      device_credentials:
+      device_credentials_hint:
+      device_name:
+      device_name_hint:
+      device_model:
+      device_model_hint:
+      device_model_switch_warning:
+      device_info:
+      current_firmware:
+      last_ping:
+      unknown:
+      never:
+      display_calibration:
+      display_calibration_hint:
+      display_calibration_pixel_ratio:
+      display_calibration_pixel_ratio_hint:
+      display_calibration_ui_scale:
+      display_calibration_ui_scale_hint:
+      edit_device:
+      firmware:
+      firmware_updates_enabled:
+      firmware_updates_disabled:
+      font_family:
+      font_family_hint:
+      guest_mode:
+      guest_mode_hint:
+      guest_mode_item_placeholder:
+      guest_mode_duration_placeholder:
+      identify:
+      identify_device:
+      identify_device_hint:
+      logs:
+      logs_hint:
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
+      low_battery_email_notification:
+      low_battery_email_notification_hint:
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
+      mirror:
+      mirror_device:
+      mirror_device_hint:
+      mirror_disabled:
+      mirror_enabled:
+      mirror_stop:
+      mirror_sync:
+      ota_enabled:
+      ota_enabled_hint:
+      ota_byod_not_supported:
+      maximum_compatibility:
+      maximum_compatibility_hint:
       color_and_rotation: Färg och rotation
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Skärmrotation
       screen_rotation_not_supported: Skärmrotation stöds för närvarande inte på din enhet.
-      palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
-      presentation: Presentation
-      sleep_mode: Sleep Mode
-      sleep_mode_hint: Adjust your refresh rate to optimize focus and battery life.
-      sleep_screen: Sleep Screen
-      sleep_screen_tooltip: Enable Sleep Mode to use this feature
-      sleep_screen_hint: Display a sleep screen during sleep mode hours.
-      special_function: Special Function
-      special_function_hint: Set a custom feature for the button on the back of your device.
+      palette:
+      palette_hint:
+      presentation:
+      sleep_mode:
+      sleep_mode_hint:
+      sleep_screen:
+      sleep_screen_tooltip:
+      sleep_screen_hint:
+      special_function:
+      special_function_hint:
       special_function_learn_more: Learn more about special functions __here__.
-      temperature_profile: Temperature Profile
-      temperature_profile_hint: Don't change unless instructed. For displays with washed out images.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
-      tidbyt_credentials: Tidbyt Credentials
-      tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
-      tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
-      tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
-      unlink: Unlink
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
-      unlink_device: Unlink Device
-      unlink_device_hint: Unlinking a TRMNL makes it safe to re-sell or give to someone else.
-      unlink_device_learn_more: Follow the full guide __here__.
-      visibility: Visibility
-      visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
-      your_device: Your TRMNL
+      temperature_profile:
+      temperature_profile_hint:
+      touchbar_mode:
+      touchbar_mode_hint:
+      tidbyt_credentials:
+      tidbyt_credentials_hint:
+      tidbyt_api_key:
+      tidbyt_credentials_invalid:
+      tidbyt_device_id:
+      tidbyt_device_api_key:
+      unlink:
+      unlink_confirm:
+      unlink_device:
+      unlink_device_hint:
+      unlink_device_learn_more:
+      visibility:
+      visibility_hint:
+      your_device:
       upgrade_og:
-        title: Upgrade to 2-bit Display Available
-        sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
-        warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
-        warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
-        cta: Upgrade to TRMNL OG (2-bit)
+        title:
+        sub_title:
+        warning_1:
+        warning_2:
+        cta:
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
-      title: Devices
-      tagline: Your TRMNL devices
-      add_device_modal_title: Add a new device
-      add_first_device: Start by adding your first device!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      title:
+      tagline:
+      add_device_modal_title:
+      add_first_device:
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
-      title: Add a new device
-      description: Enter your Friendly ID to add a new device to your account.
-      add_device: Add new device
+      title:
+      description:
+      add_device:
     associate:
-      error: Error linking device
-      success: Device successfully linked
+      error:
+      success:
     dissociate:
-      error: Error disconnecting device
-      success: Device successfully unlinked
+      error:
+      success:
     external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
+      error:
+      success:
     identify:
-      error: Error updating device
-      success: Device identification requested
+      error:
+      success:
     mirror:
-      error: Error mirroring device
-      error_not_shared: Provided Device ID is not shareable
-      error_oneself: Can't mirror oneself
-      success: Device %{friendly_id} successfully mirrored
-      success_removed: Mirroring Removed
+      error:
+      error_not_shared:
+      error_oneself:
+      success:
+      success_removed:
     switch:
-      error: Error switching device
-      success: Device switched successfully
-      title: Switch to device
+      error:
+      success:
+      title:
     update:
-      error: Error updating device
-      success: "%{device} device settings updated successfully"
+      error:
+      success:
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
-    rate_limit: Too many attempts, please wait and try again
-    invoice_not_found: Invoice not found
+    rate_limit:
+    invoice_not_found:
   logs:
     index:
-      title: Logs
-      all: All
-      bulk_destroy: Bulk Destroy
-      dump: Dump
-      id: ID
-      private_plugins: Private Plugins
-      source: Source
-      time: Time
+      title:
+      all:
+      bulk_destroy:
+      dump:
+      id:
+      private_plugins:
+      source:
+      time:
   markups:
     console_logs:
-      js_logs: JS Logs
+      js_logs:
     form:
-      back_to_plugin_settings: Back to plugin settings
-      design_system: Leverage our native design system
-      design_system_docs: Design System Docs
-      dirty_confirm: You have unsaved changes. Are you sure you want to leave this page?
-      edit_composition: Edit Composition
-      edit_markup: Edit Markup
-      edit_markup_for_plugin: Edit markup for %{plugin_setting_name}
-      edit_markup_please_save_first: Please save before editing markup
-      edit_markup_without_preview: Edit Markup (without preview)
-      error_rendering_markup: Error rendering that markup
-      fix_indentation: Fix indentation
-      go_to_preview: Go To Preview
-      live_preview: Live Preview
-      no_changes_to_save: No changes to save
-      pop_out_preview: Pop Out Preview
-      quickstart_examples: Quick-start Examples
-      quickstart_example_applied: Applied!
-      quickstart_use_this_example: Use this example
-      revert: Revert
-      revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
-      save_changes: Save Changes (⌘﹢S)
-      separate_preview: Preview is open in a separate window
+      back_to_plugin_settings:
+      design_system:
+      design_system_docs:
+      dirty_confirm:
+      edit_composition:
+      edit_markup:
+      edit_markup_for_plugin:
+      edit_markup_please_save_first:
+      edit_markup_without_preview:
+      error_rendering_markup:
+      fix_indentation:
+      go_to_preview:
+      live_preview:
+      no_changes_to_save:
+      pop_out_preview:
+      quickstart_examples:
+      quickstart_example_applied:
+      quickstart_use_this_example:
+      revert:
+      revert_confirm:
+      save_changes:
+      separate_preview:
     merge_variables:
-      your_variables: Your variables
+      your_variables:
     no_merge_variables:
-      force_refresh: If you've provided variables but they aren't being detected, try a __force refresh__.
-      no_variables_detected: No variables detected.
+      force_refresh:
+      no_variables_detected:
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
-      success: 2FA Disabled
-      invalid_otp: Invalid OTP
-      invalid_password: Invalid Password
-      invalid_otp_and_password: Invalid OTP and Password
+      success:
+      invalid_otp:
+      invalid_password:
+      invalid_otp_and_password:
     enable_otp:
-      input_otp: Enter OTP
-      submit: Verify and Enable
-      already_enabled: 2FA is already enabled
+      input_otp:
+      submit:
+      already_enabled:
     enable_otp_verify:
-      success: 2FA Enabled
-      error: Invalid OTP code
+      success:
+      error:
     verify_otp:
-      verify: Verify
-      reset: Reset MFA
-      reset_instructions: Click the button on the back of your TRMNL to generate a reset code
-      success: 2FA successful
-      error: Invalid OTP code
+      verify:
+      reset:
+      reset_instructions:
+      success:
+      error:
   playlist_items:
     index:
-      title: Playlist
-      tagline: Choose what's shown on
-      add_a_group: Add a Group
-      add_a_plugin: Add a Plugin
-      add_first_device_cta: Start by __adding__ your first TRMNL device!
+      title:
+      tagline:
+      add_a_group:
+      add_a_plugin:
+      add_first_device_cta:
       add_to_playlist: Add to Playlist
       create_first_playlist_cta: Create your playlist after __connecting__ your first plugin!
-      custom: Custom
-      device_default: Device default
-      display_period_from: Display from
-      display_period_to: to
-      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
-      never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
+      custom:
+      device_default:
+      display_period_from:
+      display_period_to:
+      display_period_validation:
+      every:
+      never_skip:
+      smart_playlist:
+      smart_playlist_hint:
       skip_after:
-        one: Skip stale screens after 1 day
-        other: Skip stale screens after %{count} days
+        one:
+        other:
     playlist_item:
-      adjust_schedule: Adjust schedule
-      delete: Are you sure you want to remove this item? The plugin will remain connected, just not shown on your device.
-      displayed_now: Displayed now
-      not_displayed_yet: Not displayed yet
-      remove_from_playlist: Remove from playlist
-      hide_playlist: Hide this item
-      show_playlist: Show this item
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      adjust_schedule:
+      delete:
+      displayed_now:
+      not_displayed_yet:
+      remove_from_playlist:
+      hide_playlist:
+      show_playlist:
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default:
+        external:
+        global:
+        mashup:
+        readonly:
     create:
       error: Failed to update playlist
-      success: Playlist updated
+      success:
     destroy:
-      error: Error removing item from playlist
+      error:
       success: Plugin removed from Playlist
     toggle_visibility:
-      success: Playlist item %{change}
+      success:
     duplicate:
       success: Playlist duplicated
     sort:
-      success: Playlist order updated
+      success:
     set_preferences:
       success: Smart playlist preference updated
     update:
-      success: Playlist order updated
+      success:
   plugins:
     index:
-      title: Plugins
-      tagline: What will you put on your TRMNL?
-      available: Available
-      connected: Connected
-      supported_by_this_device: Supported by this device
-      recipes: Recipes
-      recipes_hint: Private plugins by community members that can be installed in 1 click. __Learn more__.
+      title:
+      tagline:
+      available:
+      connected:
+      supported_by_this_device:
+      recipes:
+      recipes_hint:
     search:
-      placeholder: Search Plugins
+      placeholder:
     my:
       index:
-        title: My Plugins
-        tagline: Develop Plugins for the public marketplace
+        title:
+        tagline:
       card:
-        connections: connections
-        install: Install
-        review_are_you_sure: Are you sure? The TRMNL team will test it and email you any questions.
-        submit_for_review: Submit for Review
+        connections:
+        install:
+        review_are_you_sure:
+        submit_for_review:
     new:
-      title: Create New Plugin
-      tagline: Other users will be able to install your plugin.
-      name: Name
-      category: Category
-      category_hint: Hold cmd or ctrl to choose up to 3
-      refresh_every: Supported Refresh Interval
-      refresh_every_hint: The fastest refresh interval your plugin can support.
-      description: Description
-      description_hint: Maximum 50 characters
-      icon: Icon
-      icon_hint: 512x512px recommended
-      installation_url: Installation URL
-      installation_url_hint: Learn more about the installation flow __here__.
-      installation_success_webhook_url: Installation Success Webhook URL
-      knowledge_base_url: Knowledge Base URL
-      management_url: Plugin Management URL
-      management_url_hint: Learn more about the management flow __here__.
-      markup_url: Plugin Markup URL
-      markup_url_hint: Learn more about screen generation __here__.
-      no_screen_padding: No Screen Padding
-      no_screen_padding_hint: Removes the outermost padding in fullscreen mode.
-      uninstallation_webhook_url: Uninstallation Webhook URL
+      title:
+      tagline:
+      name:
+      category:
+      category_hint:
+      refresh_every:
+      refresh_every_hint:
+      description:
+      description_hint:
+      icon:
+      icon_hint:
+      installation_url:
+      installation_url_hint:
+      installation_success_webhook_url:
+      knowledge_base_url:
+      management_url:
+      management_url_hint:
+      markup_url:
+      markup_url_hint:
+      no_screen_padding:
+      no_screen_padding_hint:
+      uninstallation_webhook_url:
     edit:
-      title: Edit Plugin
-      tagline: Update your plugin details.
-      name: Name
-      description: Description
+      title:
+      tagline:
+      name:
+      description:
   plugin_recipes:
-    connected: Recipe connected
+    connected:
     connections:
-      one: Connection
-      other: Connections
+      one:
+      other:
     forks:
-      one: Fork
-      other: Forks
-    forked: Recipe forked
+      one:
+      other:
+    forked:
     new:
-      error: Recipe not found
+      error:
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
-    active: Active
-    copy_are_you_sure: Are you sure you want to copy this setting?
-    delete_are_you_sure: Are you sure you want to delete this setting?
+    active:
+    copy_are_you_sure:
+    delete_are_you_sure:
     delete: This will completely remove the plugin's settings. To simply hide this plugin from your device, delete it from your Playlist instead.
-    inactive: Inactive
-    no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: No plugin settings found.
-    not_supported: Not supported on current device
-    refreshing_now_please_wait: Refreshing now, reload this page in a few seconds.
-    reset_credentials: "%{plugin_name} account reset successfully"
+    inactive:
+    no_matches_found:
+    no_plugin_settings_found:
+    not_supported:
+    refreshing_now_please_wait:
+    reset_credentials:
     form:
-      active_hint: Show or hide this plugin instance on your device
-      advanced_settings: Advanced Settings
-      back_to_playlist: Back to Playlist
-      back_to_plugin: Back to %{plugin}
-      back_to_plugins: Back to Plugins
-      connect_with: Connect with %{plugin}
-      debug_logs: Debug Logs
-      debug_logs_click_here: Click here
-      debug_logs_click_here_hint: to enable debug logs for this plugin instance.
-      debug_logs_enabled: Debug logs enabled for %{hours} hours.
-      debug_logs_enabled_link: View logs
-      disconnect_account: Disconnect Account
-      manage_plugin: Configure %{plugin}
-      force_refresh: Force Refresh
-      force_refresh_hint: This feature is designed for testing only - please do not abuse it.
-      force_refresh_click_here: Click here
-      force_refresh_click_here_hint: to generate a new screen immediately
-      force_refresh_not_possible: This plugin cannot be force-refreshed because the TRMNL server does not perform image processing. Learn how to test your instance __here__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
-      learn_more: Learn about this plugin in our knowledge base
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
-      learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
-      linked_account: Linked Account
-      linked_account_success: Successfully linked with %{plugin_name}
-      link_oauth: Link Account
-      link_oauth_hint: Before you continue, follow the secure authorization process provided by %{plugin}
-      mirrored: Mirrored
-      multiple_instances_hint: This plugin supports multiple instances.
-      name: Name
-      name_hint: Give it a name for easy reference
-      parse: Parse
-      parse_save_first: Parse (Save plugin first)
-      parsed: Parsed
-      plugin_uuid: Plugin UUID
-      plugin_uuid_hint: Use this to make Webhook API requests.
-      preview: Preview - your device will show actual data
+      active_hint:
+      advanced_settings:
+      back_to_playlist:
+      back_to_plugin:
+      back_to_plugins:
+      connect_with:
+      debug_logs:
+      debug_logs_click_here:
+      debug_logs_click_here_hint:
+      debug_logs_enabled:
+      debug_logs_enabled_link:
+      disconnect_account:
+      manage_plugin:
+      force_refresh:
+      force_refresh_hint:
+      force_refresh_click_here:
+      force_refresh_click_here_hint:
+      force_refresh_not_possible:
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
+      learn_more:
+      learn_more_fork:
+      learn_more_fork_original:
+      learn_more_native_long:
+      learn_more_native_short:
+      learn_more_recipe_author:
+      learn_more_recipe_long:
+      learn_more_recipe_short:
+      learn_more_third_party_long:
+      learn_more_third_party_short:
+      linked_account:
+      linked_account_success:
+      link_oauth:
+      link_oauth_hint:
+      mirrored:
+      multiple_instances_hint:
+      name:
+      name_hint:
+      parse:
+      parse_save_first:
+      parsed:
+      plugin_uuid:
+      plugin_uuid_hint:
+      preview:
       recipe_cta_heading_published: This plugin is a Recipe
-      recipe_cta_heading_unlisted: This plugin is unlisted
+      recipe_cta_heading_unlisted:
       recipe_cta_heading_in_review: Recipe in review
       recipe_cta_heading_not_published: Publish as a Recipe?
-      recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
-      recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
-      recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
-      recipe_mirrored: This screen is mirrored from the recipe.
-      recipe_visibility_title: How would you like to publish?
-      recipe_visibility_edit_title: Edit Submission
-      recipe_visibility_public: Public
-      recipe_visibility_public_hint: Anyone can find and install.
-      recipe_visibility_private: Private
-      recipe_visibility_private_hint: Breaks external installs.
-      recipe_visibility_unlisted: Unlisted
-      recipe_visibility_unlisted_hint: Anyone with the link can install.
-      refresh_rate: Refresh rate
-      refresh_rate_hint: Define how frequently this plugin instance fetches fresh data
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
-      refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
-      refreshed: Refreshed
-      remove_plugin: Remove plugin
-      remove_plugin_hint: Removing a plugin will also remove it from your playlist
-      synced: Synced
-      refresh_paused: Refresh Paused
-      refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
-      refresh_paused_mashup: Refreshing Mashups
-      refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
-      refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.
-      view_recipe: View Recipe
-      visit_docs: Visit Docs
+      recipe_cta_body_published:
+      recipe_cta_body_in_review:
+      recipe_cta_body_not_published:
+      recipe_cta_confirm:
+      recipe_mirrored:
+      recipe_visibility_title:
+      recipe_visibility_edit_title:
+      recipe_visibility_public:
+      recipe_visibility_public_hint:
+      recipe_visibility_private:
+      recipe_visibility_private_hint:
+      recipe_visibility_unlisted:
+      recipe_visibility_unlisted_hint:
+      refresh_rate:
+      refresh_rate_hint:
+      refresh_rate_jit_hint:
+      refresh_rate_not_configurable:
+      refreshed:
+      remove_plugin:
+      remove_plugin_hint:
+      synced:
+      refresh_paused:
+      refresh_paused_hint:
+      refresh_paused_hidden_hint:
+      refresh_paused_mashup:
+      refresh_paused_mashup_hint:
+      refresh_stopped:
+      view_recipe:
+      visit_docs:
     import:
-      archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
-      missing_entry: The ZIP file does not contain %{filename}
-      entry_too_large: "%{filename} is too large"
-      malformed: "%{filename} is malformed"
+      archive_too_large:
+      missing_entry:
+      entry_too_large:
+      malformed:
     create:
-      success: Plugin created and added to your
-      playlist: playlist
+      success:
+      playlist:
     destroy:
-      success: Plugin deleted
-    handle_canceled_consent: Consent canceled, please try again
+      success:
+    handle_canceled_consent:
     update:
-      success: Plugin configuration updated successfully
+      success:
     add_to_playlist:
       success: Plugin added to Playlist
   referral_code:
     create:
-      request_received: Request received, check your inbox
+      request_received:
   recipes:
     index:
-      newest_to_oldest: Newest to Oldest
-      oldest_to_newest: Oldest to Newest
-      most_popular: Most Popular
-      install: Install
-      fork: Fork
+      newest_to_oldest:
+      oldest_to_newest:
+      most_popular:
+      install:
+      fork:
   schedules:
     form:
-      add: Add a custom schedule
-      append: And during…
-      no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
-      to: to
-      copy_prompt: Copy schedule from…
-      no_days_error: Please select at least one day.
+      add:
+      append:
+      no_schedule:
+      some_schedule:
+      to:
+      copy_prompt:
+      no_days_error:
   upgrade:
     index:
-      title: 'Upgrading device:'
-      tagline: Unlock custom plugins and __more__.
-      pay: Pay
-      error: Device %{device_name} is already upgraded, switch to another device
+      title:
+      tagline:
+      pay:
+      error:
     confirm:
-      success: Developer edition add-on is now enabled
+      success:

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -1,94 +1,94 @@
 ---
 uk:
   locale_name: Ukrainian
-  about: About
-  actions: Actions
+  about:
+  actions:
   add: Додати
   add_new: Додати новий
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: У мене вже є акаунт
-  are_you_sure: Are you sure?
+  are_you_sure:
   back: Назад
-  back_to_all_blog_posts: Back to all posts
-  blog: Blog
-  brand: Brand
+  back_to_all_blog_posts:
+  blog:
+  brand:
   buy_now: Придбати зараз
   cancel: Скасувати
   change_password: Змінити пароль
   charge_level: Рівень заряду
   charged: заряджено
-  charging: Charging
-  claim_plus_trial: Claim 6 Months Free
+  charging:
+  claim_plus_trial:
   close: Закрити
   confirm_change_password: Змінити мій пароль
   confirm_password: Новий пароль (повторно)
-  copy: Copy
-  copied_to_clipboard: Copied!
-  copy_to_clipboard: Copy to clipboard
-  created: Created
+  copy:
+  copied_to_clipboard:
+  copy_to_clipboard:
+  created:
   create_an_account: Створити акаунт
-  current_device: Current device
+  current_device:
   days: днів
   delete: Видалити
-  developers: Developers
-  developer_edition_required: Developer edition is required to enable this feature.
+  developers:
+  developer_edition_required:
   device_id: ID пристрою
   device: пристрою
-  discard: Discard
+  discard:
   edit: Редагувати
   email_address: Адреса електронної пошти
-  export: Export
-  fetching: Fetching
+  export:
+  fetching:
   first_name: Ім'я
   forgot_password: Я забув мій пароль
   forgot_password_title: Отакої…Гайда знову
-  friendly_id: Friendly ID
+  friendly_id:
   get_started: Почнемо!
-  hidden: hidden
+  hidden:
   identify: Ідентифікувати
-  import: Import
-  import_new: Import new
-  integrations: Integrations
+  import:
+  import_new:
+  integrations:
   keep_me_signed_in: Залишатись у системі
   knowledge_base: База знань
   last_name: Прізвище
-  learn_more: Learn more
-  loading: Loading
+  learn_more:
+  loading:
   login: Вхід
   log_out: Вийти
-  manage: Manage
+  manage:
   minimum_characters: мінімум символів
   mins: хв
-  my_playlist: My Playlist
+  my_playlist:
   new_password: Новий пароль
   password: Пароль
-  please_wait: Please Wait...
-  plugin_not_found: Plugin not found
-  preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
-  refresh_rates_hint: Learn how refresh rates work __here__.
+  please_wait:
+  plugin_not_found:
+  preview:
+  privacy:
+  refresh_rate:
+  refresh_rates_hint:
   reset_password: Скинути мій пароль
-  reset_to_defaults: Reset to defaults
-  required: Required
+  reset_to_defaults:
+  required:
   save: Зберегти
-  shown: shown
-  section: Section
-  settings: Settings
+  shown:
+  section:
+  settings:
   sign_in: Увійти
   sign_up: Реєстрація
-  something_went_wrong: Something went wrong
-  status: Status
-  subscribe: Subscribe
-  help_center: Support
-  terms: Terms
-  unsaved_changes: You have unsaved changes
+  something_went_wrong:
+  status:
+  subscribe:
+  help_center:
+  terms:
+  unsaved_changes:
   update: Оновити
   view: Переглянути
-  collaboration_request: Wanna collaborate?
-  collaboration_request_hint: Partnerships, group sales, special projects, your call.
-  collaboration_request_cta: Let's talk
+  collaboration_request:
+  collaboration_request_hint:
+  collaboration_request_cta:
   welcome: Ласкаво просимо
   time:
     formats:
@@ -159,51 +159,51 @@ uk:
     index:
       title: Акаунт
       tagline: Налаштування аккаунту
-      api_key_confirm: Are you sure you want to regenerate your API Key? The old key will be invalidated.
-      api_key_hint: See __the docs__ to learn how to configure your local environment.
-      api_key_label: The credential for authenticating local development tools
-      api_key_not_generated: "(none yet)"
-      api_key_reset: Regenerate
+      api_key_confirm:
+      api_key_hint:
+      api_key_label:
+      api_key_not_generated:
+      api_key_reset:
       api_key: API Key
-      beta_features: Beta Features
-      beta_features_hint: Try out new stuff here. Options may disappear at any time.
-      discord_community: Discord Community
-      discord_username: What's your Discord username?
-      discord_username_hint: May be used for support, attribution on published Recipes, etc.
+      beta_features:
+      beta_features_hint:
+      discord_community:
+      discord_username:
+      discord_username_hint:
       email_address: Єлектронна пошта
-      refer_and_earn: Refer and Earn
-      refer_and_earn_hint: Give the gift of TRMNL with a personalized coupon. Earn per use, paid monthly.
-      refer_and_earn_redemptions: Redemptions
-      refer_and_earn_request_code: Request a Code
-      device_invoice: Device Invoice
-      device_invoice_label: Download commercial documents for your accountant or (weird) PDF collection.
-      device_invoice_hint: Find this on your package tracking page or shipment notification email.
+      refer_and_earn:
+      refer_and_earn_hint:
+      refer_and_earn_redemptions:
+      refer_and_earn_request_code:
+      device_invoice:
+      device_invoice_label:
+      device_invoice_hint:
       email_address_hint: Використовується для входу в TRMNL та для отримання системних повідомлень.
       first_name_hint: Ми використовуємо ваше ім'я, щоб зробити інтерфейс TRMNL більш зручним.
       last_name_hint: Ми використовуємо ваше прізвище, щоб зробити інтерфейс TRMNL більш зручним.
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: Використовується для захисту вашого акаунту TRMNL.
-      enable_2fa: Enable 2FA?
-      enable_2fa_hint: __Click here__ to enable OTP.
-      disable_2fa: Disable 2FA
-      disable_2fa_hint: Provide valid OTP and current password above to disable this feature.
-      plus_subscription: TRMNL+ Subscription
-      plus_subscription_trial_until: You're on a free trial until %{plus_trial_end_at}.
-      plus_subscription_hint: Unlock faster refresh rates and higher rate limits. __Learn more__.
-      plus_subscription_modify: Want to update your payment method or cancel?
+      enable_2fa:
+      enable_2fa_hint:
+      disable_2fa:
+      disable_2fa_hint:
+      plus_subscription:
+      plus_subscription_trial_until:
+      plus_subscription_hint:
+      plus_subscription_modify:
       session: Сесія
       session_hint: Ви увійшли як %{user}
-      show_title_bar: Show title bar
-      show_title_bar_hint: If disabled, native (non global) and third party plugins will be more minimal.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
+      show_title_bar:
+      show_title_bar_hint:
+      theme_hint:
       time_zone: Часовий пояс
       time_zone_hint: Визначає частоту оновлення та розклад сну пристрою.
-      locale: Locale
-      locale_hint: What language and localization do you prefer? __Go here__.
+      locale:
+      locale_hint:
     update:
       success: Профіль успішно оновлено
     reset_api_key:
-      success: API key was regenerated successfully
+      success:
   dashboard:
     index:
       title: Панель управління
@@ -218,7 +218,7 @@ uk:
       next_steps: Ми повідомимо вас, якщо щось зміниться
     news:
       title: Новини
-      cta: View All
+      cta:
     playlist_items:
       title: Плейлисти
       cta: Перейти до плейлистів
@@ -229,165 +229,165 @@ uk:
       connected: Підключено
       new_and_popular: Нові та популярні
     shop:
-      title: Shop
-      need_another: Need another TRMNL?
+      title:
+      need_another:
     time_saved:
       title: Зекономлений час
       cta: Читати далі
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
-      morning_salutation: Good morning
-      afternoon_salutation: Good afternoon
-      evening_salutation: Good evening
+      morning_salutation:
+      afternoon_salutation:
+      evening_salutation:
   devices:
     edit:
-      accepts_beta_firmware: Firmware Early Release
-      accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
+      accepts_beta_firmware:
+      accepts_beta_firmware_hint:
       back_to_devices: Назад до пристроїв
-      battery_and_sleep: Battery & Sleep
+      battery_and_sleep:
       battery_consumption: Споживання батареї
       battery_consumption_hint: Заощаджуйте енергію та насолоджуйтесь тривалим часом роботи батареї, увімкнувши Режим сну.
-      battery_learn_more: Learn more about battery charging __here__.
-      battery_refresh: Refresh
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
-      developer_perks: Developer Perks
+      battery_learn_more:
+      battery_refresh:
+      click:
+      click_action:
+      controls:
+      developer_perks:
       developer_perks_hint: Options below require the __Developer add-on__.
-      device_credentials: Device Credentials
-      device_credentials_hint: See what you can do with these credentials __here__
+      device_credentials:
+      device_credentials_hint:
       device_name: Назва пристрою
       device_name_hint: Ми використовуємо імʼя пристрою, щоб зробити інтерфейс TRMNL більш зручним
-      device_model: Device Model
-      device_model_hint: Your hardware Model
-      device_model_switch_warning: This is a dangerous operation, learn more __here__
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
-      display_calibration: Display Calibration
-      display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
-      display_calibration_pixel_ratio: Pixel Ratio
-      display_calibration_pixel_ratio_hint: 'Image zoom level (0.5–3.0). Default:'
-      display_calibration_ui_scale: UI Scale
-      display_calibration_ui_scale_hint: 'Text and element sizes (0.5–2.0). Default:'
+      device_model:
+      device_model_hint:
+      device_model_switch_warning:
+      device_info:
+      current_firmware:
+      last_ping:
+      unknown:
+      never:
+      display_calibration:
+      display_calibration_hint:
+      display_calibration_pixel_ratio:
+      display_calibration_pixel_ratio_hint:
+      display_calibration_ui_scale:
+      display_calibration_ui_scale_hint:
       edit_device: Змінити налаштування пристрою
-      firmware: Firmware
-      firmware_updates_enabled: Updates enabled
-      firmware_updates_disabled: Updates disabled
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
-      guest_mode: Guest Mode
-      guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
-      guest_mode_item_placeholder: Choose an item
-      guest_mode_duration_placeholder: Choose a duration
+      firmware:
+      firmware_updates_enabled:
+      firmware_updates_disabled:
+      font_family:
+      font_family_hint:
+      guest_mode:
+      guest_mode_hint:
+      guest_mode_item_placeholder:
+      guest_mode_duration_placeholder:
       identify: Ідентифікувати
       identify_device: Ідентифікувати пристрій
       identify_device_hint: Натисніть кнопку нижче, щоб показати екран на цьому пристрої, який допоможе його ідентифікувати.
-      logs: Logs
-      logs_hint: Debug your device and plugins with a live feed of raw error logs.
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
-      low_battery_email_notification: Low Battery Email Notification
-      low_battery_email_notification_hint: Get notified via email when your device battery is running low.
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      logs:
+      logs_hint:
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
+      low_battery_email_notification:
+      low_battery_email_notification_hint:
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: Відзеркалити
       mirror_device: Відзеркалити інший пристрій
       mirror_device_hint: Надайте ID пристрою з увімкненим спільним доступом, щоб дзеркалити його плейлист. Ваш плейлист також буде відображатися.
-      mirror_disabled: Mirroring disabled
-      mirror_enabled: Mirroring
-      mirror_stop: Disconnect Mirroring
-      mirror_sync: Sync Screens
-      ota_enabled: OTA Updates Enabled
-      ota_enabled_hint: Automatically install new firmware. Disable to use your own firmware.
-      ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
-      maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      mirror_disabled:
+      mirror_enabled:
+      mirror_stop:
+      mirror_sync:
+      ota_enabled:
+      ota_enabled_hint:
+      ota_byod_not_supported:
+      maximum_compatibility:
+      maximum_compatibility_hint:
       color_and_rotation: Колір і обертання
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: Обертання екрану
       screen_rotation_not_supported: Обертання екрану в даний час не підтримується на вашому пристрої.
-      palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
-      presentation: Presentation
+      palette:
+      palette_hint:
+      presentation:
       sleep_mode: Режим сну
       sleep_mode_hint: Налаштуйте частоту оновлення, щоб покращити концентрацію та час роботи батареї.
-      sleep_screen: Sleep Screen
-      sleep_screen_tooltip: Enable Sleep Mode to use this feature
-      sleep_screen_hint: Display a sleep screen during sleep mode hours.
-      special_function: Special Function
-      special_function_hint: Set a custom feature for the button on the back of your device.
+      sleep_screen:
+      sleep_screen_tooltip:
+      sleep_screen_hint:
+      special_function:
+      special_function_hint:
       special_function_learn_more: Learn more about special functions __here__.
-      temperature_profile: Temperature Profile
-      temperature_profile_hint: Don't change unless instructed. For displays with washed out images.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
-      tidbyt_credentials: Tidbyt Credentials
-      tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
-      tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
-      tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
+      temperature_profile:
+      temperature_profile_hint:
+      touchbar_mode:
+      touchbar_mode_hint:
+      tidbyt_credentials:
+      tidbyt_credentials_hint:
+      tidbyt_api_key:
+      tidbyt_credentials_invalid:
+      tidbyt_device_id:
+      tidbyt_device_api_key:
       unlink: Відв'язати
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm:
       unlink_device: Відв'язати пристрій
       unlink_device_hint: Відв'язування пристрою TRMNL робить його безпечним для перепродажу або передачі іншій особі.
-      unlink_device_learn_more: Follow the full guide __here__.
+      unlink_device_learn_more:
       visibility: Спільний доступ
       visibility_hint: Зробіть ваш пристрій TRMNL доступним для віддзеркалення, змінивши налаштування нижче.
       your_device: Ваш TRMNL
       upgrade_og:
-        title: Upgrade to 2-bit Display Available
-        sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
-        warning_1: I understand this upgrade is <strong>irreversible</strong> and cannot be undone.
-        warning_2: I understand this is a <strong>dangerous</strong> action and can brick my device.
-        cta: Upgrade to TRMNL OG (2-bit)
+        title:
+        sub_title:
+        warning_1:
+        warning_2:
+        cta:
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: Пристрої
       tagline: Ваші пристрої TRMNL
       add_device_modal_title: Додати новий пристрій
       add_first_device: Почніть, додавши свій перший пристрій!
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: Додати новий пристрій
       description: Введіть ваш Дружній ID, щоб додати новий пристрій TRMNL до вашого акаунту.
@@ -399,8 +399,8 @@ uk:
       error: Помилка видалення пристрою
       success: Пристрій успішно видалено
     external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
+      error:
+      success:
     identify:
       error: Помилка оновлення пристрою
       success: Запит на ідентифікацію пристрою надіслано
@@ -409,143 +409,143 @@ uk:
       error_not_shared: Вказаний ідентифікатор пристрою не доступний для спільного доступу
       error_oneself: Неможливо віддзеркалити власний пристрій
       success: Пристрій %{friendly_id} успішно віддзеркалено
-      success_removed: Mirroring Removed
+      success_removed:
     switch:
       error: Помилка перемикання пристрою
       success: Пристрій успішно перемкнено
-      title: Switch to device
+      title:
     update:
       error: Помилка оновлення пристрою
       success: Налаштування пристрою %{device} успішно оновлено
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
-    rate_limit: Too many attempts, please wait and try again
-    invoice_not_found: Invoice not found
+    rate_limit:
+    invoice_not_found:
   logs:
     index:
-      title: Logs
-      all: All
-      bulk_destroy: Bulk Destroy
-      dump: Dump
-      id: ID
-      private_plugins: Private Plugins
-      source: Source
-      time: Time
+      title:
+      all:
+      bulk_destroy:
+      dump:
+      id:
+      private_plugins:
+      source:
+      time:
   markups:
     console_logs:
-      js_logs: JS Logs
+      js_logs:
     form:
-      back_to_plugin_settings: Back to plugin settings
-      design_system: Leverage our native design system
-      design_system_docs: Design System Docs
-      dirty_confirm: You have unsaved changes. Are you sure you want to leave this page?
-      edit_composition: Edit Composition
-      edit_markup: Edit Markup
-      edit_markup_for_plugin: Edit markup for %{plugin_setting_name}
-      edit_markup_please_save_first: Please save before editing markup
-      edit_markup_without_preview: Edit Markup (without preview)
-      error_rendering_markup: Error rendering that markup
-      fix_indentation: Fix indentation
-      go_to_preview: Go To Preview
-      live_preview: Live Preview
-      no_changes_to_save: No changes to save
-      pop_out_preview: Pop Out Preview
-      quickstart_examples: Quick-start Examples
-      quickstart_example_applied: Applied!
-      quickstart_use_this_example: Use this example
-      revert: Revert
-      revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
-      save_changes: Save Changes (⌘﹢S)
-      separate_preview: Preview is open in a separate window
+      back_to_plugin_settings:
+      design_system:
+      design_system_docs:
+      dirty_confirm:
+      edit_composition:
+      edit_markup:
+      edit_markup_for_plugin:
+      edit_markup_please_save_first:
+      edit_markup_without_preview:
+      error_rendering_markup:
+      fix_indentation:
+      go_to_preview:
+      live_preview:
+      no_changes_to_save:
+      pop_out_preview:
+      quickstart_examples:
+      quickstart_example_applied:
+      quickstart_use_this_example:
+      revert:
+      revert_confirm:
+      save_changes:
+      separate_preview:
     merge_variables:
-      your_variables: Your variables
+      your_variables:
     no_merge_variables:
-      force_refresh: If you've provided variables but they aren't being detected, try a __force refresh__.
-      no_variables_detected: No variables detected.
+      force_refresh:
+      no_variables_detected:
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
-      success: 2FA Disabled
-      invalid_otp: Invalid OTP
-      invalid_password: Invalid Password
-      invalid_otp_and_password: Invalid OTP and Password
+      success:
+      invalid_otp:
+      invalid_password:
+      invalid_otp_and_password:
     enable_otp:
-      input_otp: Enter OTP
-      submit: Verify and Enable
-      already_enabled: 2FA is already enabled
+      input_otp:
+      submit:
+      already_enabled:
     enable_otp_verify:
-      success: 2FA Enabled
-      error: Invalid OTP code
+      success:
+      error:
     verify_otp:
-      verify: Verify
-      reset: Reset MFA
-      reset_instructions: Click the button on the back of your TRMNL to generate a reset code
-      success: 2FA successful
-      error: Invalid OTP code
+      verify:
+      reset:
+      reset_instructions:
+      success:
+      error:
   playlist_items:
     index:
       title: Плейлист
       tagline: Виберіть, що відображається на
-      add_a_group: Add a Group
-      add_a_plugin: Add a Plugin
+      add_a_group:
+      add_a_plugin:
       add_first_device_cta: Почніть з __додавання__ вашого першого пристрою TRMNL!
       add_to_playlist: Додати до плейлиста
       create_first_playlist_cta: Створіть свій плейлист після __підключення__ вашого першого плагіна!
-      custom: Custom
-      device_default: Device default
-      display_period_from: Display from
-      display_period_to: to
-      display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
-      never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
+      custom:
+      device_default:
+      display_period_from:
+      display_period_to:
+      display_period_validation:
+      every:
+      never_skip:
+      smart_playlist:
+      smart_playlist_hint:
       skip_after:
-        one: Skip stale screens after 1 day
-        other: Skip stale screens after %{count} days
+        one:
+        other:
     playlist_item:
-      adjust_schedule: Adjust schedule
+      adjust_schedule:
       delete: Ви впевнені, що хочете видалити цей елемент? Плагін залишиться підключеним, але не відображатиметься на вашому пристрої.
       displayed_now: Відображається зараз
       not_displayed_yet: Ще не відображається
       remove_from_playlist: Видалити з плейлиста
-      hide_playlist: Hide this item
-      show_playlist: Show this item
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      hide_playlist:
+      show_playlist:
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default:
+        external:
+        global:
+        mashup:
+        readonly:
     create:
       error: Не вдалося оновити плейлист
       success: Плейлист оновлено
@@ -553,11 +553,11 @@ uk:
       error: Помилка видалення елементу з плейлиста
       success: Плагін видалено з плейлиста
     toggle_visibility:
-      success: Playlist item %{change}
+      success:
     duplicate:
       success: Playlist duplicated
     sort:
-      success: Playlist order updated
+      success:
     set_preferences:
       success: Smart playlist preference updated
     update:
@@ -568,157 +568,157 @@ uk:
       tagline: Що ви бажаєте додати на свій TRMNL?
       available: Доступні
       connected: Підключені
-      supported_by_this_device: Supported by this device
-      recipes: Recipes
-      recipes_hint: Private plugins by community members that can be installed in 1 click. __Learn more__.
+      supported_by_this_device:
+      recipes:
+      recipes_hint:
     search:
       placeholder: Знайти плагіни
     my:
       index:
-        title: My Plugins
-        tagline: Develop Plugins for the public marketplace
+        title:
+        tagline:
       card:
-        connections: connections
-        install: Install
-        review_are_you_sure: Are you sure? The TRMNL team will test it and email you any questions.
-        submit_for_review: Submit for Review
+        connections:
+        install:
+        review_are_you_sure:
+        submit_for_review:
     new:
-      title: Create New Plugin
+      title:
       tagline: Enable other user to install your plugin.
-      name: Name
-      category: Category
-      category_hint: Hold cmd or ctrl to choose up to 3
-      refresh_every: Supported Refresh Interval
-      refresh_every_hint: The fastest refresh interval your plugin can support.
-      description: Description
-      description_hint: Maximum 50 characters
-      icon: Icon
-      icon_hint: 512x512px recommended
-      installation_url: Installation URL
-      installation_url_hint: Learn more about the installation flow __here__.
-      installation_success_webhook_url: Installation Success Webhook URL
-      knowledge_base_url: Knowledge Base URL
-      management_url: Plugin Management URL
-      management_url_hint: Learn more about the management flow __here__.
-      markup_url: Plugin Markup URL
-      markup_url_hint: Learn more about screen generation __here__.
-      no_screen_padding: No Screen Padding
-      no_screen_padding_hint: Removes the outermost padding in fullscreen mode.
-      uninstallation_webhook_url: Uninstallation Webhook URL
+      name:
+      category:
+      category_hint:
+      refresh_every:
+      refresh_every_hint:
+      description:
+      description_hint:
+      icon:
+      icon_hint:
+      installation_url:
+      installation_url_hint:
+      installation_success_webhook_url:
+      knowledge_base_url:
+      management_url:
+      management_url_hint:
+      markup_url:
+      markup_url_hint:
+      no_screen_padding:
+      no_screen_padding_hint:
+      uninstallation_webhook_url:
     edit:
-      title: Edit Plugin
-      tagline: Update your plugin details.
-      name: Name
-      description: Description
+      title:
+      tagline:
+      name:
+      description:
   plugin_recipes:
-    connected: Recipe connected
+    connected:
     connections:
-      one: Connection
-      other: Connections
+      one:
+      other:
     forks:
-      one: Fork
-      other: Forks
-    forked: Recipe forked
+      one:
+      other:
+    forked:
     new:
-      error: Recipe not found
+      error:
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: Активний
-    copy_are_you_sure: Are you sure you want to copy this setting?
-    delete_are_you_sure: Are you sure you want to delete this setting?
+    copy_are_you_sure:
+    delete_are_you_sure:
     delete: Це повністю видалить налаштування плагіна. Щоб просто приховати цей плагін з вашого пристрою, видаліть його з плейлиста.
     inactive: Неактивний
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: Налаштування плагінів не знайдено.
-    not_supported: Not supported on current device
-    refreshing_now_please_wait: Refreshing now, reload this page in a few seconds.
-    reset_credentials: "%{plugin_name} account reset successfully"
+    not_supported:
+    refreshing_now_please_wait:
+    reset_credentials:
     form:
       active_hint: Показати чи приховати цей екземпляр плагіна на вашому пристрої
-      advanced_settings: Advanced Settings
-      back_to_playlist: Back to Playlist
+      advanced_settings:
+      back_to_playlist:
       back_to_plugin: Назад до %{plugin}
       back_to_plugins: Назад до Плагінів
       connect_with: Підключитися до %{plugin}
-      debug_logs: Debug Logs
-      debug_logs_click_here: Click here
-      debug_logs_click_here_hint: to enable debug logs for this plugin instance.
-      debug_logs_enabled: Debug logs enabled for %{hours} hours.
-      debug_logs_enabled_link: View logs
-      disconnect_account: Disconnect Account
-      manage_plugin: Configure %{plugin}
+      debug_logs:
+      debug_logs_click_here:
+      debug_logs_click_here_hint:
+      debug_logs_enabled:
+      debug_logs_enabled_link:
+      disconnect_account:
+      manage_plugin:
       force_refresh: Примусове Оновлення
       force_refresh_hint: Ця функція призначена лише для тестування - будь ласка, не зловживайте нею.
       force_refresh_click_here: Натисніть тут
       force_refresh_click_here_hint: щоб негайно створити новий екран
-      force_refresh_not_possible: This plugin cannot be force-refreshed because the TRMNL server does not perform image processing. Learn how to test your instance __here__.
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      force_refresh_not_possible:
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: Дізнайтеся більше про цей плагін у нашій базі знань
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
-      learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
-      linked_account: Linked Account
-      linked_account_success: Successfully linked with %{plugin_name}
+      learn_more_fork:
+      learn_more_fork_original:
+      learn_more_native_long:
+      learn_more_native_short:
+      learn_more_recipe_author:
+      learn_more_recipe_long:
+      learn_more_recipe_short:
+      learn_more_third_party_long:
+      learn_more_third_party_short:
+      linked_account:
+      linked_account_success:
       link_oauth: Підключити обліковий запис
       link_oauth_hint: Перед продовженням виконайте безпечний процес авторизації, наданий %{plugin}
-      mirrored: Mirrored
+      mirrored:
       multiple_instances_hint: Цей плагін підтримує кілька екземплярів.
       name: Ім'я
       name_hint: Дайте йому назву для зручності
-      parse: Parse
-      parse_save_first: Parse (Save plugin first)
-      parsed: Parsed
+      parse:
+      parse_save_first:
+      parsed:
       plugin_uuid: UUID плагіна
       plugin_uuid_hint: Використовуйте це для здійснення запитів Webhook API.
       preview: Попередній перегляд - ваш пристрій буде показувати актуальні дані
       recipe_cta_heading_published: This plugin is a Recipe
-      recipe_cta_heading_unlisted: This plugin is unlisted
+      recipe_cta_heading_unlisted:
       recipe_cta_heading_in_review: Recipe in review
       recipe_cta_heading_not_published: Publish as a Recipe?
-      recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
-      recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
-      recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
-      recipe_mirrored: This screen is mirrored from the recipe.
-      recipe_visibility_title: How would you like to publish?
-      recipe_visibility_edit_title: Edit Submission
-      recipe_visibility_public: Public
-      recipe_visibility_public_hint: Anyone can find and install.
-      recipe_visibility_private: Private
-      recipe_visibility_private_hint: Breaks external installs.
-      recipe_visibility_unlisted: Unlisted
-      recipe_visibility_unlisted_hint: Anyone with the link can install.
+      recipe_cta_body_published:
+      recipe_cta_body_in_review:
+      recipe_cta_body_not_published:
+      recipe_cta_confirm:
+      recipe_mirrored:
+      recipe_visibility_title:
+      recipe_visibility_edit_title:
+      recipe_visibility_public:
+      recipe_visibility_public_hint:
+      recipe_visibility_private:
+      recipe_visibility_private_hint:
+      recipe_visibility_unlisted:
+      recipe_visibility_unlisted_hint:
       refresh_rate: Частота оновлення
       refresh_rate_hint: Оберіть, як часто цей екземпляр плагіна отримує свіжі дані
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
-      refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
+      refresh_rate_jit_hint:
+      refresh_rate_not_configurable:
       refreshed: Оновлено
-      remove_plugin: Remove plugin
-      remove_plugin_hint: Removing a plugin will also remove it from your playlist
-      synced: Synced
-      refresh_paused: Refresh Paused
-      refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
-      refresh_paused_mashup: Refreshing Mashups
-      refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
-      refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.
-      view_recipe: View Recipe
+      remove_plugin:
+      remove_plugin_hint:
+      synced:
+      refresh_paused:
+      refresh_paused_hint:
+      refresh_paused_hidden_hint:
+      refresh_paused_mashup:
+      refresh_paused_mashup_hint:
+      refresh_stopped:
+      view_recipe:
       visit_docs: Переглянути Документацію
     import:
-      archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
-      missing_entry: The ZIP file does not contain %{filename}
-      entry_too_large: "%{filename} is too large"
-      malformed: "%{filename} is malformed"
+      archive_too_large:
+      missing_entry:
+      entry_too_large:
+      malformed:
     create:
       success: Плагін створено та додано до вашого
       playlist: плейлисту
@@ -731,28 +731,28 @@ uk:
       success: Plugin added to Playlist
   referral_code:
     create:
-      request_received: Request received, check your inbox
+      request_received:
   recipes:
     index:
-      newest_to_oldest: Newest to Oldest
-      oldest_to_newest: Oldest to Newest
-      most_popular: Most Popular
-      install: Install
-      fork: Fork
+      newest_to_oldest:
+      oldest_to_newest:
+      most_popular:
+      install:
+      fork:
   schedules:
     form:
-      add: Add a custom schedule
-      append: And during…
-      no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
-      to: to
-      copy_prompt: Copy schedule from…
-      no_days_error: Please select at least one day.
+      add:
+      append:
+      no_schedule:
+      some_schedule:
+      to:
+      copy_prompt:
+      no_days_error:
   upgrade:
     index:
-      title: 'Upgrading device:'
-      tagline: Unlock custom plugins and __more__.
-      pay: Pay
-      error: Device %{device_name} is already upgraded, switch to another device
+      title:
+      tagline:
+      pay:
+      error:
     confirm:
-      success: Developer edition add-on is now enabled
+      success:

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -2,7 +2,7 @@
 zh-CN:
   locale_name: 简体中文
   about: 关于
-  actions: Actions
+  actions:
   add: 添加
   add_new: 新增
   ai_assistant: Agent（智能体）
@@ -248,10 +248,10 @@ zh-CN:
       title: 节省时间
       cta: 详细信息
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: 早上好
       afternoon_salutation: 下午好
@@ -266,9 +266,9 @@ zh-CN:
       battery_consumption_hint: 启用睡眠模式可节省电量并延长电池寿命。
       battery_learn_more: __点击此处__了解更多关于充电的信息。
       battery_refresh: 刷新
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      click:
+      click_action:
+      controls:
       developer_perks: 开发者选项
       developer_perks_hint: 定制插件开发、可编辑 MAC 地址（仅限自带设备）、固件抢先体验以及 API 访问权限
       device_credentials: 设备密码
@@ -304,16 +304,16 @@ zh-CN:
       identify_device_hint: 点击以在此设备上显示识别信息
       logs: 日志
       logs_hint: 通过实时原始错误日志流对设备和插件进行故障排查。
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
       low_battery_email_notification: 低电量邮件通知
       low_battery_email_notification_hint: 在您的设备电量过低时获得邮件通知。
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: 镜像
       mirror_device: 镜像其他设备
       mirror_device_hint: 提供一个（可共享的）设备 ID 以镜像其播放列表。您自己的播放列表仍会显示。
@@ -327,7 +327,7 @@ zh-CN:
       maximum_compatibility: 启用最大兼容模式
       maximum_compatibility_hint: 解决由某些电子墨水驱动芯片引发的显示问题。禁用快速刷新功能。需固件版本 1.6.0 及以上。
       color_and_rotation: 颜色和旋转
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: 屏幕旋转
       screen_rotation_not_supported: 屏幕旋转目前不支持您的设备。
       palette: 调色板
@@ -347,7 +347,7 @@ zh-CN:
       touchbar_mode_hint: 您的设备应响应哪种类型的手势？
       tidbyt_credentials: Tidbyt 凭据
       tidbyt_credentials_hint: 从 Tidbyt 应用的「设置」→「开发者」→「获取 API 密钥」中输入您的 Tidbyt 设备的 API 凭据。
-      tidbyt_api_key: Tidbyt API Key
+      tidbyt_api_key:
       tidbyt_credentials_invalid: Tidbyt API 凭据无效。请仔细检查后重试。
       tidbyt_device_id: 设备 ID
       tidbyt_device_api_key: API 密钥
@@ -366,22 +366,22 @@ zh-CN:
         warning_2: 本人知悉此操作<strong>存在风险</strong>，可能导致设备变砖。
         cta: 升级至 TRMNL OG（2 位）
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: 设备列表
       tagline: 您的 TRMNL 设备
@@ -433,25 +433,25 @@ zh-CN:
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: 尝试次数过多，请耐心等待之后再次尝试
     invoice_not_found: 未找到发票
@@ -461,7 +461,7 @@ zh-CN:
       all: 全部
       bulk_destroy: 批量删除
       dump: 导出
-      id: ID
+      id:
       private_plugins: 私有插件
       source: 来源
       time: 时间
@@ -473,7 +473,7 @@ zh-CN:
       design_system: 利用我们的原生设计系统
       design_system_docs: 设计系统文档
       dirty_confirm: 您有未保存的更改。确定要离开此页面吗？
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: 编辑标记
       edit_markup_for_plugin: 为 %{plugin_setting_name} 编辑标记
       edit_markup_please_save_first: 请先保存后再编辑标记
@@ -498,7 +498,7 @@ zh-CN:
       no_variables_detected: 未检测到变量。
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: 已禁用双重认证
@@ -549,7 +549,7 @@ zh-CN:
       show_playlist: 显示此项
       duplicate: 复制
       duplicate_confirm: 这将创建此项的副本并将其添加到播放列表的底部。是否继续？
-      presentation: Presentation
+      presentation:
       color_palette: 颜色调色板
       device_default: 设备默认（%{name}）
       palette_unavailable: 仅适用于具有多个颜色调色板的设备
@@ -581,7 +581,7 @@ zh-CN:
       tagline: 让您的 TRMNL 更加强大
       available: 可用
       connected: 已连接
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: 配方
       recipes_hint: 社区成员开发的私有插件，支持一键安装。__了解更多__。
     search:
@@ -667,9 +667,9 @@ zh-CN:
       force_refresh_click_here: 点击此处
       force_refresh_click_here_hint: 立即刷新插件
       force_refresh_not_possible: 此插件无法强制刷新，因为 TRMNL 服务器不执行图像处理。__点击此处__了解如何测试您的实例。
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: 了解更多
       learn_more_fork: 此插件从配方分支而来。
       learn_more_fork_original: 查看原始版本
@@ -713,7 +713,7 @@ zh-CN:
       recipe_visibility_unlisted_hint: 任何拥有链接的人都可以安装。
       refresh_rate: 刷新率
       refresh_rate_hint: 设置插件刷新频率
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
+      refresh_rate_jit_hint:
       refresh_rate_not_configurable: "%{refresh_rate}同步（不可配置）"
       refreshed: 已刷新
       remove_plugin: 移除插件
@@ -721,7 +721,7 @@ zh-CN:
       synced: 已同步
       refresh_paused: 刷新已暂停
       refresh_paused_hint: 自动刷新已暂停。添加到播放列表以重新开始。
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
+      refresh_paused_hidden_hint:
       refresh_paused_mashup: 正在刷新混搭
       refresh_paused_mashup_hint: 全屏模式的自动刷新已暂停。混搭仍在更新。
       refresh_stopped: 自动刷新已停止。请修复插件错误以继续。

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -2,11 +2,11 @@
 zh-HK:
   locale_name: 繁體中文（香港）
   about: 簡介
-  actions: Actions
+  actions:
   add: 加入
   add_new: 新增
-  ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant:
+  ai_assistant_hint:
   already_have_account: 我已經有帳戶
   are_you_sure: 確定嗎？
   back: 返回
@@ -35,7 +35,7 @@ zh-HK:
   developer_edition_required: 需要開發者版本才能啟用此功能。
   device_id: 裝置ID
   device: 裝置
-  discard: Discard
+  discard:
   edit: 編輯
   email_address: 電郵地址
   export: 匯出
@@ -43,7 +43,7 @@ zh-HK:
   first_name: 名字
   forgot_password: 忘記密碼
   forgot_password_title: 再次輸入
-  friendly_id: Friendly ID
+  friendly_id:
   get_started: 讓我們開始吧！
   hidden: 隱藏
   identify: 識別
@@ -83,7 +83,7 @@ zh-HK:
   subscribe: 訂閱
   help_center: 支援
   terms: 條款
-  unsaved_changes: You have unsaved changes
+  unsaved_changes:
   update: 更新
   view: 查看
   collaboration_request: 想合作嗎？
@@ -93,7 +93,7 @@ zh-HK:
   time:
     formats:
       shorter: "%-H:%M"
-    start_of_week: 0
+    start_of_week:
   datetime:
     relative:
       past: "%{time}前"
@@ -159,7 +159,7 @@ zh-HK:
       email_address_hint: 用於登入TRMNL及接收系統訊息。
       first_name_hint: 我們使用你的名字讓TRMNL介面更具親切感。
       last_name_hint: 我們使用你的名字讓TRMNL介面更具親切感。
-      github_username_hint: Used to attribute open source contributions to the Creator Fund.
+      github_username_hint:
       password_hint: 用於保護你的TRMNL帳戶。
       enable_2fa: 啟用雙重驗證(2FA)？
       enable_2fa_hint: __按此__啟用OTP。
@@ -173,7 +173,7 @@ zh-HK:
       session_hint: 你已登入為：%{user}
       show_title_bar: 顯示標題列
       show_title_bar_hint: 如停用此功能，原生（非全域）及第三方外掛功能會顯得更簡約。
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
+      theme_hint:
       time_zone: 時區
       time_zone_hint: 決定重新整理頻率及裝置睡眠時間。
       locale: 地區語言
@@ -213,10 +213,10 @@ zh-HK:
       title: 已節省時間
       cta: 閱讀詳情
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
+      manage_persona:
+      dismiss:
     saved_discovery_setup:
-      manage_persona: Manage persona
+      manage_persona:
     welcome_message:
       morning_salutation: 早晨
       afternoon_salutation: 午安
@@ -231,9 +231,9 @@ zh-HK:
       battery_consumption_hint: 啟用「睡眠模式」可節省電量，並延長電池續航時間。
       battery_learn_more: __按此__了解更多關於電池充電的資訊。
       battery_refresh: 重新整理
-      click: Click
-      click_action: Advance playlist
-      controls: Controls
+      click:
+      click_action:
+      controls:
       developer_perks: 開發者福利
       developer_perks_hint: 開發自訂外掛、可編輯MAC地址（只限BYOD）、韌體搶先體驗及API訪問。
       device_credentials: 裝置憑證
@@ -258,8 +258,8 @@ zh-HK:
       firmware: 韌體
       firmware_updates_enabled: 已啟用更新
       firmware_updates_disabled: 已停用更新
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family:
+      font_family_hint:
       guest_mode: 訪客模式
       guest_mode_hint: 選擇啟用訪客模式時顯示的內容（以及顯示多久）。
       guest_mode_item_placeholder: 選擇項目
@@ -269,16 +269,16 @@ zh-HK:
       identify_device_hint: 按下按鈕以在裝置上生成一個幫助識別它的畫面。
       logs: 記錄檔
       logs_hint: 即時串流原始錯誤記錄，以偵錯你的裝置及外掛。
-      long_press: Long press (6–7s)
-      long_press_action: Reset Wi-Fi credentials
-      longest_press: Longest press (16–18s)
-      longest_press_action: Soft reset
+      long_press:
+      long_press_action:
+      longest_press:
+      longest_press_action:
       low_battery_email_notification: 低電量電郵通知
       low_battery_email_notification_hint: 當裝置電量不足時，透過電郵接收通知。
-      low_battery_screen_disabled: Hide Low Battery Screen
-      low_battery_screen_disabled_hint: Stop the low battery warning screen from showing on this device. Useful if it is always plugged in.
-      medium_press: Medium press (1–2s)
-      medium_press_action: Special Function (above)
+      low_battery_screen_disabled:
+      low_battery_screen_disabled_hint:
+      medium_press:
+      medium_press_action:
       mirror: 鏡像共享
       mirror_device: 鏡像共享另一部裝置
       mirror_device_hint: 輸入可共享(shareable)裝置的ID，以鏡像共享其播放清單。你的播放清單仍會顯示。
@@ -292,12 +292,12 @@ zh-HK:
       maximum_compatibility: 啟用最大兼容性
       maximum_compatibility_hint: 解決由某些電子墨水驅動晶片引起的顯示問題。會停用快速重新整理。需要韌體版本1.6.0或以上。
       color_and_rotation: 顏色和旋轉
-      image_rotation: Image Rotation
+      image_rotation:
       screen_rotation: 屏幕旋轉
       screen_rotation_not_supported: 屏幕旋轉目前不支援你的裝置。
       palette: 色彩模式
       palette_hint: 選擇此裝置生成畫面時使用的色彩模式。色彩層次越多視覺效果越佳，但層次越少則電子墨水螢幕的繪製速度越快。個別播放清單項目可以覆寫此設定。
-      presentation: Presentation
+      presentation:
       sleep_mode: 睡眠模式
       sleep_mode_hint: 調整重新整理頻率，以提升專注度及電池續航時間。
       sleep_screen: 睡眠畫面
@@ -308,16 +308,16 @@ zh-HK:
       special_function_learn_more: __按此__了解更多特別功能。
       temperature_profile: 色溫設定檔
       temperature_profile_hint: 除非獲得指示，否則請勿更改。適用於影像顯示褪色的螢幕。
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
+      touchbar_mode:
+      touchbar_mode_hint:
       tidbyt_credentials: Tidbyt憑證
       tidbyt_credentials_hint: 在Tidbyt應用程式前往「Settings → Developer → Get API Key」尋找你的Tidbyt裝置API憑證。
-      tidbyt_api_key: Tidbyt API Key
+      tidbyt_api_key:
       tidbyt_credentials_invalid: Tidbyt API憑證無效。請檢查並重試。
       tidbyt_device_id: 裝置ID
       tidbyt_device_api_key: API金鑰
       unlink: 取消連結
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm:
       unlink_device: 取消連結裝置
       unlink_device_hint: 取消連結TRMNL後，可安全地轉售或贈送他人。
       unlink_device_learn_more: __按此__查看完整指南。
@@ -331,41 +331,41 @@ zh-HK:
         warning_2: 我明白這是<strong>危險</strong>操作，可能會導致我的裝置變磚。
         cta: 升級至 TRMNL OG (2-bit)
       persona:
-        discover: Discover
-        discover_hint: Discover suggests plugins and recipes tailored to this device
-        discover_banner_toggle: Show the Discover banner on the dashboard for this device
-        persona: Persona
-        persona_hint: A device persona shapes Discover recommendations
-        provisioned_by_html: This device was provisioned by the <strong>%{name}</strong> persona.
-        mirror_disabled_hint: Persona management is disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-        save_persona: Save persona
-        reset_persona: Reset persona
-        reset_persona_hint: Resetting this device's persona will not affect its settings and playlist
-        reset_persona_confirm: Reset this persona and delete its saved recommendations?
+        discover:
+        discover_hint:
+        discover_banner_toggle:
+        persona:
+        persona_hint:
+        provisioned_by_html:
+        mirror_disabled_hint:
+        save_persona:
+        reset_persona:
+        reset_persona_hint:
+        reset_persona_confirm:
     discover_persona:
-      label: Persona & Discover
-      disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
-      completed_hint: Persona is set up for this device
-      setup_hint: Set up a persona for this device
+      label:
+      disabled_hint:
+      completed_hint:
+      setup_hint:
     index:
       title: 裝置
       tagline: 你的TRMNL裝置
       add_device_modal_title: 新增裝置
       add_first_device: 請先新增你的第一部裝置！
-      go_to_settings: Go to settings
-      clear_playlist: Clear playlist
-      clear_playlist_confirm: Remove all playlist items from %{device}? This cannot be undone.
-      copy_playlist_to_device: Copy playlist to device
-      copy_playlist_submit: Copy playlist
-      copy_playlist_from_device: From
-      copy_playlist_to_device_label: To
-      copy_playlist_non_destructive: No existing playlist items will be cleared.
+      go_to_settings:
+      clear_playlist:
+      clear_playlist_confirm:
+      copy_playlist_to_device:
+      copy_playlist_submit:
+      copy_playlist_from_device:
+      copy_playlist_to_device_label:
+      copy_playlist_non_destructive:
       target_device: Target device
     clear_playlist:
-      success: "%{device}'s playlist has been cleared."
+      success:
     copy_playlist:
-      error_same_device: Source and target device must be different.
-      success: Playlist copied from %{source} to %{target}.
+      error_same_device:
+      success:
     new:
       title: 新增裝置
       description: 輸入Friendly ID以新增裝置到你的帳戶。
@@ -391,32 +391,32 @@ zh-HK:
     switch:
       error: 切換裝置時發生錯誤
       success: 成功切換裝置
-      title: Switch to device
+      title:
     update:
       error: 更新裝置時發生錯誤
       success: 成功更新「%{device}」的裝置設定
   discovery:
     dashboard_action:
       saved:
-        title: Recommendations saved for %{device_label}
-        subtext: Review your saved picks, or update the persona that shaped them.
-        primary_label: Review saved recommendations
+        title:
+        subtext:
+        primary_label:
       fresh:
-        title: New recommendations ready for %{device_label}
-        subtext: Review the latest picks for this persona.
-        primary_label: Review new recommendations
+        title:
+        subtext:
+        primary_label:
       persona:
-        title: Persona set for %{device_label}
-        subtext: Get another set of recommendations, or update the persona when this TRMNL's role changes.
-        primary_label: Get new recommendations
+        title:
+        subtext:
+        primary_label:
       rerun:
-        title: Ready for another Discover round for %{device_label}
-        subtext: Go through another round when you want fresh recommendations for this TRMNL.
-        primary_label: Get more recommendations
+        title:
+        subtext:
+        primary_label:
       setup:
-        title: Set up a persona for %{device_label}
-        subtext: Answer a few questions so recommendations fit this TRMNL's role.
-        primary_label: Set up persona
+        title:
+        subtext:
+        primary_label:
   invoices:
     rate_limit: 嘗試次數過多，請稍後再試
     invoice_not_found: 找不到發票
@@ -426,7 +426,7 @@ zh-HK:
       all: 所有
       bulk_destroy: 批量銷毀
       dump: 傾印
-      id: ID
+      id:
       private_plugins: 客製外掛
       source: 來源
       time: 時間
@@ -438,7 +438,7 @@ zh-HK:
       design_system: 活用我們的原生設計系統
       design_system_docs: 設計系統文件
       dirty_confirm: 你有未儲存的變更。確定要離開此頁面嗎？
-      edit_composition: Edit Composition
+      edit_composition:
       edit_markup: 編輯標記碼
       edit_markup_for_plugin: 編輯「%{plugin_setting_name}」的標記碼
       edit_markup_please_save_first: 編輯標記碼前請先儲存
@@ -463,7 +463,7 @@ zh-HK:
       no_variables_detected: 未偵測到變數。
   notices:
     dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
+      discover_callout:
   mfa:
     disable_otp:
       success: 已停用雙重驗證
@@ -512,12 +512,12 @@ zh-HK:
       remove_from_playlist: 從播放清單中移除
       hide_playlist: 隱藏此項目
       show_playlist: 顯示此項目
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      duplicate:
+      duplicate_confirm:
+      presentation:
+      color_palette:
+      device_default:
+      palette_unavailable:
       refresh_rate_disabled:
         default: 無法設定此外掛的重新整理頻率。
         external: 此外掛即時擷取數據，因此重新整理頻率設定不適用。
@@ -539,14 +539,14 @@ zh-HK:
     set_preferences:
       success: 已更新智能播放清單偏好設定
     update:
-      success: Playlist order updated
+      success:
   plugins:
     index:
       title: 外掛功能
       tagline: 你會在TRMNL上顯示什麼？
       available: 可使用
       connected: 已連接
-      supported_by_this_device: Supported by this device
+      supported_by_this_device:
       recipes: 模板(Recipe)
       recipes_hint: 社群成員開發的客製外掛，一鍵即可安裝。 __了解更多__
     search:
@@ -596,19 +596,19 @@ zh-HK:
     forks:
       one: 個分叉
       other: 個分叉
-    forked: Recipe forked
+    forked:
     new:
       error: 找不到模板
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author:
+      view_all:
   plugin_settings:
     active: 啟用
     copy_are_you_sure: 確定要複製此設定嗎？
     delete_are_you_sure: 確定要刪除此設定嗎？
     delete: 這將完全移除此外掛的設定。如只想在裝置上隱藏，請從播放清單中刪除。
     inactive: 停用
-    no_matches_found: No plugins match your filters.
+    no_matches_found:
     no_plugin_settings_found: 找不到外掛設定。
     not_supported: 此裝置不支援
     refreshing_now_please_wait: 正在重新整理，請在幾秒鐘後重新載入此頁面。
@@ -616,7 +616,7 @@ zh-HK:
     form:
       active_hint: 在裝置上顯示或隱藏此外掛實例
       advanced_settings: 進階設定
-      back_to_playlist: Back to Playlist
+      back_to_playlist:
       back_to_plugin: 返回%{plugin}
       back_to_plugins: 返回外掛列表
       connect_with: 連接%{plugin}
@@ -632,9 +632,9 @@ zh-HK:
       force_refresh_click_here: 按此
       force_refresh_click_here_hint: 立即生成新的畫面
       force_refresh_not_possible: 無法強制重新整理此外掛，因為TRMNL伺服器不執行影像處理。__按此__了解如何測試你的外掛。
-      health_notifications: Health notifications
-      health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
-      health_notifications_checkbox: Email me when this plugin becomes unhealthy
+      health_notifications:
+      health_notifications_hint:
+      health_notifications_checkbox:
       learn_more: 前往知識庫以了解此外掛
       learn_more_fork: 此外掛是從模板分叉(fork)而來。
       learn_more_fork_original: 查看原始版本
@@ -649,7 +649,7 @@ zh-HK:
       linked_account_success: 成功連結%{plugin_name}
       link_oauth: 連結帳戶
       link_oauth_hint: 如要繼續，請先按照「%{plugin}」提供的安全授權流程進行
-      mirrored: Mirrored
+      mirrored:
       multiple_instances_hint: 此外掛支援多個執行個體。
       name: 名稱
       name_hint: 為其命名以便參考
@@ -667,7 +667,7 @@ zh-HK:
       recipe_cta_body_in_review: 此外掛已提交給我們的團隊審核。請稍候。
       recipe_cta_body_not_published: 提交此外掛以供其他人安裝。__了解更多__。
       recipe_cta_confirm: 確定嗎？我們的團隊將進行審核，並在數日內回覆你。你可以繼續進行變更。
-      recipe_mirrored: This screen is mirrored from the recipe.
+      recipe_mirrored:
       recipe_visibility_title: 你想如何發佈？
       recipe_visibility_edit_title: 編輯提交內容
       recipe_visibility_public: 公開
@@ -678,7 +678,7 @@ zh-HK:
       recipe_visibility_unlisted_hint: 擁有連結的任何人都可以安裝。
       refresh_rate: 重新整理頻率
       refresh_rate_hint: 設定此外掛每隔多久後擷取新資料。
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
+      refresh_rate_jit_hint:
       refresh_rate_not_configurable: 重新整理頻率 %{refresh_rate}（固定）
       refreshed: 已重新整理
       remove_plugin: 移除外掛
@@ -686,11 +686,11 @@ zh-HK:
       synced: 已同步
       refresh_paused: 已暫停更新
       refresh_paused_hint: 自動更新已暫停，請加入至播放清單以重新開始。
-      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
+      refresh_paused_hidden_hint:
       refresh_paused_mashup: 只更新混搭畫面
       refresh_paused_mashup_hint: 已暫停全螢幕的自動更新，混搭畫面(Mashup)仍會更新。
       refresh_stopped: 自動更新已停止。請修正外掛錯誤以繼續。
-      view_recipe: View Recipe
+      view_recipe:
       visit_docs: 查看文件
     import:
       archive_too_large: ZIP檔案太大（最大%{max_mb} MB）
@@ -725,7 +725,7 @@ zh-HK:
       some_schedule: 只於此期間顯示畫面⋯
       to: 至
       copy_prompt: 複製時間表⋯
-      no_days_error: Please select at least one day.
+      no_days_error:
   upgrade:
     index:
       title: 正在升級裝置：

--- a/lib/trmnl/i18n/synchronization/processor.rb
+++ b/lib/trmnl/i18n/synchronization/processor.rb
@@ -4,6 +4,7 @@ require "cogger"
 require "refinements"
 require "yaml"
 
+require_relative "untranslated_reducer"
 require_relative "value_reducer"
 
 module TRMNL
@@ -44,10 +45,16 @@ module TRMNL
           destination_root
         end
 
+        # A new key arrives empty rather than as English, so an untranslated string is not
+        # mistaken for a finished one by anything reading these files.
         # :reek:ControlParameter
         def reduce source_locale, destination_locale
           repository.load(source_locale)[source_locale].then do |contents|
-            destination_locale == "raw" ? reducer.call(contents) : contents
+            case destination_locale
+              when "raw" then reducer.call contents
+              when source_locale then contents
+              else UntranslatedReducer.call contents
+            end
           end
         end
       end

--- a/lib/trmnl/i18n/synchronization/untranslated_reducer.rb
+++ b/lib/trmnl/i18n/synchronization/untranslated_reducer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module TRMNL
+  module I18n
+    module Synchronization
+      # Reduces a nested structure to the same shape with every value emptied.
+      UntranslatedReducer = lambda do |initial_value|
+        return unless initial_value.is_a? Hash
+
+        initial_value.transform_values { |value| UntranslatedReducer.call value }
+      end
+    end
+  end
+end

--- a/spec/lib/trmnl/i18n/synchronization/processor_spec.rb
+++ b/spec/lib/trmnl/i18n/synchronization/processor_spec.rb
@@ -20,8 +20,12 @@ RSpec.describe TRMNL::I18n::Synchronization::Processor do
       processor.call
     end
 
-    it "copies values from the source locale to the destination locales" do
-      expect(repo.load("fr")).to eq({"fr" => {"hello" => "Bonjour", "world" => "World"}})
+    it "adds keys the destination locale is missing, marked untranslated" do
+      expect(repo.load("fr")).to eq({"fr" => {"hello" => "Bonjour", "world" => nil}})
+    end
+
+    it "leaves the source locale alone" do
+      expect(repo.load("en")).to eq({"en" => {"hello" => "Hello", "world" => "World"}})
     end
 
     it "generates values for the raw locale" do

--- a/spec/lib/trmnl/i18n/synchronization/untranslated_reducer_spec.rb
+++ b/spec/lib/trmnl/i18n/synchronization/untranslated_reducer_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "trmnl/i18n/synchronization/untranslated_reducer"
+
+RSpec.describe TRMNL::I18n::Synchronization::UntranslatedReducer do
+  subject(:generator) { described_class }
+
+  describe "#call" do
+    it "answers nil for a simple value" do
+      expect(generator.call("Hello")).to be(nil)
+    end
+
+    it "answers hash with emptied values" do
+      result = generator.call({"key_1" => "value_1", "key_2" => "value_2"})
+      expect(result).to eq("key_1" => nil, "key_2" => nil)
+    end
+
+    it "answers nested hash with emptied values" do
+      result = generator.call({"key_1" => {"key_2" => "value_2"}})
+      expect(result).to eq("key_1" => {"key_2" => nil})
+    end
+
+    it "answers nil for an array" do
+      expect(generator.call(%w[value_1 value_2])).to be(nil)
+    end
+
+    it "answers nil for a value that is already nil" do
+      expect(generator.call(nil)).to be(nil)
+    end
+
+    it "keeps every key of the original structure" do
+      result = generator.call({"key_1" => {"key_2" => "value_2", "key_3" => %w[a b]}})
+      expect(result["key_1"].keys).to eq(%w[key_2 key_3])
+    end
+  end
+end


### PR DESCRIPTION
`bin/sync` filled a key the destination locale was missing with the English string, so a locale file could not say whether a value was translated or merely copied. Anything reading these files counts an English placeholder as done.

Measured by importing this repo into a local Weblate: 25 of 26 languages report 100% complete, including Slovak at a real 6.6% and Swedish at 7.3%. A contributor opening it sees a finished project with nothing to do.

Two commits. The first stops sync creating the problem, the second clears what it already created.

Sync now adds a missing key as empty rather than as English. The `raw` locale still gets its dotted key paths and the source locale is left alone.

The clearing nulls the 7596 entries whose value was byte-identical to the English source:

- arrays and plural sets are nulled only when every element or form matched English
- nothing is nulled that differed from English, and no key is removed
- `en.yml` and `raw.yml` are untouched

Core falls back to English for a nil, so an untranslated string now reads as untranslated without changing what anyone sees.

A plural set resolves as one unit after the fallback chain has already settled on a locale, so nulling one form while a sibling holds a translation makes the singular render the plural rather than falling back. Polish and Romanian `plugin_recipes.forks` hit exactly that and are left alone.

Verified by resolving all 7710 cleared key and locale pairs through I18n against the gem before and after: 7688 resolve identically, none absent, none raising. The 22 that differ are `logs.index.dump`, `logs.index.private_plugins` and `logs.index.time`, where core's own locale file has since replaced the English those placeholders had frozen, so nine locales stop showing copy English retired.

Running `bin/sync` against the result changes nothing, and a newly added key lands as empty in every locale.

The same Weblate instance on this branch reports 62.9% overall against 64.0% measured, tracking real coverage per language: Slovak 4.9%, Swedish 5.5%, French 77.0%, German 94.7%. The residual point is plural forms, which Weblate counts as one unit per pair.

Groundwork for opening this repo to outside contributors. Core needs no change: https://github.com/usetrmnl/core/pull/4583 already makes a blank translation fall back, and nil has always fallen back.
