### PR TITLE
Added a date format each language orders itself

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -70,6 +70,10 @@ https://trmnl.com/plugins/demo
 
 localization files live inside `lib/trmnl/i18n/locales`. from within that directory make a copy of `web_ui/en.yml`, `plugin_renders/en.yml`, or `custom_plugins/en.yml`, save a new version using your [ISO 639 language code](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes). submit this as a pull request and [ask questions](https://github.com/usetrmnl/trmnl-i18n/issues/new) if you need help.
 
+copy `en.yml`, not `raw.yml`. the two look alike, but `raw.yml` opens with `raw:` and every spec reads that first line to know which locale the file holds. change it to your own code, so `it.yml` starts with `it:`.
+
+leave a string you have not translated yet empty rather than copying the English. an empty value falls back to English on screen and counts as outstanding work, where a copy of the English counts as finished and nobody comes back to it.
+
 ## general tips
 
 we understand that...

--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -221,6 +221,9 @@ cs:
       morning_salutation:
       afternoon_salutation:
       evening_salutation:
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware:
@@ -238,6 +241,8 @@ cs:
       developer_perks_hint:
       device_credentials:
       device_credentials_hint:
+      device_api_key:
+      mac_address:
       device_name:
       device_name_hint:
       device_model:

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -221,6 +221,9 @@ da:
       morning_salutation: Godmorgen
       afternoon_salutation: God eftermiddag
       evening_salutation: God aften
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: Firmware Tidlig Udgivelse
@@ -238,6 +241,8 @@ da:
       developer_perks_hint: Nogle muligheder kræver __Udviklerudgave-tilføjelse__.
       device_credentials: Enhedsoplysninger
       device_credentials_hint: Se hvad du kan gøre med disse oplysninger __her__
+      device_api_key:
+      mac_address:
       device_name: Enhedsnavn
       device_name_hint: Bruges til at gøre TRMNL-grænsefladen mere personlig
       device_model: Enhedsmodel

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -221,6 +221,9 @@ de-AT:
       morning_salutation: Guten Morgen
       afternoon_salutation: Guten Tag
       evening_salutation: Guten Abend
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: Beta-Firmware
@@ -238,6 +241,8 @@ de-AT:
       developer_perks_hint: Entwicklung eigener Erweiterungen, bearbeitbare MAC-Adresse (nur BYOD), Vorab-Firmware und API-Zugang
       device_credentials: Geräteinformationen
       device_credentials_hint: Erfahre __hier__ mehr über die Verwendungsmöglichkeiten der Infos
+      device_api_key:
+      mac_address:
       device_name: Gerätename
       device_name_hint: Wir verwenden den Gerätenamen, um die TRMNL-Benutzeroberfläche zu personalisieren.
       device_model: Gerätemodell

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -221,6 +221,9 @@ de:
       morning_salutation: Guten Morgen
       afternoon_salutation: Guten Tag
       evening_salutation: Guten Abend
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: Beta-Firmware
@@ -238,6 +241,8 @@ de:
       developer_perks_hint: Entwicklung eigener Erweiterungen, bearbeitbare MAC-Adresse (nur BYOD), Vorab-Firmware und API-Zugang
       device_credentials: Geräteinformationen
       device_credentials_hint: Erfahre __hier__ mehr über die Verwendungsmöglichkeiten der Infos
+      device_api_key:
+      mac_address:
       device_name: Gerätename
       device_name_hint: Wir verwenden den Gerätenamen, um die TRMNL-Benutzeroberfläche zu personalisieren.
       device_model: Gerätemodell

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -221,6 +221,9 @@ en-GB:
       morning_salutation:
       afternoon_salutation:
       evening_salutation:
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware:
@@ -238,6 +241,8 @@ en-GB:
       developer_perks_hint: Options below require the __Developer add-on__.
       device_credentials:
       device_credentials_hint:
+      device_api_key:
+      mac_address:
       device_name:
       device_name_hint:
       device_model:

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -221,6 +221,9 @@ en:
       morning_salutation: Good morning
       afternoon_salutation: Good afternoon
       evening_salutation: Good evening
+  date:
+    formats:
+      day_month_long: "%A, %B %-d"
   devices:
     edit:
       accepts_beta_firmware: Firmware Early Release
@@ -238,6 +241,8 @@ en:
       developer_perks_hint: Custom plugin development, editable MAC address (BYOD-only), firmware early release, and API access
       device_credentials: Device Credentials
       device_credentials_hint: See what you can do with these credentials __here__
+      device_api_key: Device API Key
+      mac_address: MAC Address
       device_name: Device Name
       device_name_hint: We use this to make the TRMNL interface more comfortable
       device_model: Device Model

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -221,6 +221,9 @@ es-ES:
       morning_salutation: "¡Buenos días,"
       afternoon_salutation: "¡Buenas tardes,"
       evening_salutation: "¡Buenas noches,"
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: Firmware de versión de pruebas
@@ -238,6 +241,8 @@ es-ES:
       developer_perks_hint: Las opciones a continuación requieren el __plugin de Desarrolladores__.
       device_credentials: Credenciales del dispositivo
       device_credentials_hint: Puedes ver qué puedes hacer con estas credenciales __aquí__
+      device_api_key:
+      mac_address:
       device_name: Nombre del dispositivo
       device_name_hint: Lo utilizamos para hacer la interfaz de TRMNL más cómoda
       device_model: Modelo del dispositivo

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -223,6 +223,9 @@ fr:
       morning_salutation: Bonjour
       afternoon_salutation: Bonjour
       evening_salutation: Bonsoir
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: Mise à jour en accès anticipé
@@ -240,6 +243,8 @@ fr:
       developer_perks_hint: Les options ci-dessous requièrent le __complément payant Developer__.
       device_credentials: Identifiants de l'appareil
       device_credentials_hint: Voir ce que vous pouvez faire avec ces identifiants __en cliquant ici__
+      device_api_key:
+      mac_address:
       device_name: Nom de l'appareil
       device_name_hint: Nous utilisons cela pour rendre l'interface de TRMNL plus agréable
       device_model: Modèle d'appareil

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -223,6 +223,9 @@ he:
       morning_salutation:
       afternoon_salutation:
       evening_salutation:
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware:
@@ -240,6 +243,8 @@ he:
       developer_perks_hint: Options below require the __Developer add-on__.
       device_credentials:
       device_credentials_hint:
+      device_api_key:
+      mac_address:
       device_name:
       device_name_hint:
       device_model:

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -221,6 +221,9 @@ hu:
       morning_salutation: Jó reggelt
       afternoon_salutation: Jó napot
       evening_salutation: Jó estét
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: Korai firmware kiadás
@@ -238,6 +241,8 @@ hu:
       developer_perks_hint: Az alábbi opciók használatához a __Fejlesztői bővítmény__ szükséges.
       device_credentials: Eszköz hitelesítő adatok
       device_credentials_hint: Nézd meg, mit tehetsz ezekkel az adatokkal __itt__.
+      device_api_key:
+      mac_address:
       device_name: Eszköz neve
       device_name_hint: A TRMNL felület személyre szabásához használjuk ezt a nevet.
       device_model: Eszközmodell

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -223,6 +223,9 @@ id:
       morning_salutation:
       afternoon_salutation:
       evening_salutation:
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: Firmware tahap Beta
@@ -240,6 +243,8 @@ id:
       developer_perks_hint: Opsi di bawah ini membutuhkan __add-on Pengembang__.
       device_credentials:
       device_credentials_hint:
+      device_api_key:
+      mac_address:
       device_name: Nama Perangkat
       device_name_hint: Kami menggunakan ini untuk membuat antarmuka TRMNL lebih nyaman
       device_model:

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -221,6 +221,9 @@ is:
       morning_salutation: Góðan dag
       afternoon_salutation: Góðan dag
       evening_salutation: Gott kvöld
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: Snemmútgáfa fastbúnaðar
@@ -238,6 +241,8 @@ is:
       developer_perks_hint: Valkostir hér að neðan krefjast __forritaraviðbótar__.
       device_credentials: Auðkenni tækis
       device_credentials_hint: Sjáðu hvað þú getur gert með þessum auðkennum __hér__
+      device_api_key:
+      mac_address:
       device_name: Heiti tækis
       device_name_hint: Við notum þetta til að gera TRMNL viðmótið þægilegra.
       device_model: Gerð tækis

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -221,6 +221,9 @@ it:
       morning_salutation: Buongiorno
       afternoon_salutation: Buon pomeriggio
       evening_salutation: Buonasera
+  date:
+    formats:
+      day_month_long: "%A %-d %B"
   devices:
     edit:
       accepts_beta_firmware: Firmware Accesso Anticipato
@@ -238,6 +241,8 @@ it:
       developer_perks_hint: Queste opzioni richiedono la Modalità Sviluppatore.
       device_credentials: Credenziali Dispositivo
       device_credentials_hint: Scopri cosa puoi fare con queste credenziali __qui__
+      device_api_key:
+      mac_address:
       device_name: Nome Dispositivo
       device_name_hint: Lo usiamo per migliorare l'interfaccia TRMNL
       device_model: Modello dispositivo

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -221,6 +221,9 @@ ja:
       morning_salutation: おはようございます
       afternoon_salutation: こんにちは
       evening_salutation: こんばんは
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: 新しいファームウェアを受け入れる
@@ -238,6 +241,8 @@ ja:
       developer_perks_hint: 以下は、__開発者オプション__を追加した場合に利用可能です。
       device_credentials: デバイス認証情報
       device_credentials_hint: この認証情報でできることは__こちら__で確認できます
+      device_api_key:
+      mac_address:
       device_name: デバイス名
       device_name_hint: TRMNLインターフェースをより快適に使用するためです。
       device_model:

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -221,6 +221,9 @@ ko:
       morning_salutation: 좋은 아침
       afternoon_salutation: 안녕
       evening_salutation: 안녕
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: 펌웨어 조기 배포
@@ -238,6 +241,8 @@ ko:
       developer_perks_hint: 커스텀 플러그인 개발, MAC 주소 편집(BYOD 전용), 펌웨어 조기 배포, API 접근
       device_credentials: 기기 인증 정보
       device_credentials_hint: 이 인증 정보로 무엇을 할 수 있는지 __여기서__ 확인하세요.
+      device_api_key:
+      mac_address:
       device_name: 기기 이름
       device_name_hint: TRMNL을 더 편안하게 만드는 데 사용돼요
       device_model: 기기 모델

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -221,6 +221,9 @@ lt:
       morning_salutation: Labas rytas
       afternoon_salutation: Laba diena
       evening_salutation: Labas vakaras
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: Ankstyvoji programinės įrangos versija
@@ -238,6 +241,8 @@ lt:
       developer_perks_hint: Pasirinktinių įskiepių kūrimas, redaguojamas MAC adresas (tik BYOD), ankstyvosios programinės įrangos versijos ir API prieiga.
       device_credentials: Įrenginio kredencialai
       device_credentials_hint: Sužinokite, ką galite daryti su šiais kredencialais __čia__.
+      device_api_key:
+      mac_address:
       device_name: Įrenginio pavadinimas
       device_name_hint: Mes naudojame tai, kad TRMNL sąsaja būtų jaukesnė.
       device_model: Įrenginio modelis

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -221,6 +221,9 @@ nl:
       morning_salutation: Goedemorgen
       afternoon_salutation: Goedemiddag
       evening_salutation: Goedenavond
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: Beta firmware-release
@@ -238,6 +241,8 @@ nl:
       developer_perks_hint: De onderstaande opties vereisen de __ontwikkelaars-add-on__.
       device_credentials: Apparaatgegevens
       device_credentials_hint: Beijk __hier__ wat je met deze gegevens kunt doen.
+      device_api_key:
+      mac_address:
       device_name: Apparaatnaam
       device_name_hint: We gebruiken dit om de TRMNL interface persoonlijker te maken
       device_model:

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -221,6 +221,9 @@
       morning_salutation: God morgen
       afternoon_salutation: God ettermiddag
       evening_salutation: God kveld
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: Tidlig utgivelse av fastvare
@@ -238,6 +241,8 @@
       developer_perks_hint: Valgene nedenfor krever __Utviklertillegget__.
       device_credentials: Enhetslegitimasjon
       device_credentials_hint: Se hva du kan gjøre med denne legitimasjonen __her__
+      device_api_key:
+      mac_address:
       device_name: Enhetsnavn
       device_name_hint: Vi bruker dette for å gjøre TRMNL-grensesnittet mer brukervennlig
       device_model:

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -243,6 +243,9 @@ pl:
       morning_salutation: Dzień dobry
       afternoon_salutation: Dzień dobry
       evening_salutation: Dobry wieczór
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: Firmware - wczesny dostęp
@@ -260,6 +263,8 @@ pl:
       developer_perks_hint: Tworzenie własnych pluginów, edytowalny adres MAC (tylko BYOD), wczesny dostęp do firmware'u, dostęp do API.
       device_credentials: Poświadczenia urządzenia
       device_credentials_hint: __Tutaj__ przeczytasz, do czego służą poświadczenia.
+      device_api_key:
+      mac_address:
       device_name: Nazwa urządzenia
       device_name_hint: Ułatwia korzystanie z interfejsu TRMNL.
       device_model: Model urządzenia

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -221,6 +221,9 @@ pt-BR:
       morning_salutation: Bom dia
       afternoon_salutation: Boa tarde
       evening_salutation: Boa noite
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: Versões Antecipadas de Firmware
@@ -238,6 +241,8 @@ pt-BR:
       developer_perks_hint: Opções abaixo requerem o __Add-on de Desenvolvedor__.
       device_credentials: Credenciais do Dispositivo
       device_credentials_hint: Veja o que você pode fazer com essas credenciais __aqui__
+      device_api_key:
+      mac_address:
       device_name: Nome do Dispositivo
       device_name_hint: Usamos esse nome para tornar a interface do TRMNL mais confortável
       device_model: Modelo do Dispositivo

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -221,6 +221,9 @@ raw:
       morning_salutation: dashboard.welcome_message.morning_salutation
       afternoon_salutation: dashboard.welcome_message.afternoon_salutation
       evening_salutation: dashboard.welcome_message.evening_salutation
+  date:
+    formats:
+      day_month_long: date.formats.day_month_long
   devices:
     edit:
       accepts_beta_firmware: devices.edit.accepts_beta_firmware
@@ -238,6 +241,8 @@ raw:
       developer_perks_hint: devices.edit.developer_perks_hint
       device_credentials: devices.edit.device_credentials
       device_credentials_hint: device_credentials_hint __here__
+      device_api_key: devices.edit.device_api_key
+      mac_address: devices.edit.mac_address
       device_name: devices.edit.device_name
       device_name_hint: devices.edit.device_name_hint
       device_model: devices.edit.device_model

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -221,6 +221,9 @@ ro:
       morning_salutation: Bună dimineața
       afternoon_salutation: Bună ziua
       evening_salutation: Bună seara
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: Firmware lansare anticipată
@@ -238,6 +241,8 @@ ro:
       developer_perks_hint: Dezvoltare plugin-uri personalizate, adresă MAC editabilă (doar BYOD), lansare anticipată firmware și acces API
       device_credentials: Credențiale dispozitiv
       device_credentials_hint: Vezi ce poți face cu aceste credențiale __aici__
+      device_api_key:
+      mac_address:
       device_name: Nume dispozitiv
       device_name_hint: Folosim asta pentru a face interfața TRMNL mai confortabilă
       device_model: Model dispozitiv

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -243,6 +243,9 @@ ru:
       morning_salutation: Доброе утро
       afternoon_salutation: Добрый день
       evening_salutation: Добрый вечер
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: Ранний доступ к прошивке
@@ -260,6 +263,8 @@ ru:
       developer_perks_hint: Для следующих опций требуется __дополнение для разработчиков__.
       device_credentials: Учётные данные устройства
       device_credentials_hint: Узнайте, что можно делать с этими учётными данными __здесь__
+      device_api_key:
+      mac_address:
       device_name: Название устройства
       device_name_hint: Мы используем его, чтобы сделать интерфейс TRMNL более удобным
       device_model: Модель устройства

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -232,6 +232,9 @@ sk:
       morning_salutation:
       afternoon_salutation:
       evening_salutation:
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware:
@@ -249,6 +252,8 @@ sk:
       developer_perks_hint: Options below require the __Developer add-on__.
       device_credentials:
       device_credentials_hint:
+      device_api_key:
+      mac_address:
       device_name:
       device_name_hint:
       device_model:

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -221,6 +221,9 @@ sv:
       morning_salutation:
       afternoon_salutation:
       evening_salutation:
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware:
@@ -238,6 +241,8 @@ sv:
       developer_perks_hint: Options below require the __Developer add-on__.
       device_credentials:
       device_credentials_hint:
+      device_api_key:
+      mac_address:
       device_name:
       device_name_hint:
       device_model:

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -243,6 +243,9 @@ uk:
       morning_salutation:
       afternoon_salutation:
       evening_salutation:
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware:
@@ -260,6 +263,8 @@ uk:
       developer_perks_hint: Options below require the __Developer add-on__.
       device_credentials:
       device_credentials_hint:
+      device_api_key:
+      mac_address:
       device_name: Назва пристрою
       device_name_hint: Ми використовуємо імʼя пристрою, щоб зробити інтерфейс TRMNL більш зручним
       device_model:

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -256,6 +256,9 @@ zh-CN:
       morning_salutation: 早上好
       afternoon_salutation: 下午好
       evening_salutation: 晚上好
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: beta 测试固件
@@ -273,6 +276,8 @@ zh-CN:
       developer_perks_hint: 定制插件开发、可编辑 MAC 地址（仅限自带设备）、固件抢先体验以及 API 访问权限
       device_credentials: 设备密码
       device_credentials_hint: __点击此处__了解如果使用这些密码。
+      device_api_key:
+      mac_address:
       device_name: 设备名称
       device_name_hint: 用于 TRMNL 界面
       device_model: 设备型号

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -221,6 +221,9 @@ zh-HK:
       morning_salutation: 早晨
       afternoon_salutation: 午安
       evening_salutation: 晚安
+  date:
+    formats:
+      day_month_long:
   devices:
     edit:
       accepts_beta_firmware: 韌體搶先體驗
@@ -238,6 +241,8 @@ zh-HK:
       developer_perks_hint: 開發自訂外掛、可編輯MAC地址（只限BYOD）、韌體搶先體驗及API訪問。
       device_credentials: 裝置憑證
       device_credentials_hint: __按此__了解如何使用這些憑證。
+      device_api_key:
+      mac_address:
       device_name: 裝置名稱
       device_name_hint: 我們使用此名稱讓TRMNL介面更具親切感。
       device_model: 裝置型號


### PR DESCRIPTION
The calendar date format dropdown offers fixed strftime patterns, so the option labelled "Thursday, November 26" is `"%A, %B %-d"` in every locale. Italian puts the day before the month, so an Italian reader gets `mercoledì, agosto 27` where the language wants `mercoledì 27 agosto`. Reported in #155.

Adds `date.formats.day_month_long`, which each locale orders for itself:

- Italian is set to `"%A %-d %B"`, the order the reporter gave, and now renders `mercoledì 26 agosto`
- English keeps `"%A, %B %-d"`, unchanged
- every other locale arrives empty and falls back to the English pattern, which is what they already render today

I did not guess the other 25. The day and month order can be derived from each locale's `date.formats.long` in rails-i18n, but whether a comma follows the weekday cannot: German writes `Mittwoch, 26. August` and French writes `mercredi 26 août`. Those are now translatable strings rather than a hardcoded pattern, so a native speaker can set each one.

Also in here:

- `devices.edit.mac_address` and `devices.edit.device_api_key`, two of the labels listed in #114 that are still hardcoded in core at `app/views/devices/edit/developer.html.erb`
- two notes in the guide that cost a contributor a round trip in #266: `raw.yml` is not the file to copy, and an untranslated string should be left empty rather than filled with English

Core wiring follows in a separate PR: the dropdown needs an option pointing at the new format, and the two device labels need their `t()` calls.

Checked while triaging, no change needed here:

- the `[time span] ago` request in #114 and #179 is already solved by `TimeHelper#localized_time_ago`, which renders `vor ungefähr 3 Stunden`, `około 3 godziny temu` and `circa 3 ore fa`, with future forms
- the Tempest weather conditions in #179 are wired to `renders.weather.tempest.conditions.*` and resolve in German; Italian falls back to English only because those keys are untranslated
- 8 of the 12 strings named in #114 already have keys
