### PR TITLE
Stop Weblate rewrapping every long value it writes

### DIFF
--- a/lib/tasks/weblate.rake
+++ b/lib/tasks/weblate.rake
@@ -13,8 +13,8 @@ namespace :weblate do
 
     Weblate::COMPONENTS.each do |name|
       if existing.key? name
-        client.patch "components/#{Weblate::PROJECT}/#{name}/", Weblate.update_settings(name)
-        puts "updated #{name}"
+        applied = Weblate.update_component client, name
+        puts "updated #{name} (#{applied.count} settings)"
       else
         client.post "projects/#{Weblate::PROJECT}/components/", Weblate.component_settings(name)
         puts "created #{name}"

--- a/lib/tasks/weblate.rb
+++ b/lib/tasks/weblate.rb
@@ -12,23 +12,32 @@ module Weblate
   PROJECT_SETTINGS = {"name" => "TRMNL", "slug" => PROJECT, "web" => "https://trmnl.com/"}.freeze
   REPOSITORY = "https://github.com/usetrmnl/trmnl-i18n.git"
 
-  # Weblate shares one checkout across components in a project, and a linked component
-  # rejects any repository field outright instead of ignoring it.
-  SHARED_REPOSITORY_KEYS = %w[slug repo branch vcs push push_branch].freeze
+  # A component sharing another's checkout inherits these and answers 400 for them rather than
+  # ignoring them. Which component Weblate treats as the borrower is not visible over the API —
+  # is_repo_link reads null for all of them — so the update tries everything, then retries
+  # without them when Weblate says so.
+  INHERITED_BY_LINKED_COMPONENT = "Option is not available for linked repositories"
+  INHERITED_KEYS = %w[branch].freeze
+  SHARED_REPOSITORY_KEYS = %w[slug].freeze
 
   COMPONENT_DEFAULTS = {
     "file_format" => "ruby-yaml",
+    # 65535 is Weblate's "no line wrapping". At its default of 80 it refolds every long value
+    # on write, so one translated string arrives as hundreds of reformatted lines.
+    "file_format_params" => {"yaml_line_wrap" => 65_535},
     # raw.yml holds dotted key paths for debugging, not a translation, and "raw" is not a
     # language. Weblate applies this only while discovering languages, so a component that
     # imported raw once has to be deleted and recreated, not patched.
     "language_regex" => "^(?!raw$).+$",
     "repo" => REPOSITORY,
     "branch" => "main",
+    # push is deliberately absent. Weblate authenticates a push to origin from credentials in
+    # the URL itself, so it holds a token, and Cloudflare rejects a request body carrying one
+    # with error 1010. It is set once on the server and this task must not overwrite it.
     # The github backend opens a pull request instead of pushing to the branch people
     # read. Naming a push branch is what keeps the work in this repository: Weblate
     # only forks when the push branch is absent or equal to the translated branch.
     "vcs" => "github",
-    "push" => REPOSITORY,
     "push_branch" => "weblate-translations",
     "license" => "MIT"
   }.freeze
@@ -98,6 +107,20 @@ module Weblate
   end
 
   def self.update_settings(name) = component_settings(name).except(*SHARED_REPOSITORY_KEYS)
+
+  # Answers the settings that applied. Sent as one patch so Weblate validates them together:
+  # vcs github is refused on its own because it reads push_branch as still empty.
+  # :reek:TooManyStatements - one patch and a guarded retry; splitting it hides the guard.
+  def self.update_component client, name
+    path = "components/#{PROJECT}/#{name}/"
+    settings = update_settings name
+    client.patch path, settings
+    settings
+  rescue Client::Error => error
+    raise unless error.message.include? INHERITED_BY_LINKED_COMPONENT
+
+    settings.except(*INHERITED_KEYS).tap { client.patch path, it }
+  end
 
   # screenshots/plugin_renders/weather.png names the strings it shows. Weblate separates
   # nested keys with -> rather than a dot, so a dotted prefix matches nothing.

--- a/spec/tasks/weblate_spec.rb
+++ b/spec/tasks/weblate_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Weblate do
         "name" => "Web ui",
         "slug" => "web_ui",
         "file_format" => "ruby-yaml",
+        "file_format_params" => {"yaml_line_wrap" => 65_535},
         "filemask" => "lib/trmnl/i18n/locales/web_ui/*.yml",
         "template" => "lib/trmnl/i18n/locales/web_ui/en.yml",
         "screenshot_filemask" => "screenshots/web_ui/*.png",
@@ -17,7 +18,6 @@ RSpec.describe Weblate do
         "repo" => "https://github.com/usetrmnl/trmnl-i18n.git",
         "branch" => "main",
         "vcs" => "github",
-        "push" => "https://github.com/usetrmnl/trmnl-i18n.git",
         "push_branch" => "weblate-translations",
         "license" => "MIT"
       )
@@ -32,12 +32,55 @@ RSpec.describe Weblate do
   describe ".update_settings" do
     subject(:settings) { described_class.update_settings "web_ui" }
 
-    it "omits the repository fields a linked component rejects" do
-      expect(settings.keys).not_to include("slug", "repo", "branch", "vcs", "push", "push_branch")
+    it "omits the slug, which names the component rather than configuring it" do
+      expect(settings.keys).not_to include("slug")
+    end
+
+    it "leaves the push URL alone, since it carries a token this task cannot send" do
+      expect(settings.keys).not_to include("push")
     end
 
     it "keeps the file layout so a moved locale directory still lands" do
       expect(settings["filemask"]).to eq("lib/trmnl/i18n/locales/web_ui/*.yml")
+    end
+  end
+
+  describe ".update_component" do
+    subject(:applied) { described_class.update_component client, "web_ui" }
+
+    let(:client) { instance_double Weblate::Client }
+    let(:refusal) { Weblate::Client::Error.new "400 Option is not available for linked repositories." }
+
+    context "when the whole patch applies" do
+      before { allow(client).to receive(:patch).and_return({}) }
+
+      it "keeps the repository fields" do
+        expect(applied.keys).to include("branch", "repo")
+      end
+    end
+
+    context "when the component inherits its repository from another" do
+      before do
+        call = 0
+        allow(client).to receive(:patch) { (call += 1) == 1 ? fail(refusal) : {} }
+      end
+
+      it "retries without the inherited fields" do
+        expect(applied.keys).not_to include("branch")
+      end
+
+      it "still applies the rest" do
+        expect(applied.keys).to include("vcs", "push_branch")
+      end
+    end
+
+    context "when Weblate refuses for any other reason" do
+      before { allow(client).to receive(:patch).and_raise(Weblate::Client::Error, "400 nope") }
+
+      it "raises" do
+        expectation = proc { applied }
+        expect(&expectation).to raise_error(Weblate::Client::Error, /nope/)
+      end
     end
   end
 


### PR DESCRIPTION
A single translated string arrived as a pull request of +235 -110. Weblate writes YAML through ruamel at a default width of 80, so every value longer than that was refolded across two lines and the one real change was buried. The same translation now produces +1 -2.

`yaml_line_wrap` is a documented file format parameter and 65535 is its "no line wrapping" choice, so this is configuration rather than a patch.

Also stops the task setting the push URL. Weblate authenticates a push to origin from credentials embedded in that URL, so it holds a token, and Cloudflare answers 1010 to any request body carrying one. It is set once on the server, and this task overwriting it with a bare URL was breaking every push.

Proven end to end against translate.trmnl.com: translate a string, commit, push, and Weblate opens a pull request from `weblate-translations` containing only the changed line.