### PR TITLE
Stop three components pushing over each other's branch

### DIFF
--- a/lib/tasks/weblate.rb
+++ b/lib/tasks/weblate.rb
@@ -7,7 +7,10 @@ require "net/http"
 # rebuilt rather than remembered. Repository tooling, loaded by lib/tasks/weblate.rake.
 # :reek:TooManyConstants - the constants are the configuration; that is the point of it.
 module Weblate
-  COMPONENTS = %w[web_ui plugin_renders custom_plugins].freeze
+  # The first owns the checkout; the rest borrow it. Three components pushing the same branch
+  # from three checkouts overwrite each other, which Weblate reports as a conflicting setup.
+  PRIMARY_COMPONENT = "plugin_renders"
+  COMPONENTS = [PRIMARY_COMPONENT, "web_ui", "custom_plugins"].freeze
   PROJECT = "trmnl"
   PROJECT_SETTINGS = {"name" => "TRMNL", "slug" => PROJECT, "web" => "https://trmnl.com/"}.freeze
   REPOSITORY = "https://github.com/usetrmnl/trmnl-i18n.git"
@@ -17,7 +20,7 @@ module Weblate
   # is_repo_link reads null for all of them — so the update tries everything, then retries
   # without them when Weblate says so.
   INHERITED_BY_LINKED_COMPONENT = "Option is not available for linked repositories"
-  INHERITED_KEYS = %w[branch].freeze
+  INHERITED_KEYS = %w[branch push push_branch].freeze
   SHARED_REPOSITORY_KEYS = %w[slug].freeze
 
   COMPONENT_DEFAULTS = {
@@ -29,7 +32,6 @@ module Weblate
     # language. Weblate applies this only while discovering languages, so a component that
     # imported raw once has to be deleted and recreated, not patched.
     "language_regex" => "^(?!raw$).+$",
-    "repo" => REPOSITORY,
     "branch" => "main",
     # push is deliberately absent. Weblate authenticates a push to origin from credentials in
     # the URL itself, so it holds a token, and Cloudflare rejects a request body carrying one
@@ -98,8 +100,18 @@ module Weblate
     end
   end
 
+  # :reek:ControlParameter - one component owns the checkout and the rest borrow it; which one
+  # a component is IS the question this answers.
+  def self.repository_settings name
+    return {"repo" => REPOSITORY} if name == PRIMARY_COMPONENT
+
+    # Borrowing the primary's checkout, so Weblate refuses every repository field of its own.
+    {"repo" => "weblate://#{PROJECT}/#{PRIMARY_COMPONENT}"}.merge(INHERITED_KEYS.to_h { [it, ""] })
+  end
+
   def self.component_settings name
-    COMPONENT_DEFAULTS.merge "name" => name.tr("_", " ").capitalize,
+    COMPONENT_DEFAULTS.merge(repository_settings(name))
+                      .merge "name" => name.tr("_", " ").capitalize,
                              "slug" => name,
                              "filemask" => "lib/trmnl/i18n/locales/#{name}/*.yml",
                              "template" => "lib/trmnl/i18n/locales/#{name}/en.yml",

--- a/spec/tasks/weblate_spec.rb
+++ b/spec/tasks/weblate_spec.rb
@@ -6,26 +6,28 @@ require "tasks/weblate"
 RSpec.describe Weblate do
   describe ".component_settings" do
     it "answers a component whose template is the English file in its own directory" do
-      expect(described_class.component_settings("web_ui")).to eq(
-        "name" => "Web ui",
-        "slug" => "web_ui",
-        "file_format" => "ruby-yaml",
-        "file_format_params" => {"yaml_line_wrap" => 65_535},
-        "filemask" => "lib/trmnl/i18n/locales/web_ui/*.yml",
-        "template" => "lib/trmnl/i18n/locales/web_ui/en.yml",
-        "screenshot_filemask" => "screenshots/web_ui/*.png",
-        "language_regex" => "^(?!raw$).+$",
-        "repo" => "https://github.com/usetrmnl/trmnl-i18n.git",
-        "branch" => "main",
-        "vcs" => "github",
-        "push_branch" => "weblate-translations",
-        "license" => "MIT"
-      )
+      expect(described_class.component_settings("web_ui")["template"])
+        .to eq("lib/trmnl/i18n/locales/web_ui/en.yml")
     end
 
-    it "names a push branch so translations arrive as a pull request, not a fork" do
+    it "stops Weblate refolding long values into an unreviewable diff" do
+      expect(described_class.component_settings("web_ui")["file_format_params"])
+        .to eq({"yaml_line_wrap" => 65_535})
+    end
+
+    it "points the primary component at the real repository" do
+      expect(described_class.component_settings("plugin_renders")["repo"])
+        .to eq("https://github.com/usetrmnl/trmnl-i18n.git")
+    end
+
+    it "borrows the primary's checkout for the others, so one branch serves them all" do
+      expect(described_class.component_settings("web_ui")["repo"])
+        .to eq("weblate://trmnl/plugin_renders")
+    end
+
+    it "clears the repository fields a borrowing component may not set" do
       settings = described_class.component_settings "web_ui"
-      expect(settings["push_branch"]).to eq("weblate-translations")
+      expect(settings.values_at(*described_class::INHERITED_KEYS)).to all(eq(""))
     end
   end
 
@@ -36,8 +38,8 @@ RSpec.describe Weblate do
       expect(settings.keys).not_to include("slug")
     end
 
-    it "leaves the push URL alone, since it carries a token this task cannot send" do
-      expect(settings.keys).not_to include("push")
+    it "never sends a push URL for the component that owns the checkout" do
+      expect(described_class.update_settings("plugin_renders").keys).not_to include("push")
     end
 
     it "keeps the file layout so a moved locale directory still lands" do
@@ -70,7 +72,7 @@ RSpec.describe Weblate do
       end
 
       it "still applies the rest" do
-        expect(applied.keys).to include("vcs", "push_branch")
+        expect(applied.keys).to include("file_format", "filemask")
       end
     end
 


### PR DESCRIPTION
Weblate raised a conflicting repository setup: each component had its own checkout of the same repository and all three pushed `weblate-translations`, so whichever pushed last overwrote the others.

They now share one checkout. `plugin_renders` owns it and the other two borrow it through a `weblate://` URL, which is Weblate's own remedy. One checkout means one branch and one pull request covering every component, rather than three racing for the same ref.

A borrowing component inherits `branch`, `push` and `push_branch` and answers 400 for each, so they are sent empty. `vcs` is not among them: it is a choice field that rejects an empty value, and a borrowing component still needs its own.

Applied to translate.trmnl.com and verified: `is_repo_link` is true for the two borrowers, only the owner carries a push URL, and no error alerts remain on any component. The task is idempotent across repeated runs.