### PR TITLE
Added the English keys core is waiting on

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -905,6 +905,7 @@ cs:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: Soubor ZIP je příliš velký (maximálně %{max_mb} MB)
       missing_entry: Soubor ZIP neobsahuje %{filename}
@@ -928,6 +929,7 @@ cs:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Žádost byla přijata, zkontrolujte svou e-mailovou schránku

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -906,6 +906,7 @@ da:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP-fil er for stor (%{max_mb} MB maksimum)
       missing_entry: ZIP-filen indeholder ikke %{filename}
@@ -929,6 +930,7 @@ da:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Anmodning modtaget, tjek din indbakke

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -905,6 +905,7 @@ de-AT:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP-Datei ist zu groß (maximal %{max_mb} MB)
       missing_entry: Die ZIP-Datei enthält nicht %{filename}
@@ -928,6 +929,7 @@ de-AT:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Anfrage erhalten, bitte Posteingang überprüfen

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -905,6 +905,7 @@ de:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP-Datei ist zu groß (maximal %{max_mb} MB)
       missing_entry: Die ZIP-Datei enthält nicht %{filename}
@@ -928,6 +929,7 @@ de:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Anfrage erhalten, bitte Posteingang überprüfen

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -905,6 +905,7 @@ en-AU:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -928,6 +929,7 @@ en-AU:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -906,6 +906,7 @@ en-GB:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -929,6 +930,7 @@ en-GB:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -905,6 +905,7 @@ en:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -928,6 +929,7 @@ en:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -906,6 +906,7 @@ es-ES:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: El archivo ZIP es demasiado grande (%{max_mb} MB máximo)
       missing_entry: El archivo ZIP no contiene %{filename}
@@ -929,6 +930,7 @@ es-ES:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Solicitud recibida, compruebe su bandeja de entrada

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -908,6 +908,7 @@ fr:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: Le fichier ZIP est trop volumineux (%{max_mb} MB maximum)
       missing_entry: Le fichier ZIP ne contient pas %{filename}
@@ -931,6 +932,7 @@ fr:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Demande reçue, vérifiez votre boîte de réception

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -908,6 +908,7 @@ he:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -931,6 +932,7 @@ he:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -906,6 +906,7 @@ hu:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: A ZIP fájl túl nagy (%{max_mb} MB a maximális méret)
       missing_entry: A ZIP fájl nem tartalmazza a(z) %{filename} fájlt
@@ -929,6 +930,7 @@ hu:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Kérés fogadva, ellenőrizd az e-mail fiókodat

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -908,6 +908,7 @@ id:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -931,6 +932,7 @@ id:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -906,6 +906,7 @@ is:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP skrá er of stór (%{max_mb} MB hámark)
       missing_entry: ZIP skrá inniheldur ekki %{filename}
@@ -929,6 +930,7 @@ is:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Beiðni móttekin, skoðaðu pósthólfið þitt

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -906,6 +906,7 @@ it:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: File ZIP troppo grande (%{max_mb} MB massimi)
       missing_entry: Il file ZIP non contiene %{filename}
@@ -929,6 +930,7 @@ it:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Richiesta ricevuta, controlla la tua posta

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -906,6 +906,7 @@ ja:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -929,6 +930,7 @@ ja:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: リクエストを受信しました。受信箱を確認してください

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -906,6 +906,7 @@ ko:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP 파일이 너무 커요 (최대 %{max_mb} MB)
       missing_entry: ZIP 파일에 %{filename}이(가) 없어요
@@ -929,6 +930,7 @@ ko:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: 요청을 받았어요. 이메일을 확인해주세요

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -906,6 +906,7 @@ lt:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP failas yra per didelis (maksimaliai %{max_mb} MB)
       missing_entry: ZIP faile nėra %{filename}
@@ -929,6 +930,7 @@ lt:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Užklausa gauta, patikrinkite savo pašto dėžutę

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -906,6 +906,7 @@ nl:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP bestand is te groot (%{max_mb} MB max)
       missing_entry: Het ZIP bestand bevat %{filename} niet
@@ -929,6 +930,7 @@ nl:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Request ontvangen, check je inbox

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -906,6 +906,7 @@
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP-filen er for stor (maksimum %{max_mb} MB)
       missing_entry: ZIP-filen inneholder ikke %{filename}
@@ -929,6 +930,7 @@
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Forespørsel mottatt, sjekk innboksen din

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -928,6 +928,7 @@ pl:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: Archiwum ZIP jest zbyt duże (maksimum %{max_mb} MB)
       missing_entry: Archiwum ZIP nie zawiera %{filename}
@@ -951,6 +952,7 @@ pl:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Zgłoszenie przyjęte, sprawdź swoją skrzynkę odbiorczą

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -906,6 +906,7 @@ pt-BR:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: O arquivo ZIP é muito grande (máximo de %{max_mb} MB)
       missing_entry: O arquivo ZIP não contém %{filename}
@@ -929,6 +930,7 @@ pt-BR:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Pedido recebido, verifique sua caixa de entrada

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -906,6 +906,7 @@ raw:
       preview_from_device: plugin_settings.form.preview_from_device
       refresh_paused_merge: plugin_settings.form.refresh_paused_merge
       refresh_paused_merge_hint: plugin_settings.form.refresh_paused_merge_hint
+      clear_state: plugin_settings.form.clear_state
     import:
       archive_too_large: plugin_settings.import.archive_too_large
       missing_entry: plugin_settings.import.missing_entry
@@ -929,6 +930,7 @@ raw:
     delete_mashup_warning:
       one: plugin_settings.delete_mashup_warning.one
       other: plugin_settings.delete_mashup_warning.other
+    state_cleared: plugin_settings.state_cleared
   referral_code:
     create:
       request_received: referral_code.create.request_received

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -906,6 +906,7 @@ ro:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: Fișierul ZIP este prea mare (%{max_mb} MB maxim)
       missing_entry: Fișierul ZIP nu conține %{filename}
@@ -929,6 +930,7 @@ ro:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Cerere primită, verifică inbox-ul

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -928,6 +928,7 @@ ru:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP-файл слишком большой (максимум %{max_mb} МБ)
       missing_entry: ZIP-файл не содержит %{filename}
@@ -951,6 +952,7 @@ ru:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Запрос получен, проверьте свой почтовый ящик

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -917,6 +917,7 @@ sk:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -940,6 +941,7 @@ sk:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -906,6 +906,7 @@ sv:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -929,6 +930,7 @@ sv:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -928,6 +928,7 @@ uk:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -951,6 +952,7 @@ uk:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -941,6 +941,7 @@ zh-CN:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP 文件过大（最大 %{max_mb} MB）
       missing_entry: ZIP 文件不包含 %{filename}
@@ -964,6 +965,7 @@ zh-CN:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: 已收到请求，请查收邮箱

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -906,6 +906,7 @@ zh-HK:
       preview_from_device: Preview from %{device}
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
+      clear_state: Clear Saved State
     import:
       archive_too_large: ZIP檔案太大（最大%{max_mb} MB）
       missing_entry: ZIP檔案未包含「%{filename}」
@@ -929,6 +930,7 @@ zh-HK:
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
+    state_cleared: Saved state cleared. The next refresh starts from scratch.
   referral_code:
     create:
       request_received: 已收到請求，請查看收件箱


### PR DESCRIPTION
Opened automatically from usetrmnl/core. These keys already ship in core's
`config/locales/pending.en.yml`, which shadows this gem's English until they land
here. Merging lets core drop its copy and lets translators pick the copy up.

Only additions — copy this repository already holds is left alone. The other
locales carry the new keys too, from this repository's own `bin/sync`.