### PR TITLE
Added a workflow telling Weblate to pull on every push to main

### DIFF
--- a/.github/workflows/weblate.yml
+++ b/.github/workflows/weblate.yml
@@ -1,0 +1,29 @@
+name: Weblate
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: weblate-pull
+
+jobs:
+  pull:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull main into Weblate
+        env:
+          WEBLATE_TOKEN: ${{ secrets.WEBLATE_TOKEN }}
+        run: |
+          # Only the primary component owns a checkout and the other two borrow it, so
+          # pulling it is what moves all three. See PRIMARY_COMPONENT in lib/tasks/weblate.rb.
+          answer=$(curl --fail-with-body -sS --max-time 120 -X POST \
+            -H "Authorization: Token $WEBLATE_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"operation": "pull"}' \
+            https://translate.trmnl.com/api/components/trmnl/plugin_renders/repository/)
+          echo "$answer" | jq .
+          # Weblate answers 200 with result false and the reason in detail, so the HTTP
+          # status on its own does not say whether the pull landed.
+          echo "$answer" | jq -e '.result' > /dev/null


### PR DESCRIPTION
Weblate only picked up a merge on its nightly remote update, so what landed here and what translators saw drifted by up to a day. While writing this its checkout was two merges behind main, still on c411a9c.

On every push to main, and on manual dispatch, this posts a pull to the Weblate REST API.

- pulls only the primary component, plugin_renders, since web_ui and custom_plugins borrow its checkout
- reads the token from a WEBLATE_TOKEN repository secret
- fails the job when Weblate answers result false, which it does with a 200 and the reason in detail

Needs the WEBLATE_TOKEN secret added before this merges, otherwise the first push to main goes red on a 401.

Weblate's own /hooks/github/ endpoint would need no secret and no workflow, but it verifies no signature. The webhook secret Weblate carries covers legacy GitHub App deliveries only, so that endpoint accepts a crafted payload from anyone who knows the URL.