### PR TITLE
Added the English keys core is waiting on

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -215,6 +215,22 @@ cs:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Nástěnka
@@ -394,6 +410,71 @@ cs:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Objevovat
       disabled_hint: Zakázáno pro zrcadlené TRMNL. Doporučení spravujte na hlavním zařízení.
@@ -670,6 +751,11 @@ cs:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Aktualizace playlistu se nezdařila
       success: Playlist aktualizován
@@ -750,6 +836,19 @@ cs:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Pluginy
@@ -1058,6 +1157,14 @@ cs:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1560,3 +1667,39 @@ cs:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -215,6 +215,22 @@ da:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Dashboard
@@ -394,6 +410,71 @@ da:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -671,6 +752,11 @@ da:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Fejl ved opdatering af playliste
       success: Playliste opdateret
@@ -751,6 +837,19 @@ da:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Plugins
@@ -1059,6 +1158,14 @@ da:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1561,3 +1668,39 @@ da:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -215,6 +215,22 @@ de-AT:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Übersicht
@@ -394,6 +410,71 @@ de-AT:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -670,6 +751,11 @@ de-AT:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Fehler beim Aktualisieren der Wiedergabeliste
       success: Wiedergabeliste aktualisiert
@@ -750,6 +836,19 @@ de-AT:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Erweiterungen
@@ -1058,6 +1157,14 @@ de-AT:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1560,3 +1667,39 @@ de-AT:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -215,6 +215,22 @@ de:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Übersicht
@@ -394,6 +410,71 @@ de:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -670,6 +751,11 @@ de:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Fehler beim Aktualisieren der Wiedergabeliste
       success: Wiedergabeliste aktualisiert
@@ -750,6 +836,19 @@ de:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Erweiterungen
@@ -1058,6 +1157,14 @@ de:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1560,3 +1667,39 @@ de:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -215,6 +215,22 @@ en-AU:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Dashboard
@@ -394,6 +410,71 @@ en-AU:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -670,6 +751,11 @@ en-AU:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Failed to update Playlist
       success: Playlist updated
@@ -750,6 +836,19 @@ en-AU:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Plugins
@@ -1058,6 +1157,14 @@ en-AU:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1560,3 +1667,39 @@ en-AU:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -215,6 +215,22 @@ en-GB:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Dashboard
@@ -394,6 +410,71 @@ en-GB:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -671,6 +752,11 @@ en-GB:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Failed to update Playlist
       success: Playlist updated
@@ -751,6 +837,19 @@ en-GB:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Plugins
@@ -1059,6 +1158,14 @@ en-GB:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1561,3 +1668,39 @@ en-GB:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -215,6 +215,22 @@ en:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Dashboard
@@ -394,6 +410,71 @@ en:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -670,6 +751,11 @@ en:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Failed to update Playlist
       success: Playlist updated
@@ -750,6 +836,19 @@ en:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Plugins
@@ -1058,6 +1157,14 @@ en:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1560,3 +1667,39 @@ en:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -215,6 +215,22 @@ es-ES:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Panel de control
@@ -394,6 +410,71 @@ es-ES:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -671,6 +752,11 @@ es-ES:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Falló la actualización de la lista
       success: Lista actualizada
@@ -751,6 +837,19 @@ es-ES:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Plugins
@@ -1059,6 +1158,14 @@ es-ES:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1561,3 +1668,39 @@ es-ES:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -217,6 +217,22 @@ fr:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Tableau de bord
@@ -396,6 +412,71 @@ fr:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -673,6 +754,11 @@ fr:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Échec de la mise à jour de la playlist
       success: Playlist mise à jour
@@ -753,6 +839,19 @@ fr:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Plugins
@@ -1061,6 +1160,14 @@ fr:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1563,3 +1670,39 @@ fr:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -217,6 +217,22 @@ he:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Dashboard
@@ -396,6 +412,71 @@ he:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -673,6 +754,11 @@ he:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Failed to update playlist
       success: Playlist updated
@@ -753,6 +839,19 @@ he:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Plugins
@@ -1061,6 +1160,14 @@ he:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1563,3 +1670,39 @@ he:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -215,6 +215,22 @@ hu:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Irányítópult
@@ -394,6 +410,71 @@ hu:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -671,6 +752,11 @@ hu:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Hiba történt a lejátszási lista frissítésekor
       success: Lejátszási lista frissítve
@@ -751,6 +837,19 @@ hu:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Bővítmények
@@ -1059,6 +1158,14 @@ hu:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1561,3 +1668,39 @@ hu:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -217,6 +217,22 @@ id:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Dasbor
@@ -396,6 +412,71 @@ id:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -673,6 +754,11 @@ id:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Gagal memperbarui daftar putar
       success: Daftar putar berhasil diperbarui
@@ -753,6 +839,19 @@ id:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Plugin
@@ -1061,6 +1160,14 @@ id:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1563,3 +1670,39 @@ id:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -215,6 +215,22 @@ is:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Stjórnborð
@@ -394,6 +410,71 @@ is:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -671,6 +752,11 @@ is:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Gat ekki uppfært spilunarlista
       success: Spilunarlisti uppfærður
@@ -751,6 +837,19 @@ is:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Viðbætur
@@ -1059,6 +1158,14 @@ is:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1561,3 +1668,39 @@ is:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -215,6 +215,22 @@ it:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Dashboard
@@ -394,6 +410,71 @@ it:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -671,6 +752,11 @@ it:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Aggiornamento Playlist fallito
       success: Playlist aggiornata
@@ -751,6 +837,19 @@ it:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Plugin
@@ -1059,6 +1158,14 @@ it:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1561,3 +1668,39 @@ it:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -215,6 +215,22 @@ ja:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: ダッシュボード
@@ -394,6 +410,71 @@ ja:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -671,6 +752,11 @@ ja:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: プレイリストの更新に失敗しました
       success: プレイリストが更新されました
@@ -751,6 +837,19 @@ ja:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: プラグイン管理
@@ -1059,6 +1158,14 @@ ja:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1561,3 +1668,39 @@ ja:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -215,6 +215,22 @@ ko:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: 대시보드
@@ -394,6 +410,71 @@ ko:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -671,6 +752,11 @@ ko:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: 플레이리스트 업데이트 실패
       success: 플레이리스트를 업데이트했어요
@@ -751,6 +837,19 @@ ko:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: 플러그인
@@ -1059,6 +1158,14 @@ ko:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1561,3 +1668,39 @@ ko:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -215,6 +215,22 @@ lt:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Skydelis
@@ -394,6 +410,71 @@ lt:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -671,6 +752,11 @@ lt:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Nepavyko atnaujinti grojaraščio
       success: Grojaraštis atnaujintas
@@ -751,6 +837,19 @@ lt:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Įskiepiai
@@ -1059,6 +1158,14 @@ lt:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1561,3 +1668,39 @@ lt:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -215,6 +215,22 @@ nl:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Dashboard
@@ -394,6 +410,71 @@ nl:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -671,6 +752,11 @@ nl:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Bijwerken van afspeellijst is mislukt
       success: Afspeellijst is bijgewerkt
@@ -751,6 +837,19 @@ nl:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Plugins
@@ -1059,6 +1158,14 @@ nl:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1561,3 +1668,39 @@ nl:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -215,6 +215,22 @@
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Oversikt
@@ -394,6 +410,71 @@
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -671,6 +752,11 @@
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Kunne ikke oppdatere spillelisten
       success: Spilleliste oppdatert
@@ -751,6 +837,19 @@
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Plugins
@@ -1059,6 +1158,14 @@
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1561,3 +1668,39 @@
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -237,6 +237,22 @@ pl:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Pulpit
@@ -416,6 +432,71 @@ pl:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -693,6 +774,11 @@ pl:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Aktualizacja playlisty nie powiodła się
       success: Playlista zaktualizowana
@@ -773,6 +859,19 @@ pl:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Pluginy
@@ -1081,6 +1180,14 @@ pl:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1583,3 +1690,39 @@ pl:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -215,6 +215,22 @@ pt-BR:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Dashboard
@@ -394,6 +410,71 @@ pt-BR:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -671,6 +752,11 @@ pt-BR:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Falha ao atualizar a playlist
       success: Playlist atualizada
@@ -751,6 +837,19 @@ pt-BR:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Plugins
@@ -1059,6 +1158,14 @@ pt-BR:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1561,3 +1668,39 @@ pt-BR:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -215,6 +215,22 @@ raw:
       avg_cost_per_plugin: account.ai_agent_settings.avg_cost_per_plugin
       cache: account.ai_agent_settings.cache
       cost_by_model: account.ai_agent_settings.cost_by_model
+    shared_accounts:
+      title: account.shared_accounts.title
+      hint: account.shared_accounts.hint
+      switch: account.shared_accounts.switch
+      leave: account.shared_accounts.leave
+    sharing:
+      name: account.sharing.name
+      name_hint: account.sharing.name_hint
+      save_name: account.sharing.save_name
+      title: account.sharing.title
+      hint: account.sharing.hint
+      email_placeholder: account.sharing.email_placeholder
+      invite: account.sharing.invite
+      pending: account.sharing.pending
+      expired: account.sharing.expired
+      remove: account.sharing.remove
   dashboard:
     index:
       title: dashboard.index.title
@@ -394,6 +410,71 @@ raw:
       theme: devices.edit.theme
       theme_hint: devices.edit.theme_hint
       theme_version_note: devices.edit.theme_version_note
+      waits_for_next_render: devices.edit.waits_for_next_render
+      waits_for_next_render_hint: devices.edit.waits_for_next_render_hint
+      battery_advice:
+        title: devices.edit.battery_advice.title
+        wakes_per_day:
+          one: devices.edit.battery_advice.wakes_per_day.one
+          other: devices.edit.battery_advice.wakes_per_day.other
+        days_per_charge:
+          one: devices.edit.battery_advice.days_per_charge.one
+          other: devices.edit.battery_advice.days_per_charge.other
+        gain:
+          zero: devices.edit.battery_advice.gain.zero
+          one: devices.edit.battery_advice.gain.one
+          other: devices.edit.battery_advice.gain.other
+        nothing_to_change: devices.edit.battery_advice.nothing_to_change
+        suggestions:
+          enable_wait: devices.edit.battery_advice.suggestions.enable_wait
+          match_plugin_interval: devices.edit.battery_advice.suggestions.match_plugin_interval
+          enable_sleep_mode: devices.edit.battery_advice.suggestions.enable_sleep_mode
+      check_in_preview:
+        next_check_in: devices.edit.check_in_preview.next_check_in
+        next_check_in_unknown: devices.edit.check_in_preview.next_check_in_unknown
+        next_check_in_overdue: devices.edit.check_in_preview.next_check_in_overdue
+        why: devices.edit.check_in_preview.why
+        title: devices.edit.check_in_preview.title
+        then_shows: devices.edit.check_in_preview.then_shows
+        then_shows_nothing: devices.edit.check_in_preview.then_shows_nothing
+        then_sleeps: devices.edit.check_in_preview.then_sleeps
+        renders_at: devices.edit.check_in_preview.renders_at
+        no_render_because: devices.edit.check_in_preview.no_render_because
+        render_overdue: devices.edit.check_in_preview.render_overdue
+        told: devices.edit.check_in_preview.told
+        timeline_title: devices.edit.check_in_preview.timeline_title
+        timeline_group:
+          one: devices.edit.check_in_preview.timeline_group.one
+          other: devices.edit.check_in_preview.timeline_group.other
+        timeline_sleep_group:
+          one: devices.edit.check_in_preview.timeline_sleep_group.one
+          other: devices.edit.check_in_preview.timeline_sleep_group.other
+        timeline_nothing_group:
+          one: devices.edit.check_in_preview.timeline_nothing_group.one
+          other: devices.edit.check_in_preview.timeline_nothing_group.other
+        timeline_step: devices.edit.check_in_preview.timeline_step
+        timeline_asleep: devices.edit.check_in_preview.timeline_asleep
+        timeline_nothing: devices.edit.check_in_preview.timeline_nothing
+        rules: devices.edit.check_in_preview.rules
+        close: devices.edit.check_in_preview.close
+        reasons:
+          waiting_for_render: devices.edit.check_in_preview.reasons.waiting_for_render
+          sleep_window: devices.edit.check_in_preview.reasons.sleep_window
+          maximum_wait: devices.edit.check_in_preview.reasons.maximum_wait
+          next_screen_change: devices.edit.check_in_preview.reasons.next_screen_change
+          asleep: devices.edit.check_in_preview.reasons.asleep
+          rotation: devices.edit.check_in_preview.reasons.rotation
+          render_before_next_poll: devices.edit.check_in_preview.reasons.render_before_next_poll
+          nothing_served: devices.edit.check_in_preview.reasons.nothing_served
+          wait_disabled: devices.edit.check_in_preview.reasons.wait_disabled
+          setup_day: devices.edit.check_in_preview.reasons.setup_day
+          push_driven: devices.edit.check_in_preview.reasons.push_driven
+          clock_driven: devices.edit.check_in_preview.reasons.clock_driven
+          renders_elsewhere: devices.edit.check_in_preview.reasons.renders_elsewhere
+          scheduled: devices.edit.check_in_preview.reasons.scheduled
+          feature_off: devices.edit.check_in_preview.reasons.feature_off
+          no_render_scheduled: devices.edit.check_in_preview.reasons.no_render_scheduled
+          render_running: devices.edit.check_in_preview.reasons.render_running
     discover_persona:
       label: devices.discover_persona.label
       disabled_hint: devices.discover_persona.disabled_hint
@@ -671,6 +752,11 @@ raw:
       title_tooltip:
         source_plugin: playlist_items.playlist_item.title_tooltip.source_plugin
       force_refresh: playlist_items.playlist_item.force_refresh
+      next_shown: playlist_items.playlist_item.next_shown
+      next_shown_overdue: playlist_items.playlist_item.next_shown_overdue
+      next_render: playlist_items.playlist_item.next_render
+      render_overdue: playlist_items.playlist_item.render_overdue
+      no_next_render: playlist_items.playlist_item.no_next_render
     create:
       error: playlists.create.error
       success: playlists.create.success
@@ -751,6 +837,19 @@ raw:
       adjust_schedule: playlist_items.playlist_item_schedule.adjust_schedule
     update_full_playlist_order:
       error: playlist_items.update_full_playlist_order.error
+    day_ahead:
+      title: playlist_items.day_ahead.title
+      window: playlist_items.day_ahead.window
+      open: playlist_items.day_ahead.open
+      toggle: playlist_items.day_ahead.toggle
+      times:
+        one: playlist_items.day_ahead.times.one
+        other: playlist_items.day_ahead.times.other
+      asleep: playlist_items.day_ahead.asleep
+      nothing: playlist_items.day_ahead.nothing
+      asleep_segment: playlist_items.day_ahead.asleep_segment
+      nothing_segment: playlist_items.day_ahead.nothing_segment
+      segment: playlist_items.day_ahead.segment
   plugins:
     index:
       title: plugins.index.title
@@ -1059,6 +1158,14 @@ raw:
     attributes:
       plugin_setting:
         ai_coauthored: activerecord.attributes.plugin_setting.ai_coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: activerecord.errors.models.account_membership.attributes.email.owner
+            owner:
+              admin: activerecord.errors.models.account_membership.attributes.owner.admin
   apps:
     core:
       public:
@@ -1559,3 +1666,39 @@ raw:
       variables: compositions.form.variables
       visible_if: compositions.form.visible_if
       width: compositions.form.width
+  shared:
+    impersonator:
+      managing: shared.impersonator.managing
+      back_to_my_account: shared.impersonator.back_to_my_account
+  account_invitations:
+    show:
+      title: account_invitations.show.title
+      body: account_invitations.show.body
+      accept: account_invitations.show.accept
+      not_now: account_invitations.show.not_now
+      have_a_login: account_invitations.show.have_a_login
+      log_in: account_invitations.show.log_in
+      create_and_accept: account_invitations.show.create_and_accept
+    accept:
+      accepted: account_invitations.accept.accepted
+      own_account: account_invitations.accept.own_account
+      already_member: account_invitations.accept.already_member
+  account_memberships:
+    create:
+      sent: account_memberships.create.sent
+    destroy:
+      removed: account_memberships.destroy.removed
+    leave:
+      left: account_memberships.leave.left
+  account_switches:
+    create:
+      switched: account_switches.create.switched
+    revoked: account_switches.revoked
+    own_account_only: account_switches.own_account_only
+  user_mailer:
+    account_invitation:
+      subject: user_mailer.account_invitation.subject
+      greeting: user_mailer.account_invitation.greeting
+      body: user_mailer.account_invitation.body
+      accept: user_mailer.account_invitation.accept
+      expiry: user_mailer.account_invitation.expiry

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -215,6 +215,22 @@ ro:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Panou de control
@@ -394,6 +410,71 @@ ro:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -671,6 +752,11 @@ ro:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Actualizarea listei de redare a eșuat
       success: Listă de redare actualizată
@@ -751,6 +837,19 @@ ro:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Plugin-uri
@@ -1059,6 +1158,14 @@ ro:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1561,3 +1668,39 @@ ro:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -237,6 +237,22 @@ ru:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Панель управления
@@ -416,6 +432,71 @@ ru:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -693,6 +774,11 @@ ru:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Не удалось обновить плейлист
       success: Плейлист обновлен
@@ -773,6 +859,19 @@ ru:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Плагины
@@ -1081,6 +1180,14 @@ ru:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1583,3 +1690,39 @@ ru:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -226,6 +226,22 @@ sk:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Dashboard
@@ -405,6 +421,71 @@ sk:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -682,6 +763,11 @@ sk:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Failed to update playlist
       success: Playlist updated
@@ -762,6 +848,19 @@ sk:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Plugins
@@ -1070,6 +1169,14 @@ sk:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1572,3 +1679,39 @@ sk:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -215,6 +215,22 @@ sv:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Dashboard
@@ -394,6 +410,71 @@ sv:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -671,6 +752,11 @@ sv:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Failed to update playlist
       success: Playlist updated
@@ -751,6 +837,19 @@ sv:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Plugins
@@ -1059,6 +1158,14 @@ sv:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1561,3 +1668,39 @@ sv:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -237,6 +237,22 @@ uk:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: Панель управління
@@ -416,6 +432,71 @@ uk:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -693,6 +774,11 @@ uk:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: Не вдалося оновити плейлист
       success: Плейлист оновлено
@@ -773,6 +859,19 @@ uk:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: Плагіни
@@ -1081,6 +1180,14 @@ uk:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1583,3 +1690,39 @@ uk:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -250,6 +250,22 @@ zh-CN:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: 仪表盘
@@ -429,6 +445,71 @@ zh-CN:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -706,6 +787,11 @@ zh-CN:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: 创建播放列表错误
       success: 播放列表创建成功
@@ -786,6 +872,19 @@ zh-CN:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: 插件
@@ -1094,6 +1193,14 @@ zh-CN:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1596,3 +1703,39 @@ zh-CN:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -215,6 +215,22 @@ zh-HK:
       avg_cost_per_plugin: Avg Cost / Plugin
       cache: 'Cache: %{read} read / %{created} created'
       cost_by_model: Cost by Model
+    shared_accounts:
+      title: Accounts shared with you
+      hint: Pick an account to manage its devices, playlists and plugins, or leave it.
+      switch: Manage
+      leave: Leave
+    sharing:
+      name: Account name
+      name_hint: What the people you share with see, such as Home or Acme HQ. Leave blank to use your name.
+      save_name: Rename
+      title: Sharing
+      hint: Invite someone to manage your devices, playlists and plugins. They use their own TRMNL login.
+      email_placeholder: name@example.com
+      invite: Invite
+      pending: Pending
+      expired: Expired
+      remove: Remove
   dashboard:
     index:
       title: 儀表板
@@ -394,6 +410,71 @@ zh-HK:
       theme: Theme
       theme_hint: Apply a color theme across your plugin screens.
       theme_version_note: Requires Framework 3.2 or later. Private plugins pinned to an older version will not be affected.
+      waits_for_next_render: Wait for the next update
+      waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
+      battery_advice:
+        title: Battery advice
+        wakes_per_day:
+          one: This device wakes about once a day.
+          other: This device wakes about %{count} times a day.
+        days_per_charge:
+          one: At that rate a charge lasts about a day.
+          other: At that rate a charge lasts about %{count} days.
+        gain:
+          zero: ''
+          one: "(adds about a day to a charge)"
+          other: "(adds about %{count} days to a charge)"
+        nothing_to_change: Nothing to change here. It already wakes no more often than its plugins update.
+        suggestions:
+          enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
+          match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
+          enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+      check_in_preview:
+        next_check_in: Next check-in %{when}.
+        next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
+        next_check_in_overdue: Check-in overdue since %{when}.
+        why: Why?
+        title: How this device decides when to check in
+        then_shows: Then it shows %{item}.
+        then_shows_nothing: Then it has nothing to show.
+        then_sleeps: Then it shows the sleep screen until its sleep window ends.
+        renders_at: "%{item} next renders %{when}."
+        no_render_because: "%{item} has no render time, %{reason}."
+        render_overdue: "%{item} has had a render overdue since %{when}."
+        told: It will be told to check in again in %{when}, %{reason}.
+        timeline_title: The day ahead
+        timeline_group:
+          one: "%{item}: once, at %{at}"
+          other: "%{item}: %{count} times, first at %{at}"
+        timeline_sleep_group:
+          one: 'Asleep: once'
+          other: 'Asleep: %{count} times'
+        timeline_nothing_group:
+          one: 'Nothing to show: once'
+          other: 'Nothing to show: %{count} times'
+        timeline_step: "%{at}: shows %{item}, then waits %{wait}."
+        timeline_asleep: "%{at}: sleeps until %{until}."
+        timeline_nothing: "%{at}: has nothing to show."
+        rules: Its refresh rate, a playlist item's own duration, each plugin's refresh interval, sleep mode and the wait for the next update each decide part of this.
+        close: Close
+        reasons:
+          waiting_for_render: because its plugin's next update is not due before then
+          sleep_window: because its sleep window starts then
+          maximum_wait: because two hours is the longest a device waits
+          next_screen_change: because the room's next meeting starts or ends then
+          asleep: because it is inside its sleep window
+          rotation: because its playlist rotates more than one item, so every check-in shows the next
+          render_before_next_poll: because its plugin's next update lands before then
+          nothing_served: because nothing is on its playlist yet
+          wait_disabled: because waiting for the next update is turned off for this device
+          setup_day: because it was set up less than a day ago
+          push_driven: because its plugin updates whenever data arrives, not on a schedule
+          clock_driven: because its screen changes with the clock rather than with a render
+          renders_elsewhere: because its plugin is rendered by a shared master, not on its own schedule
+          scheduled: because it only shows inside a schedule window
+          feature_off: because waiting for the next update is switched off for everyone
+          no_render_scheduled: because no render is scheduled for its plugin
+          render_running: because its plugin is rendering right now
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -671,6 +752,11 @@ zh-HK:
       title_tooltip:
         source_plugin: Source plugin
       force_refresh: Refresh now
+      next_shown: Next shown %{time}
+      next_shown_overdue: Next shown as soon as it checks in; it is overdue
+      next_render: Renders again %{time}
+      render_overdue: A render has been overdue since %{time}
+      no_next_render: No render before then, %{reason}
     create:
       error: 更新播放清單時發生錯誤
       success: 已更新播放清單
@@ -751,6 +837,19 @@ zh-HK:
       adjust_schedule: Adjust schedule
     update_full_playlist_order:
       error: Playlist order could not be saved
+    day_ahead:
+      title: The day ahead
+      window: next 24 hours
+      open: Open the day ahead
+      toggle: Hide or show the day ahead
+      times:
+        one: once
+        other: "%{count}×"
+      asleep: Asleep %{duration}
+      nothing: Nothing to show %{duration}
+      asleep_segment: Asleep
+      nothing_segment: Nothing to show
+      segment: "%{item} for %{duration}"
   plugins:
     index:
       title: 外掛功能
@@ -1059,6 +1158,14 @@ zh-HK:
     attributes:
       plugin_setting:
         ai_coauthored: AI Coauthored
+    errors:
+      models:
+        account_membership:
+          attributes:
+            email:
+              owner: is the account owner's own address
+            owner:
+              admin: is an admin login and cannot be shared
   apps:
     core:
       public:
@@ -1561,3 +1668,39 @@ zh-HK:
       variables: Variables
       visible_if: Visible if...
       width: Width
+  shared:
+    impersonator:
+      managing: Managing %{name}
+      back_to_my_account: Back to my account
+  account_invitations:
+    show:
+      title: You have been invited
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept
+      not_now: Not now
+      have_a_login: Already have a TRMNL login?
+      log_in: Log in
+      create_and_accept: Create login and accept
+    accept:
+      accepted: You're now managing %{name}'s account
+      own_account: That invitation is for your own account
+      already_member: You already manage this account
+  account_memberships:
+    create:
+      sent: Invitation sent to %{email}
+    destroy:
+      removed: Access removed
+    leave:
+      left: You left %{name}
+  account_switches:
+    create:
+      switched: You're now managing %{name}'s account
+    revoked: Your access to that account was removed
+    own_account_only: Switch back to your own account first
+  user_mailer:
+    account_invitation:
+      subject: "%{name} invited you to manage their TRMNL"
+      greeting: Hey there,
+      body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
+      accept: Accept the invitation
+      expiry: This link will work for %{days} days.


### PR DESCRIPTION
Opened automatically from usetrmnl/core. These keys already ship in core's
`config/locales/pending.en.yml`, which shadows this gem's English until they land
here. Merging lets core drop its copy and lets translators pick the copy up.

Only additions — copy this repository already holds is left alone. The other
locales carry the new keys too, from this repository's own `bin/sync`.