### PR TITLE
Added the English keys core is waiting on

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -607,6 +607,7 @@ cs:
       revert_confirm: Opravdu chcete změny vrátit? Všechny neuložené změny budou ztraceny.
       save_changes: Uložit změny (⌘﹢S)
       separate_preview: Náhled je otevřen v samostatném okně
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Vaše proměnné
     no_merge_variables:
@@ -1039,6 +1040,8 @@ cs:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Žádost byla přijata, zkontrolujte svou e-mailovou schránku

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -608,6 +608,7 @@ da:
       revert_confirm: Er du sikker på, at du vil gendanne? Alle ikke-gemte ændringer vil gå tabt.
       save_changes: Gem ændringer (⌘﹢S)
       separate_preview: Forhåndsvisning er åben i et separat vindue
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Dine variabler
     no_merge_variables:
@@ -1040,6 +1041,8 @@ da:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Anmodning modtaget, tjek din indbakke

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -607,6 +607,7 @@ de-AT:
       revert_confirm: Wirklich rückgängig machen? Alle nicht gespeicherten Änderungen gehen verloren.
       save_changes: Speichern (⌘﹢S)
       separate_preview: Vorschau wird in separatem Fenster angezeigt
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Variablen
     no_merge_variables:
@@ -1039,6 +1040,8 @@ de-AT:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Anfrage erhalten, bitte Posteingang überprüfen

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -607,6 +607,7 @@ de:
       revert_confirm: Wirklich rückgängig machen? Alle nicht gespeicherten Änderungen gehen verloren.
       save_changes: Speichern (⌘﹢S)
       separate_preview: Vorschau wird in separatem Fenster angezeigt
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Variablen
     no_merge_variables:
@@ -1039,6 +1040,8 @@ de:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Anfrage erhalten, bitte Posteingang überprüfen

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -607,6 +607,7 @@ en-AU:
       revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
       save_changes: Save Changes (⌘﹢S)
       separate_preview: Preview is open in a separate window
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Your variables
     no_merge_variables:
@@ -1039,6 +1040,8 @@ en-AU:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -608,6 +608,7 @@ en-GB:
       revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
       save_changes: Save Changes (⌘﹢S)
       separate_preview: Preview is open in a separate window
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Your variables
     no_merge_variables:
@@ -1040,6 +1041,8 @@ en-GB:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -607,6 +607,7 @@ en:
       revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
       save_changes: Save Changes (⌘﹢S)
       separate_preview: Preview is open in a separate window
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Your variables
     no_merge_variables:
@@ -1039,6 +1040,8 @@ en:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -608,6 +608,7 @@ es-ES:
       revert_confirm: "¿Seguro que quieres revertir? Todos los cambios sin guardar se perderán."
       save_changes: Guardar cambios (⌘﹢S)
       separate_preview: La vista previa está abierta en una ventana separada
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Tus variables
     no_merge_variables:
@@ -1040,6 +1041,8 @@ es-ES:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Solicitud recibida, compruebe su bandeja de entrada

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -610,6 +610,7 @@ fr:
       revert_confirm: Êtes-vous sûr de vouloir annuler ? Toutes modifications non enregistrées seront perdues.
       save_changes: Enregistrer les modifications (⌘﹢S)
       separate_preview: L'aperçu est ouvert dans une fenêtre séparée
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Vos variables
     no_merge_variables:
@@ -1042,6 +1043,8 @@ fr:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Demande reçue, vérifiez votre boîte de réception

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -610,6 +610,7 @@ he:
       revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
       save_changes: Save Changes (⌘﹢S)
       separate_preview: Preview is open in a separate window
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Your variables
     no_merge_variables:
@@ -1042,6 +1043,8 @@ he:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -608,6 +608,7 @@ hu:
       revert_confirm: Biztosan vissza szeretnéd állítani? Minden nem mentett változtatás elvész.
       save_changes: Módosítások mentése (⌘﹢S)
       separate_preview: Az előnézet külön ablakban van megnyitva
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Saját változóid
     no_merge_variables:
@@ -1040,6 +1041,8 @@ hu:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Kérés fogadva, ellenőrizd az e-mail fiókodat

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -610,6 +610,7 @@ id:
       revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
       save_changes: Save Changes (⌘﹢S)
       separate_preview: Preview is open in a separate window
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Your variables
     no_merge_variables:
@@ -1042,6 +1043,8 @@ id:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -608,6 +608,7 @@ is:
       revert_confirm: Ertu viss? Allar óvistaðar breytingar munu tapast.
       save_changes: Vista breytingar (⌘﹢S)
       separate_preview: Forskoðun er opin í sér glugga
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Þínar breytur
     no_merge_variables:
@@ -1040,6 +1041,8 @@ is:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Beiðni móttekin, skoðaðu pósthólfið þitt

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -608,6 +608,7 @@ it:
       revert_confirm: Sei sicuro di voler annullare? Tutti i cambiamenti non salvati andranno persi.
       save_changes: Salva cambiamenti (⌘﹢S)
       separate_preview: L'anteprima è visualizzata in una finestra separata
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Le tue variabili
     no_merge_variables:
@@ -1040,6 +1041,8 @@ it:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Richiesta ricevuta, controlla la tua posta

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -608,6 +608,7 @@ ja:
       revert_confirm: 元に戻してもよろしいですか？保存されていない変更はすべて失われます。
       save_changes: 変更を保存 (⌘﹢S)
       separate_preview: Preview is open in a separate window
+      preview_layout: Preview layout
     merge_variables:
       your_variables: 変数
     no_merge_variables:
@@ -1040,6 +1041,8 @@ ja:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: リクエストを受信しました。受信箱を確認してください

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -608,6 +608,7 @@ ko:
       revert_confirm: 되돌릴까요? 저장하지 않은 변경사항이 모두 사라져요.
       save_changes: 저장하기 (⌘﹢S)
       separate_preview: 별도 창에서 미리보기가 열려 있어요
+      preview_layout: Preview layout
     merge_variables:
       your_variables: 내 변수
     no_merge_variables:
@@ -1040,6 +1041,8 @@ ko:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: 요청을 받았어요. 이메일을 확인해주세요

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -608,6 +608,7 @@ lt:
       revert_confirm: Ar tikrai norite sugrąžinti? Visi neišsaugoti pakeitimai bus prarasti.
       save_changes: Išsaugoti pakeitimus (⌘﹢S)
       separate_preview: Peržiūra atidaryta atskirame lange
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Jūsų kintamieji
     no_merge_variables:
@@ -1040,6 +1041,8 @@ lt:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Užklausa gauta, patikrinkite savo pašto dėžutę

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -608,6 +608,7 @@ nl:
       revert_confirm: Weet je zeker dat je wilt terugzetten? All niet-opgeslagen wijzigingen gaan verloren.
       save_changes: Wijzigingen opslaan (⌘﹢S)
       separate_preview: Preview is open in a separate window
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Jouw variabelen
     no_merge_variables:
@@ -1040,6 +1041,8 @@ nl:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Request ontvangen, check je inbox

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -608,6 +608,7 @@
       revert_confirm: Er du sikker på at du vil angre? Alle uspurte endringer vil gå tapt.
       save_changes: Lagre endringer (⌘﹢S)
       separate_preview: Preview is open in a separate window
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Dine variabler
     no_merge_variables:
@@ -1040,6 +1041,8 @@
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Forespørsel mottatt, sjekk innboksen din

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -630,6 +630,7 @@ pl:
       revert_confirm: Na pewno chcesz cofnąć? Wszystkie niezapisane zmiany zostaną utracone.
       save_changes: Zapisz zmiany (⌘﹢S / Ctrl + S)
       separate_preview: Podgląd wyświetla się w osobnym oknie
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Twoje zmienne
     no_merge_variables:
@@ -1062,6 +1063,8 @@ pl:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Zgłoszenie przyjęte, sprawdź swoją skrzynkę odbiorczą

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -608,6 +608,7 @@ pt-BR:
       revert_confirm: Tem certeza que deseja reverter? Todas as mudanças não salvas serão perdidas.
       save_changes: Salvar (⌘﹢S)
       separate_preview: Pré-visualização aberta em janela separada
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Suas variáveis
     no_merge_variables:
@@ -1040,6 +1041,8 @@ pt-BR:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Pedido recebido, verifique sua caixa de entrada

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -608,6 +608,7 @@ raw:
       revert_confirm: markups.form.revert_confirm
       save_changes: markups.form.save_changes
       separate_preview: markups.form.separate_preview
+      preview_layout: markups.form.preview_layout
     merge_variables:
       your_variables: markups.merge_variables.your_variables
     no_merge_variables:
@@ -1040,6 +1041,8 @@ raw:
       one: plugin_settings.delete_mashup_warning.one
       other: plugin_settings.delete_mashup_warning.other
     state_cleared: plugin_settings.state_cleared
+    index:
+      no_plugin_settings_found: plugin_settings.index.no_plugin_settings_found
   referral_code:
     create:
       request_received: referral_code.create.request_received

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -608,6 +608,7 @@ ro:
       revert_confirm: Ești sigur că vrei să revertezi? Toate modificările nesalvate vor fi pierdute.
       save_changes: Salvează modificările (⌘﹢S)
       separate_preview: Previzualizarea este deschisă într-o fereastră separată
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Variabilele tale
     no_merge_variables:
@@ -1040,6 +1041,8 @@ ro:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Cerere primită, verifică inbox-ul

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -630,6 +630,7 @@ ru:
       revert_confirm: Вы уверены, что хотите отменить? Все несохраненные изменения будут потеряны.
       save_changes: Сохранить изменения (⌘﹢S)
       separate_preview: Предпросмотр открыт в отдельном окне
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Ваши переменные
     no_merge_variables:
@@ -1062,6 +1063,8 @@ ru:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Запрос получен, проверьте свой почтовый ящик

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -619,6 +619,7 @@ sk:
       revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
       save_changes: Save Changes (⌘﹢S)
       separate_preview: Preview is open in a separate window
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Your variables
     no_merge_variables:
@@ -1051,6 +1052,8 @@ sk:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -608,6 +608,7 @@ sv:
       revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
       save_changes: Save Changes (⌘﹢S)
       separate_preview: Preview is open in a separate window
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Your variables
     no_merge_variables:
@@ -1040,6 +1041,8 @@ sv:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -630,6 +630,7 @@ uk:
       revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
       save_changes: Save Changes (⌘﹢S)
       separate_preview: Preview is open in a separate window
+      preview_layout: Preview layout
     merge_variables:
       your_variables: Your variables
     no_merge_variables:
@@ -1062,6 +1063,8 @@ uk:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -643,6 +643,7 @@ zh-CN:
       revert_confirm: 确定要还原吗？所有未保存的更改都将丢失。
       save_changes: 保存更改（⌘﹢S）
       separate_preview: 预览已在单独窗口中打开
+      preview_layout: Preview layout
     merge_variables:
       your_variables: 您的变量
     no_merge_variables:
@@ -1075,6 +1076,8 @@ zh-CN:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: 已收到请求，请查收邮箱

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -608,6 +608,7 @@ zh-HK:
       revert_confirm: 確定要還原嗎？所有未儲存的變更將會遺失。
       save_changes: 儲存變更 (⌘﹢S)
       separate_preview: 預覽已在獨立視窗開啟
+      preview_layout: Preview layout
     merge_variables:
       your_variables: 變數
     no_merge_variables:
@@ -1040,6 +1041,8 @@ zh-HK:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.
     state_cleared: Saved state cleared. The next refresh starts from scratch.
+    index:
+      no_plugin_settings_found: You have not set up this plugin yet.
   referral_code:
     create:
       request_received: 已收到請求，請查看收件箱


### PR DESCRIPTION
Opened automatically from usetrmnl/core. These keys already ship in core's
`config/locales/pending`, which shadows this gem's English until they land
here. Merging lets core drop its copy and lets translators pick the copy up.

Only additions — copy this repository already holds is left alone. The other
locales carry the new keys too, from this repository's own `bin/sync`.