### PR TITLE
Added the English keys core is waiting on

### DIFF
--- a/lib/trmnl/i18n/locales/plugin_renders/cs.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/cs.yml
@@ -281,3 +281,18 @@ cs:
         - code: 1282
           day: Bouřka se sněžením
           night: Bouřka se sněžením
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/da.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/da.yml
@@ -281,3 +281,18 @@ da:
         - code: 1282
           day: Torden og sne
           night: Torden og sne
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
@@ -281,3 +281,18 @@ de-AT:
         - code: 1282
           day: Gewitter mit Schnee
           night: Gewitter mit Schnee
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/de.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de.yml
@@ -281,3 +281,18 @@ de:
         - code: 1282
           day: Gewitter mit Schnee
           night: Gewitter mit Schnee
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/en.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/en.yml
@@ -281,3 +281,18 @@ en:
         - code: 1282
           day: Thunder & Snow
           night: Thunder & Snow
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
@@ -281,3 +281,18 @@ es-ES:
         - code: 1282
           day: Tormenta con Nieve
           night: Tormenta con Nieve
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/fr.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/fr.yml
@@ -281,3 +281,18 @@ fr:
         - code: 1282
           day: Orage et neige
           night: Orage et neige
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/he.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/he.yml
@@ -281,3 +281,18 @@ he:
         - code: 1282
           day: Thunder & Snow
           night: Thunder & Snow
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/hu.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/hu.yml
@@ -281,3 +281,18 @@ hu:
         - code: 1282
           day: Zivatar és hó
           night: Zivatar és hó
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/id.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/id.yml
@@ -281,3 +281,18 @@ id:
         - code: 1282
           day: Thunder & Snow
           night: Thunder & Snow
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/is.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/is.yml
@@ -281,3 +281,18 @@ is:
         - code: 1282
           day: Þrumur & snjókoma
           night: Þrumur & snjókoma
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/it.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/it.yml
@@ -281,3 +281,18 @@ it:
         - code: 1282
           day: Thunder & Snow
           night: Thunder & Snow
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/ja.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ja.yml
@@ -281,3 +281,18 @@ ja:
         - code: 1282
           day: Thunder & Snow
           night: Thunder & Snow
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/ko.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ko.yml
@@ -281,3 +281,18 @@ ko:
         - code: 1282
           day: 천둥 동반 강한 눈
           night: 천둥 동반 강한 눈
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/lt.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/lt.yml
@@ -281,3 +281,18 @@ lt:
         - code: 1282
           day: Perkūnija ir sniegas
           night: Perkūnija ir sniegas
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/nl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/nl.yml
@@ -281,3 +281,18 @@ nl:
         - code: 1282
           day: Onweer & Sneeuw
           night: Onweer & Sneeuw
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/no.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/no.yml
@@ -281,3 +281,18 @@
         - code: 1282
           day: Thunder & Snow
           night: Thunder & Snow
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/pl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pl.yml
@@ -282,3 +282,18 @@ pl:
         - code: 1282
           day: Burza z intensywnymi opadami śniegu
           night: Burza z intensywnymi opadami śniegu
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
@@ -281,3 +281,18 @@ pt-BR:
         - code: 1282
           day: Trovões e Neve
           night: Trovões e Neve
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/raw.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/raw.yml
@@ -281,3 +281,18 @@ raw:
         - code: renders.weather.weatherapi.conditions[47].code
           day: renders.weather.weatherapi.conditions[47].day
           night: renders.weather.weatherapi.conditions[47].night
+    place_of_the_day:
+      title: renders.place_of_the_day.title
+      wikipedia_credit: renders.place_of_the_day.wikipedia_credit
+      type: renders.place_of_the_day.type
+      population: renders.place_of_the_day.population
+      coordinates: renders.place_of_the_day.coordinates
+      founded: renders.place_of_the_day.founded
+      elevation: renders.place_of_the_day.elevation
+      area: renders.place_of_the_day.area
+      local_time: renders.place_of_the_day.local_time
+      year_bc: renders.place_of_the_day.year_bc
+      metres: renders.place_of_the_day.metres
+      square_km: renders.place_of_the_day.square_km
+      city: renders.place_of_the_day.city
+      wonder: renders.place_of_the_day.wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/ro.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ro.yml
@@ -281,3 +281,18 @@ ro:
         - code: 1282
           day: Tunet și ninsoare
           night: Tunet și ninsoare
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/ru.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ru.yml
@@ -281,3 +281,18 @@ ru:
         - code: 1282
           day: Гроза и снег
           night: Гроза и снег
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/sk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sk.yml
@@ -281,3 +281,18 @@ sk:
         - code: 1282
           day: Búrka so snehom
           night: Búrka so snehom
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/sv.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sv.yml
@@ -281,3 +281,18 @@ sv:
         - code: 1282
           day: Thunder & Snow
           night: Thunder & Snow
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/uk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/uk.yml
@@ -281,3 +281,18 @@ uk:
         - code: 1282
           day: Thunder & Snow
           night: Thunder & Snow
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
@@ -281,3 +281,18 @@ zh-CN:
         - code: 1282
           day: 雷雪
           night: 雷雪
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
@@ -281,3 +281,18 @@ zh-HK:
         - code: 1282
           day: 雷雪
           night: 雷雪
+    place_of_the_day:
+      title: Place of the Day
+      wikipedia_credit: Wikipedia CC BY-SA
+      type: Type
+      population: Population
+      coordinates: Coordinates
+      founded: Founded
+      elevation: Elevation
+      area: Area
+      local_time: Local time
+      year_bc: "%{count} BC"
+      metres: "%{count} m"
+      square_km: "%{count} km²"
+      city: City
+      wonder: Wonder

--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -1123,6 +1123,7 @@ cs:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1132,6 +1133,7 @@ cs:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1461,6 +1463,27 @@ cs:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -1124,6 +1124,7 @@ da:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1133,6 +1134,7 @@ da:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1462,6 +1464,27 @@ da:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -1123,6 +1123,7 @@ de-AT:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1132,6 +1133,7 @@ de-AT:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1461,6 +1463,27 @@ de-AT:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -1123,6 +1123,7 @@ de:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1132,6 +1133,7 @@ de:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1461,6 +1463,27 @@ de:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -1123,6 +1123,7 @@ en-AU:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1132,6 +1133,7 @@ en-AU:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1461,6 +1463,27 @@ en-AU:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -1124,6 +1124,7 @@ en-GB:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1133,6 +1134,7 @@ en-GB:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1462,6 +1464,27 @@ en-GB:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -1123,6 +1123,7 @@ en:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1132,6 +1133,7 @@ en:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1461,6 +1463,27 @@ en:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -1124,6 +1124,7 @@ es-ES:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1133,6 +1134,7 @@ es-ES:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1462,6 +1464,27 @@ es-ES:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -1126,6 +1126,7 @@ fr:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1135,6 +1136,7 @@ fr:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1464,6 +1466,27 @@ fr:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -1126,6 +1126,7 @@ he:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1135,6 +1136,7 @@ he:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1464,6 +1466,27 @@ he:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -1124,6 +1124,7 @@ hu:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1133,6 +1134,7 @@ hu:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1462,6 +1464,27 @@ hu:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -1126,6 +1126,7 @@ id:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1135,6 +1136,7 @@ id:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1464,6 +1466,27 @@ id:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -1124,6 +1124,7 @@ is:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1133,6 +1134,7 @@ is:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1462,6 +1464,27 @@ is:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -1124,6 +1124,7 @@ it:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1133,6 +1134,7 @@ it:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1462,6 +1464,27 @@ it:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -1124,6 +1124,7 @@ ja:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1133,6 +1134,7 @@ ja:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1462,6 +1464,27 @@ ja:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -1124,6 +1124,7 @@ ko:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1133,6 +1134,7 @@ ko:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1462,6 +1464,27 @@ ko:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -1124,6 +1124,7 @@ lt:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1133,6 +1134,7 @@ lt:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1462,6 +1464,27 @@ lt:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -1124,6 +1124,7 @@ nl:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1133,6 +1134,7 @@ nl:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1462,6 +1464,27 @@ nl:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -1124,6 +1124,7 @@
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1133,6 +1134,7 @@
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1462,6 +1464,27 @@
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -1146,6 +1146,7 @@ pl:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1155,6 +1156,7 @@ pl:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1484,6 +1486,27 @@ pl:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -1124,6 +1124,7 @@ pt-BR:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1133,6 +1134,7 @@ pt-BR:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1462,6 +1464,27 @@ pt-BR:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -1124,6 +1124,7 @@ raw:
         timezone: apps.room_booking.common.timezone
         tz: apps.room_booking.common.tz
         walk_up_title: apps.room_booking.common.walk_up_title
+        billing: apps.room_booking.common.billing
       shared:
         back_to_apps: apps.room_booking.shared.back_to_apps
         displays:
@@ -1133,6 +1134,7 @@ raw:
           show_on_device: apps.room_booking.shared.displays.show_on_device
           stop_showing_confirm: apps.room_booking.shared.displays.stop_showing_confirm
           title: apps.room_booking.shared.displays.title
+        back_to_app: apps.room_booking.shared.back_to_app
       screens:
         available:
           next: apps.room_booking.screens.available.next
@@ -1460,6 +1462,27 @@ raw:
           walk_up_booking: apps.room_booking.settings.show.walk_up_booking
           walk_up_calendar: apps.room_booking.settings.show.walk_up_calendar
           walk_up_calendar_hint: apps.room_booking.settings.show.walk_up_calendar_hint
+      billing:
+        title: apps.room_booking.billing.title
+        summary:
+          one: apps.room_booking.billing.summary.one
+          other: apps.room_booking.billing.summary.other
+        incomplete: apps.room_booking.billing.incomplete
+        active: apps.room_booking.billing.active
+        manage: apps.room_booking.billing.manage
+        checkout_error: apps.room_booking.billing.checkout_error
+        trial_active: apps.room_booking.billing.trial_active
+        nothing_to_bill: apps.room_booking.billing.nothing_to_bill
+        bind_confirm:
+          one: apps.room_booking.billing.bind_confirm.one
+          other: apps.room_booking.billing.bind_confirm.other
+        screen_title: apps.room_booking.billing.screen_title
+        screen_body: apps.room_booking.billing.screen_body
+        locked: apps.room_booking.billing.locked
+        past_due: apps.room_booking.billing.past_due
+        grace:
+          one: apps.room_booking.billing.grace.one
+          other: apps.room_booking.billing.grace.other
   mashups:
     mashup:
       add_to_playlist: mashups.mashup.add_to_playlist

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -1124,6 +1124,7 @@ ro:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1133,6 +1134,7 @@ ro:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1462,6 +1464,27 @@ ro:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -1146,6 +1146,7 @@ ru:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1155,6 +1156,7 @@ ru:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1484,6 +1486,27 @@ ru:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -1135,6 +1135,7 @@ sk:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1144,6 +1145,7 @@ sk:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1473,6 +1475,27 @@ sk:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -1124,6 +1124,7 @@ sv:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1133,6 +1134,7 @@ sv:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1462,6 +1464,27 @@ sv:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -1146,6 +1146,7 @@ uk:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1155,6 +1156,7 @@ uk:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1484,6 +1486,27 @@ uk:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -1159,6 +1159,7 @@ zh-CN:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1168,6 +1169,7 @@ zh-CN:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1497,6 +1499,27 @@ zh-CN:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -1124,6 +1124,7 @@ zh-HK:
         timezone: 'Time Zone:'
         tz: Time Zone
         walk_up_title: Occupied
+        billing: Billing
       shared:
         back_to_apps: Back to Apps
         displays:
@@ -1133,6 +1134,7 @@ zh-HK:
           show_on_device: 'Show this %{type} on %{which} device:'
           stop_showing_confirm: Stop showing %{name} on %{device}?
           title: Displays
+        back_to_app: Back to %{app}
       screens:
         available:
           next: 'Next: %{title}'
@@ -1462,6 +1464,27 @@ zh-HK:
           walk_up_booking: Walk-up Booking
           walk_up_calendar: Show Calendar
           walk_up_calendar_hint: Show upcoming bookings on the walk-up booking screen.
+      billing:
+        title: Billing
+        summary:
+          one: "%{count} resource on displays — %{total} per month"
+          other: "%{count} resources on displays — %{total} per month"
+        incomplete: Checkout was not completed.
+        active: Your Booking subscription is active.
+        manage: Manage billing
+        checkout_error: Could not load checkout. Refresh to try again.
+        trial_active: Your free trial is running. You will be billed when it ends.
+        nothing_to_bill: Nothing is on a display yet, so there is nothing to bill. Put a resource on a device to get started.
+        bind_confirm:
+          one: This adds 1 resource to your plan (%{amount}). Continue?
+          other: This adds %{count} resources to your plan (%{amount}). Continue?
+        screen_title: Subscription needed
+        screen_body: Add a payment method to show this resource again.
+        locked: Add a payment method to keep your resources on screen.
+        past_due: Your last payment failed. Update your card to avoid interruption.
+        grace:
+          one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
+          other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
   mashups:
     mashup:
       add_to_playlist: Add to playlist


### PR DESCRIPTION
Opened automatically from usetrmnl/core. These keys already ship in core's
`config/locales/pending.en.yml`, which shadows this gem's English until they land
here. Merging lets core drop its copy and lets translators pick the copy up.

Only additions — copy this repository already holds is left alone. The other
locales carry the new keys too, from this repository's own `bin/sync`.