### PR TITLE
Added the English keys core is waiting on

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -180,6 +180,8 @@ cs:
       locale_hint: Jaký jazyk a lokalizaci preferujete? __Přejděte sem__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Profil byl úspěšně aktualizován
     reset_api_key:
@@ -1484,6 +1486,9 @@ cs:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -180,6 +180,8 @@ da:
       locale_hint: Hvilket sprog og lokalisering foretrækker du? __Klik her__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Profil opdateret med succes
     reset_api_key:
@@ -1485,6 +1487,9 @@ da:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -180,6 +180,8 @@ de-AT:
       locale_hint: Wähle die gewünschte Sprache und Lokalisierung aus. __Weitere Infos__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Konto erfolgreich aktualisiert
     reset_api_key:
@@ -1484,6 +1486,9 @@ de-AT:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -180,6 +180,8 @@ de:
       locale_hint: Wähle die gewünschte Sprache und Lokalisierung aus. __Weitere Infos__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Konto erfolgreich aktualisiert
     reset_api_key:
@@ -1484,6 +1486,9 @@ de:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -180,6 +180,8 @@ en-AU:
       locale_hint: What language and localization do you prefer? __Go here__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Profile updated successfully
     reset_api_key:
@@ -1484,6 +1486,9 @@ en-AU:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -180,6 +180,8 @@ en-GB:
       locale_hint: What language and localization do you prefer? __Go here__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Profile updated successfully
     reset_api_key:
@@ -1485,6 +1487,9 @@ en-GB:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -180,6 +180,8 @@ en:
       locale_hint: What language and localization do you prefer? __Go here__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Profile updated successfully
     reset_api_key:
@@ -1484,6 +1486,9 @@ en:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -180,6 +180,8 @@ es-ES:
       locale_hint: "¿Qué idioma y localización prefieres? __Accede aquí__."
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Perfil actualizado correctamente
     reset_api_key:
@@ -1485,6 +1487,9 @@ es-ES:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -182,6 +182,8 @@ fr:
       locale_hint: Quel langage et localisation préférez-vous ? __Voir ici__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Profil mis à jour avec succès
     reset_api_key:
@@ -1487,6 +1489,9 @@ fr:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -182,6 +182,8 @@ he:
       locale_hint: What language and localization do you prefer? __Go here__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Profile updated successfully
     reset_api_key:
@@ -1487,6 +1489,9 @@ he:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -180,6 +180,8 @@ hu:
       locale_hint: Milyen nyelvet és formátumot részesítesz előnyben? __Kattints ide__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: A profil sikeresen frissült
     reset_api_key:
@@ -1485,6 +1487,9 @@ hu:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -182,6 +182,8 @@ id:
       locale_hint: What language and localization do you prefer? __Go here__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Profil Anda berhasil diperbarui!
     reset_api_key:
@@ -1487,6 +1489,9 @@ id:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -180,6 +180,8 @@ is:
       locale_hint: Veldu tungumál og staðfærslu. __Smelltu hér__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Aðgangurinn var uppfærður
     reset_api_key:
@@ -1485,6 +1487,9 @@ is:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -180,6 +180,8 @@ it:
       locale_hint: Quale lingua e localizzazione preferisci? __Vai qui__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Profilo aggiornato con successo
     reset_api_key:
@@ -1485,6 +1487,9 @@ it:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -180,6 +180,8 @@ ja:
       locale_hint: ご希望の言語とローカライズ設定は？ __こちら__ をご覧ください。
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: プロフィール情報が更新されました。
     reset_api_key:
@@ -1485,6 +1487,9 @@ ja:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -180,6 +180,8 @@ ko:
       locale_hint: 선호하는 언어가 있나요? __여기서__ 설정하세요.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: 프로필을 업데이트했어요.
     reset_api_key:
@@ -1485,6 +1487,9 @@ ko:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -180,6 +180,8 @@ lt:
       locale_hint: Kokiai kalbai ir lokalizacijai teikiate pirmenybę? __Eikite čia__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Profilis sėkmingai atnaujintas
     reset_api_key:
@@ -1485,6 +1487,9 @@ lt:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -180,6 +180,8 @@ nl:
       locale_hint: Welke taal en lokalisatie heeft je voorkeur? __Ga hiernaartoe__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Profiel succesvol bijgewerkt
     reset_api_key:
@@ -1485,6 +1487,9 @@ nl:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -180,6 +180,8 @@
       locale_hint: Hvilket språk og lokalitet foretrekker du? __Gå hit__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Profil oppdatert
     reset_api_key:
@@ -1485,6 +1487,9 @@
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -202,6 +202,8 @@ pl:
       locale_hint: Jaki język preferujesz? __Więcej informacji__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Pomyślnie zaktualizowano profil
     reset_api_key:
@@ -1507,6 +1509,9 @@ pl:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -180,6 +180,8 @@ pt-BR:
       locale_hint: Qual idioma você prefere? __Veja mais__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Perfil atualizado com sucesso
     reset_api_key:
@@ -1485,6 +1487,9 @@ pt-BR:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -180,6 +180,8 @@ raw:
       locale_hint: account.index.locale_hint __Go here__.
       low_battery_notification_email: account.index.low_battery_notification_email
       low_battery_notification_email_hint: account.index.low_battery_notification_email_hint
+      explore_apps: account.index.explore_apps
+      explore_apps_hint: account.index.explore_apps_hint
     update:
       success: account.update.success
     reset_api_key:
@@ -1483,6 +1485,9 @@ raw:
         grace:
           one: apps.room_booking.billing.grace.one
           other: apps.room_booking.billing.grace.other
+      tagline: apps.room_booking.tagline
+    fleet:
+      tagline: apps.fleet.tagline
   mashups:
     mashup:
       add_to_playlist: mashups.mashup.add_to_playlist

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -180,6 +180,8 @@ ro:
       locale_hint: Ce limbă și localizare preferi? __Mergi aici__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Profil actualizat cu succes
     reset_api_key:
@@ -1485,6 +1487,9 @@ ro:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -202,6 +202,8 @@ ru:
       locale_hint: Какой язык и локализацию вы предпочитаете? __Перейдите сюда__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Профиль успешно обновлён
     reset_api_key:
@@ -1507,6 +1509,9 @@ ru:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -191,6 +191,8 @@ sk:
       locale_hint: What language and localization do you prefer? __Go here__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Profile updated successfully
     reset_api_key:
@@ -1496,6 +1498,9 @@ sk:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -180,6 +180,8 @@ sv:
       locale_hint: What language and localization do you prefer? __Go here__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Profile updated successfully
     reset_api_key:
@@ -1485,6 +1487,9 @@ sv:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -202,6 +202,8 @@ uk:
       locale_hint: What language and localization do you prefer? __Go here__.
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: Профіль успішно оновлено
     reset_api_key:
@@ -1507,6 +1509,9 @@ uk:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -215,6 +215,8 @@ zh-CN:
       locale_hint: 您喜欢哪种语言和区域设置？__前往此处__。
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: 账户修改成功
     reset_api_key:
@@ -1520,6 +1522,9 @@ zh-CN:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -180,6 +180,8 @@ zh-HK:
       locale_hint: 你偏好哪種語言及地區設定？ __按此了解更多__。
       low_battery_notification_email: Low Battery Notification Email
       low_battery_notification_email_hint: Send every device's low battery email here instead of to your account address. Leave blank to use your account address.
+      explore_apps: Explore Apps
+      explore_apps_hint: TRMNL Booking (walk-up meeting room reservations), fleet management, and more.
     update:
       success: 成功更新個人資料
     reset_api_key:
@@ -1485,6 +1487,9 @@ zh-HK:
         grace:
           one: Booking becomes a paid app on %{date}. Your %{count} resource will be %{total} per month.
           other: Booking becomes a paid app on %{date}. Your %{count} resources will be %{total} per month.
+      tagline: Room schedules on your displays, with walk-up QR booking.
+    fleet:
+      tagline: Mirror one device's screen and settings across many displays.
   mashups:
     mashup:
       add_to_playlist: Add to playlist


### PR DESCRIPTION
Opened automatically from usetrmnl/core. These keys already ship in core's
`config/locales/pending.en.yml`, which shadows this gem's English until they land
here. Merging lets core drop its copy and lets translators pick the copy up.

Only additions — copy this repository already holds is left alone. The other
locales carry the new keys too, from this repository's own `bin/sync`.