### PR TITLE
Added the fifteen keys core uses that were never defined here

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -351,6 +351,18 @@ cs:
         reset_persona_confirm: Obnovit tuto personu a smazat její uložená doporučení?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Objevovat
       disabled_hint: Zakázáno pro zrcadlené TRMNL. Doporučení spravujte na hlavním zařízení.
@@ -650,6 +662,10 @@ cs:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Pluginy
@@ -1369,6 +1385,8 @@ cs:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -351,6 +351,18 @@ da:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -651,6 +663,10 @@ da:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Plugins
@@ -1370,6 +1386,8 @@ da:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -351,6 +351,18 @@ de-AT:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -650,6 +662,10 @@ de-AT:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Erweiterungen
@@ -1369,6 +1385,8 @@ de-AT:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -351,6 +351,18 @@ de:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -650,6 +662,10 @@ de:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Erweiterungen
@@ -1369,6 +1385,8 @@ de:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -351,6 +351,18 @@ en-AU:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -650,6 +662,10 @@ en-AU:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Plugins
@@ -1369,6 +1385,8 @@ en-AU:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -351,6 +351,18 @@ en-GB:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -651,6 +663,10 @@ en-GB:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Plugins
@@ -1370,6 +1386,8 @@ en-GB:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -351,6 +351,18 @@ en:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -650,6 +662,10 @@ en:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Plugins
@@ -1369,6 +1385,8 @@ en:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -351,6 +351,18 @@ es-ES:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -651,6 +663,10 @@ es-ES:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Plugins
@@ -1370,6 +1386,8 @@ es-ES:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -353,6 +353,18 @@ fr:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -653,6 +665,10 @@ fr:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Plugins
@@ -1372,6 +1388,8 @@ fr:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -353,6 +353,18 @@ he:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -653,6 +665,10 @@ he:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Plugins
@@ -1372,6 +1388,8 @@ he:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -351,6 +351,18 @@ hu:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -651,6 +663,10 @@ hu:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Bővítmények
@@ -1370,6 +1386,8 @@ hu:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -353,6 +353,18 @@ id:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -653,6 +665,10 @@ id:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Plugin
@@ -1372,6 +1388,8 @@ id:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -351,6 +351,18 @@ is:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -651,6 +663,10 @@ is:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Viðbætur
@@ -1370,6 +1386,8 @@ is:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -351,6 +351,18 @@ it:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -651,6 +663,10 @@ it:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Plugin
@@ -1370,6 +1386,8 @@ it:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -351,6 +351,18 @@ ja:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -651,6 +663,10 @@ ja:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: プラグイン管理
@@ -1370,6 +1386,8 @@ ja:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -351,6 +351,18 @@ ko:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -651,6 +663,10 @@ ko:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: 플러그인
@@ -1370,6 +1386,8 @@ ko:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -351,6 +351,18 @@ lt:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -651,6 +663,10 @@ lt:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Įskiepiai
@@ -1370,6 +1386,8 @@ lt:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -351,6 +351,18 @@ nl:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -651,6 +663,10 @@ nl:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Plugins
@@ -1370,6 +1386,8 @@ nl:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -351,6 +351,18 @@
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -651,6 +663,10 @@
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Plugins
@@ -1370,6 +1386,8 @@
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -373,6 +373,18 @@ pl:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -673,6 +685,10 @@ pl:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Pluginy
@@ -1392,6 +1408,8 @@ pl:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -351,6 +351,18 @@ pt-BR:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -651,6 +663,10 @@ pt-BR:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Plugins
@@ -1370,6 +1386,8 @@ pt-BR:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -351,6 +351,18 @@ raw:
         reset_persona_confirm: devices.edit.persona.reset_persona_confirm
       low_battery_notification_email: devices.edit.low_battery_notification_email
       low_battery_notification_email_hint: devices.edit.low_battery_notification_email_hint
+      custom_width: devices.edit.custom_width
+      custom_height: devices.edit.custom_height
+      custom_format: devices.edit.custom_format
+      framework_size: devices.edit.framework_size
+      maximum_image_bytes: devices.edit.maximum_image_bytes
+      dither_pixel_ratio: devices.edit.dither_pixel_ratio
+      text_scale: devices.edit.text_scale
+      text_scale_hint: devices.edit.text_scale_hint
+      text_scale_version_note: devices.edit.text_scale_version_note
+      theme: devices.edit.theme
+      theme_hint: devices.edit.theme_hint
+      theme_version_note: devices.edit.theme_version_note
     discover_persona:
       label: devices.discover_persona.label
       disabled_hint: devices.discover_persona.disabled_hint
@@ -651,6 +663,10 @@ raw:
     smart_skip_modal:
       title: playlist_items.smart_skip_modal.title
       apply: playlist_items.smart_skip_modal.apply
+    playlist_item_schedule:
+      adjust_schedule: playlist_items.playlist_item_schedule.adjust_schedule
+    update_full_playlist_order:
+      error: playlist_items.update_full_playlist_order.error
   plugins:
     index:
       title: plugins.index.title
@@ -1368,6 +1384,8 @@ raw:
     update:
       success: mashups.update.success
       error: mashups.update.error
+    render_section_error:
+      error: mashups.render_section_error.error
   playlist_coverage:
     title: playlist_coverage.title
     your_timezone: playlist_coverage.your_timezone

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -351,6 +351,18 @@ ro:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -651,6 +663,10 @@ ro:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Plugin-uri
@@ -1370,6 +1386,8 @@ ro:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -373,6 +373,18 @@ ru:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -673,6 +685,10 @@ ru:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Плагины
@@ -1392,6 +1408,8 @@ ru:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -362,6 +362,18 @@ sk:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -662,6 +674,10 @@ sk:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Plugins
@@ -1381,6 +1397,8 @@ sk:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -351,6 +351,18 @@ sv:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -651,6 +663,10 @@ sv:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Plugins
@@ -1370,6 +1386,8 @@ sv:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -373,6 +373,18 @@ uk:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -673,6 +685,10 @@ uk:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: Плагіни
@@ -1392,6 +1408,8 @@ uk:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -386,6 +386,18 @@ zh-CN:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -686,6 +698,10 @@ zh-CN:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: 插件
@@ -1405,6 +1421,8 @@ zh-CN:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -351,6 +351,18 @@ zh-HK:
         reset_persona_confirm: Reset this persona and delete its saved recommendations?
       low_battery_notification_email: Send This Device's Notification To
       low_battery_notification_email_hint: Overrides the address on your account, so one display can alert whoever looks after it. Leave blank to use the account address.
+      custom_width: Width (px)
+      custom_height: Height (px)
+      custom_format: Image format
+      framework_size: Framework size
+      maximum_image_bytes: Maximum image bytes
+      dither_pixel_ratio: Dither pixel ratio
+      text_scale: Text Scale
+      text_scale_hint: Adjust the size of text across your plugin screens.
+      text_scale_version_note: Requires Framework 3.1.5 or later. Private plugins pinned to an older version will not be affected.
+      theme: Theme
+      theme_hint: Apply a color theme across your plugin screens.
+      theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -651,6 +663,10 @@ zh-HK:
     smart_skip_modal:
       title: Smart Skip
       apply: Done
+    playlist_item_schedule:
+      adjust_schedule: Adjust schedule
+    update_full_playlist_order:
+      error: Playlist order could not be saved
   plugins:
     index:
       title: 外掛功能
@@ -1370,6 +1386,8 @@ zh-HK:
     update:
       success: Mashup updated
       error: Every section needs a plugin — pick one for each and save again.
+    render_section_error:
+      error: That section could not be rendered — try again.
   playlist_coverage:
     title: Playlist coverage
     your_timezone: your timezone


### PR DESCRIPTION
Core reads these fifteen keys and this gem does not carry them, so they cannot be translated at all. Every locale falls through to the English written inline at the call site.

Twelve are the device model and palette fields. Their English is copied from the default each call already passes rather than written afresh, so nothing on screen changes in English.

mashups.render_section_error.error is the one that was visibly wrong. It passes no default and neither its key nor the fallback tier existed, so the flash alert rendered the words "Translation missing" to anyone whose section failed to render. That string is new copy, written to match mashups.update.error.

Found by pointing i18n-tasks at core and resolving each reported key against a booted application. That cleared 45 of 65 reports as scoping artefacts, and of the 20 left, five are helper and controller lazy-key quirks that resolve through a different path.

Purely additive: 18 lines per locale across 29 files, no deletions.

Core still passes an inline default for fourteen of these. Those become redundant once this lands and come out with the lock bump.