### PR TITLE
Added the English keys core is waiting on

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -429,6 +429,10 @@ cs:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ cs:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Objevovat
       disabled_hint: Zakázáno pro zrcadlené TRMNL. Doporučení spravujte na hlavním zařízení.
@@ -849,6 +856,9 @@ cs:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Pluginy
@@ -1039,6 +1049,7 @@ cs:
       most_popular: Nejoblíbenější
       install: Nainstalovat
       fork: Forknout
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Přidat vlastní rozvrh
@@ -1671,6 +1682,13 @@ cs:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1703,3 +1721,10 @@ cs:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -429,6 +429,10 @@ da:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ da:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -850,6 +857,9 @@ da:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Plugins
@@ -1040,6 +1050,7 @@ da:
       most_popular: Mest populære
       install: Installer
       fork: Forgren
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Tilføj en brugerdefineret tidsplan
@@ -1672,6 +1683,13 @@ da:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1704,3 +1722,10 @@ da:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -429,6 +429,10 @@ de-AT:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ de-AT:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -849,6 +856,9 @@ de-AT:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Erweiterungen
@@ -1039,6 +1049,7 @@ de-AT:
       most_popular: Am beliebtesten
       install: Installieren
       fork: Forken
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Eigenen Zeitplan hinzufügen
@@ -1671,6 +1682,13 @@ de-AT:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1703,3 +1721,10 @@ de-AT:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -429,6 +429,10 @@ de:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ de:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -849,6 +856,9 @@ de:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Erweiterungen
@@ -1039,6 +1049,7 @@ de:
       most_popular: Am beliebtesten
       install: Installieren
       fork: Forken
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Eigenen Zeitplan hinzufügen
@@ -1671,6 +1682,13 @@ de:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1703,3 +1721,10 @@ de:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -429,6 +429,10 @@ en-AU:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ en-AU:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -849,6 +856,9 @@ en-AU:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Plugins
@@ -1039,6 +1049,7 @@ en-AU:
       most_popular: Most Popular
       install: Install
       fork: Fork
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Add a custom schedule
@@ -1671,6 +1682,13 @@ en-AU:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1703,3 +1721,10 @@ en-AU:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -429,6 +429,10 @@ en-GB:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ en-GB:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -850,6 +857,9 @@ en-GB:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Plugins
@@ -1040,6 +1050,7 @@ en-GB:
       most_popular: Most Popular
       install: Install
       fork: Fork
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Add a custom schedule
@@ -1672,6 +1683,13 @@ en-GB:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1704,3 +1722,10 @@ en-GB:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -429,6 +429,10 @@ en:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ en:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -849,6 +856,9 @@ en:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Plugins
@@ -1039,6 +1049,7 @@ en:
       most_popular: Most Popular
       install: Install
       fork: Fork
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Add a custom schedule
@@ -1671,6 +1682,13 @@ en:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1703,3 +1721,10 @@ en:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -429,6 +429,10 @@ es-ES:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ es-ES:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -850,6 +857,9 @@ es-ES:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Plugins
@@ -1040,6 +1050,7 @@ es-ES:
       most_popular: Más populares
       install: Instalar
       fork: Fork
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Añade una programación personalizada
@@ -1672,6 +1683,13 @@ es-ES:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1704,3 +1722,10 @@ es-ES:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -431,6 +431,10 @@ fr:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -477,6 +481,9 @@ fr:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -852,6 +859,9 @@ fr:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Plugins
@@ -1042,6 +1052,7 @@ fr:
       most_popular: Les plus populaires
       install: Installer
       fork: Dupliquer
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Ajouter un horaire personnalisé
@@ -1674,6 +1685,13 @@ fr:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1706,3 +1724,10 @@ fr:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -431,6 +431,10 @@ he:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -477,6 +481,9 @@ he:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -852,6 +859,9 @@ he:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Plugins
@@ -1042,6 +1052,7 @@ he:
       most_popular: Most Popular
       install: Install
       fork: Fork
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Add a custom schedule
@@ -1674,6 +1685,13 @@ he:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1706,3 +1724,10 @@ he:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -429,6 +429,10 @@ hu:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ hu:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -850,6 +857,9 @@ hu:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Bővítmények
@@ -1040,6 +1050,7 @@ hu:
       most_popular: Legnépszerűbb
       install: Telepítés
       fork: Fork létrehozása
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Egyéni ütemezés hozzáadása
@@ -1672,6 +1683,13 @@ hu:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1704,3 +1722,10 @@ hu:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -431,6 +431,10 @@ id:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -477,6 +481,9 @@ id:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -852,6 +859,9 @@ id:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Plugin
@@ -1042,6 +1052,7 @@ id:
       most_popular: Most Popular
       install: Install
       fork: Fork
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Add a custom schedule
@@ -1674,6 +1685,13 @@ id:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1706,3 +1724,10 @@ id:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -429,6 +429,10 @@ is:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ is:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -850,6 +857,9 @@ is:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Viðbætur
@@ -1040,6 +1050,7 @@ is:
       most_popular: Vinsælast
       install: Setja upp
       fork: Afrita
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Bæta við sérsniðinni tímasetningu
@@ -1672,6 +1683,13 @@ is:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1704,3 +1722,10 @@ is:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -429,6 +429,10 @@ it:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ it:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -850,6 +857,9 @@ it:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Plugin
@@ -1040,6 +1050,7 @@ it:
       most_popular: Popolari
       install: Installa
       fork: Fork
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Aggiungi programmazione personalizzata
@@ -1672,6 +1683,13 @@ it:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1704,3 +1722,10 @@ it:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -429,6 +429,10 @@ ja:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ ja:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -850,6 +857,9 @@ ja:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: プラグイン管理
@@ -1040,6 +1050,7 @@ ja:
       most_popular: Most Popular
       install: Install
       fork: Fork
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Add a custom schedule
@@ -1672,6 +1683,13 @@ ja:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1704,3 +1722,10 @@ ja:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -429,6 +429,10 @@ ko:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ ko:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -850,6 +857,9 @@ ko:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: 플러그인
@@ -1040,6 +1050,7 @@ ko:
       most_popular: 인기순
       install: 설치
       fork: 포크
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: 커스텀 스케줄 추가
@@ -1672,6 +1683,13 @@ ko:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1704,3 +1722,10 @@ ko:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -429,6 +429,10 @@ lt:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ lt:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -850,6 +857,9 @@ lt:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Įskiepiai
@@ -1040,6 +1050,7 @@ lt:
       most_popular: Populiariausi
       install: Įdiegti
       fork: Atšakoti (Fork)
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Pridėti pasirinktinį tvarkaraštį
@@ -1672,6 +1683,13 @@ lt:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1704,3 +1722,10 @@ lt:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -429,6 +429,10 @@ nl:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ nl:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -850,6 +857,9 @@ nl:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Plugins
@@ -1040,6 +1050,7 @@ nl:
       most_popular: Populairste
       install: Installeer
       fork: Fork
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Voeg een op-maat schema toe
@@ -1672,6 +1683,13 @@ nl:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1704,3 +1722,10 @@ nl:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -429,6 +429,10 @@
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -850,6 +857,9 @@
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Plugins
@@ -1040,6 +1050,7 @@
       most_popular: Most Popular
       install: Install
       fork: Fork
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Add a custom schedule
@@ -1672,6 +1683,13 @@
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1704,3 +1722,10 @@
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -451,6 +451,10 @@ pl:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -497,6 +501,9 @@ pl:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -872,6 +879,9 @@ pl:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Pluginy
@@ -1062,6 +1072,7 @@ pl:
       most_popular: Najpopularniejsze
       install: Instaluj
       fork: Forkuj
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Dodaj własny harmonogram
@@ -1694,6 +1705,13 @@ pl:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1726,3 +1744,10 @@ pl:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -429,6 +429,10 @@ pt-BR:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ pt-BR:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -850,6 +857,9 @@ pt-BR:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Plugins
@@ -1040,6 +1050,7 @@ pt-BR:
       most_popular: Mais Populares
       install: Instalar
       fork: Derivar
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Adicione uma agenda customizada
@@ -1672,6 +1683,13 @@ pt-BR:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1704,3 +1722,10 @@ pt-BR:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -429,6 +429,10 @@ raw:
           enable_wait: devices.edit.battery_advice.suggestions.enable_wait
           match_plugin_interval: devices.edit.battery_advice.suggestions.match_plugin_interval
           enable_sleep_mode: devices.edit.battery_advice.suggestions.enable_sleep_mode
+        wakes_per_day_measured:
+          one: devices.edit.battery_advice.wakes_per_day_measured.one
+          other: devices.edit.battery_advice.wakes_per_day_measured.other
+        stale: devices.edit.battery_advice.stale
       check_in_preview:
         next_check_in: devices.edit.check_in_preview.next_check_in
         next_check_in_unknown: devices.edit.check_in_preview.next_check_in_unknown
@@ -475,6 +479,9 @@ raw:
           feature_off: devices.edit.check_in_preview.reasons.feature_off
           no_render_scheduled: devices.edit.check_in_preview.reasons.no_render_scheduled
           render_running: devices.edit.check_in_preview.reasons.render_running
+          schedule_boundary: devices.edit.check_in_preview.reasons.schedule_boundary
+          sibling_render: devices.edit.check_in_preview.reasons.sibling_render
+      battery_estimate: devices.edit.battery_estimate
     discover_persona:
       label: devices.discover_persona.label
       disabled_hint: devices.discover_persona.disabled_hint
@@ -850,6 +857,9 @@ raw:
       asleep_segment: playlist_items.day_ahead.asleep_segment
       nothing_segment: playlist_items.day_ahead.nothing_segment
       segment: playlist_items.day_ahead.segment
+      window_hours: playlist_items.day_ahead.window_hours
+      window_label: playlist_items.day_ahead.window_label
+      window_option: playlist_items.day_ahead.window_option
   plugins:
     index:
       title: plugins.index.title
@@ -1040,6 +1050,7 @@ raw:
       most_popular: recipes.index.most_popular
       install: recipes.index.install
       fork: recipes.index.fork
+      search_placeholder: recipes.index.search_placeholder
   schedules:
     form:
       add: schedules.form.add
@@ -1670,6 +1681,13 @@ raw:
     impersonator:
       managing: shared.impersonator.managing
       back_to_my_account: shared.impersonator.back_to_my_account
+    search_bar:
+      min_characters: shared.search_bar.min_characters
+      sort_by: shared.search_bar.sort_by
+      plugin_catalog_placeholder: shared.search_bar.plugin_catalog_placeholder
+    search_summary:
+      found: shared.search_summary.found
+      none: shared.search_summary.none
   account_invitations:
     show:
       title: account_invitations.show.title
@@ -1702,3 +1720,10 @@ raw:
       body: user_mailer.account_invitation.body
       accept: user_mailer.account_invitation.accept
       expiry: user_mailer.account_invitation.expiry
+  pages:
+    flash_firmware:
+      linux_warning: pages.flash_firmware.linux_warning
+      serial_failure:
+        guide_link: pages.flash_firmware.serial_failure.guide_link
+        port_unavailable: pages.flash_firmware.serial_failure.port_unavailable
+        reset_refused: pages.flash_firmware.serial_failure.reset_refused

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -429,6 +429,10 @@ ro:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ ro:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -850,6 +857,9 @@ ro:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Plugin-uri
@@ -1040,6 +1050,7 @@ ro:
       most_popular: Cele mai populare
       install: Instalează
       fork: Bifurcă
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Adaugă un program personalizat
@@ -1672,6 +1683,13 @@ ro:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1704,3 +1722,10 @@ ro:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -451,6 +451,10 @@ ru:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -497,6 +501,9 @@ ru:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -872,6 +879,9 @@ ru:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Плагины
@@ -1062,6 +1072,7 @@ ru:
       most_popular: Самые популярные
       install: Установить
       fork: Форк
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Добавить пользовательское расписание
@@ -1694,6 +1705,13 @@ ru:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1726,3 +1744,10 @@ ru:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -440,6 +440,10 @@ sk:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -486,6 +490,9 @@ sk:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -861,6 +868,9 @@ sk:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Plugins
@@ -1051,6 +1061,7 @@ sk:
       most_popular: Most Popular
       install: Install
       fork: Fork
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Add a custom schedule
@@ -1683,6 +1694,13 @@ sk:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1715,3 +1733,10 @@ sk:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -429,6 +429,10 @@ sv:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ sv:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -850,6 +857,9 @@ sv:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Plugins
@@ -1040,6 +1050,7 @@ sv:
       most_popular: Most Popular
       install: Install
       fork: Fork
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Add a custom schedule
@@ -1672,6 +1683,13 @@ sv:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1704,3 +1722,10 @@ sv:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -451,6 +451,10 @@ uk:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -497,6 +501,9 @@ uk:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -872,6 +879,9 @@ uk:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: Плагіни
@@ -1062,6 +1072,7 @@ uk:
       most_popular: Most Popular
       install: Install
       fork: Fork
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: Add a custom schedule
@@ -1694,6 +1705,13 @@ uk:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1726,3 +1744,10 @@ uk:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -464,6 +464,10 @@ zh-CN:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -510,6 +514,9 @@ zh-CN:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -885,6 +892,9 @@ zh-CN:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: 插件
@@ -1075,6 +1085,7 @@ zh-CN:
       most_popular: 最受欢迎
       install: 安装数
       fork: 分支数
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: 添加自定义时间表
@@ -1707,6 +1718,13 @@ zh-CN:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1739,3 +1757,10 @@ zh-CN:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -429,6 +429,10 @@ zh-HK:
           enable_wait: Turn "Wait for the next update" back on, so it sleeps through updates that cannot have changed.
           match_plugin_interval: Set the refresh rate to %{minutes} minutes, the fastest any of its plugins updates.
           enable_sleep_mode: Turn on Sleep Mode for the hours nobody is looking.
+        wakes_per_day_measured:
+          one: Over the last 7 days this device woke about once a day.
+          other: Over the last 7 days this device woke about %{count} times a day.
+        stale: Save your changes to work these figures out again for the new setting.
       check_in_preview:
         next_check_in: Next check-in %{when}.
         next_check_in_unknown: 'Next check-in: unknown until it has checked in.'
@@ -475,6 +479,9 @@ zh-HK:
           feature_off: because waiting for the next update is switched off for everyone
           no_render_scheduled: because no render is scheduled for its plugin
           render_running: because its plugin is rendering right now
+          schedule_boundary: because a schedule window on its playlist opens or closes then
+          sibling_render: because another item on its playlist updates then
+      battery_estimate: 'Estimated battery life at this setting: %{days} days'
     discover_persona:
       label: Persona & Discover
       disabled_hint: Disabled for mirrored TRMNLs. Manage recommendations on the master device instead.
@@ -850,6 +857,9 @@ zh-HK:
       asleep_segment: Asleep
       nothing_segment: Nothing to show
       segment: "%{item} for %{duration}"
+      window_hours: next %{count} hours
+      window_label: How far ahead to look
+      window_option: "%{count}h"
   plugins:
     index:
       title: 外掛功能
@@ -1040,6 +1050,7 @@ zh-HK:
       most_popular: 最受歡迎
       install: 安裝
       fork: 分叉
+      search_placeholder: 'Search eg: Comic'
   schedules:
     form:
       add: 加入自訂時間表
@@ -1672,6 +1683,13 @@ zh-HK:
     impersonator:
       managing: Managing %{name}
       back_to_my_account: Back to my account
+    search_bar:
+      min_characters: Type at least 3 characters to search
+      sort_by: 'Sort by:'
+      plugin_catalog_placeholder: Search plugins by name, description or category
+    search_summary:
+      found: "%{results} found for “%{query}”"
+      none: Nothing matches “%{query}”. Try a shorter word.
   account_invitations:
     show:
       title: You have been invited
@@ -1704,3 +1722,10 @@ zh-HK:
       body: "%{inviter} invited you to manage their TRMNL: its devices, playlists and plugins."
       accept: Accept the invitation
       expiry: This link will work for %{days} days.
+  pages:
+    flash_firmware:
+      linux_warning: Flashing from Linux often fails because Chrome can't open the serial port. Add your user to the dialout group (sudo usermod -aG dialout $USER), log out and back in, then retry. If that doesn't help, use Chrome or Edge on a Mac or Windows PC.
+      serial_failure:
+        guide_link: See the flashing mode guide
+        port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
+        reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.


### PR DESCRIPTION
Opened automatically from usetrmnl/core. These keys already ship in core's
`config/locales/pending.en.yml`, which shadows this gem's English until they land
here. Merging lets core drop its copy and lets translators pick the copy up.

Only additions — copy this repository already holds is left alone. The other
locales carry the new keys too, from this repository's own `bin/sync`.