### PR TITLE
Removed the web UI copy core stopped reading

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -12,7 +12,6 @@ cs:
   back: Zpět
   back_to_all_blog_posts: Zpět na všechny příspěvky
   blog: Blog
-  brand: Značka
   buy_now: Koupit nyní
   cancel: Zrušit
   change_password: Změnit heslo
@@ -26,15 +25,11 @@ cs:
   copy: Kopírovat
   copied_to_clipboard: Zkopírováno!
   copy_to_clipboard: Zkopírovat do schránky
-  created: Vytvořeno
   create_an_account: Vytvořit účet
   current_device: Aktuální zařízení
-  days: dní
   delete: Smazat
   developers: Vývojáři
   developer_edition_required: Pro povolení této funkce je vyžadována edice Developer.
-  device_id: ID zařízení
-  device: Zařízení
   discard: Zahodit
   edit: Upravit
   email_address: E-mailová adresa
@@ -45,7 +40,6 @@ cs:
   forgot_password_title: A je to tu zas
   friendly_id: Friendly ID
   get_started: Jdeme na to!
-  hidden: skryté
   identify: Identifikovat
   import: Importovat
   import_new: Importovat nové
@@ -59,32 +53,23 @@ cs:
   log_out: Odhlásit se
   manage: Spravovat
   minimum_characters: znaků minimálně
-  mins: min
-  my_playlist: Můj playlist
   new_password: Nové heslo
   password: Heslo
-  please_wait: Čekejte prosím...
   plugin_not_found: Plugin nenalezen
   preview: Náhled
-  privacy: Soukromí
-  refresh_rate: Obnovovací frekvence
   refresh_rates_hint: Jak funguje obnovovací frekvence zjistíte __zde__.
   reset_password: Obnovit moje heslo
   reset_to_defaults: Obnovit výchozí
   required: Povinné
   save: Uložit
-  shown: zobrazeno
   section: Sekce
   settings: Nastavení
   sign_in: Přihlásit se
   sign_up: Registrovat se
   something_went_wrong: Něco se pokazilo
   status: Stav
-  subscribe: Odebírat
   help_center: Podpora
-  terms: Podmínky
   unsaved_changes: Máte neuložené změny
-  update: Aktualizovat
   view: Zobrazit
   collaboration_request: Chcete spolupracovat?
   collaboration_request_hint: Partnerství, skupinový prodej, speciální projekty – je to na vás.
@@ -153,9 +138,6 @@ cs:
       refer_and_earn_hint: Darujte TRMNL s personalizovaným kupónem. Získejte odměnu za každé použití, vyplácenou měsíčně.
       refer_and_earn_redemptions: Uplatnění
       refer_and_earn_request_code: Požádat o kód
-      device_invoice: Faktura za zařízení
-      device_invoice_label: Stáhněte si účetní doklady pro svého účetního nebo vaši sbírku PDF.
-      device_invoice_hint: Najdete na stránce sledování zásilky nebo v e-mailu o odeslání.
       email_address_hint: Používá se k přihlášení do TRMNL a přijímání systémových zpráv.
       first_name_hint: Vaše jméno používáme k přizpůsobení rozhraní TRMNL.
       last_name_hint: Vaše příjmení používáme k přizpůsobení rozhraní TRMNL.
@@ -234,13 +216,7 @@ cs:
   dashboard:
     index:
       title: Nástěnka
-      last_7_days: Posledních 7 dní
-      last_30_days: Posledních 30 dní
-      last_90_days: Posledních 90 dní
-      today: Dnes
-      yesterday: Včera
     health:
-      bad: Pluginy mají problémy
       good: Pluginy fungují správně
       next_steps: Budeme vás informovat, pokud se cokoli změní
     news:
@@ -257,14 +233,9 @@ cs:
       new_and_popular: Nové a populární
     shop:
       title: Obchod
-      need_another: Potřebujete další TRMNL?
     time_saved:
       title: Ušetřený čas
-      cta: Číst o
     discover_callout:
-      manage_persona: Spravovat personu
-      dismiss: Skrýt
-    saved_discovery_setup:
       manage_persona: Spravovat personu
     welcome_message:
       morning_salutation: Dobré ráno
@@ -277,7 +248,6 @@ cs:
     edit:
       accepts_beta_firmware: Předběžné verze firmwaru
       accepts_beta_firmware_hint: Zapněte pro získání nejnovějších vylepšení firmwaru před ostatními uživateli.
-      back_to_devices: Zpět na zařízení
       battery_and_sleep: Baterie a spánek
       battery_consumption: Spotřeba baterie
       battery_consumption_hint: Šetřete energii a užijte si delší výdrž baterie povolením režimu spánku.
@@ -299,7 +269,6 @@ cs:
       device_model_switch_warning: Toto je nebezpečná operace, dozvíte se více __zde__
       device_info: Informace o zařízení
       current_firmware: Aktuální firmware
-      last_ping: Poslední ping
       unknown: Neznámý
       never: Nikdy
       display_calibration: Kalibrace displeje
@@ -345,7 +314,6 @@ cs:
       ota_byod_not_supported: OTA není podporována pro BYOD zařízení. Nahrajte kompatibilní verzi přímo z trmnl.com/flash
       maximum_compatibility: Povolit maximální kompatibilitu
       maximum_compatibility_hint: Řeší problémy se zobrazením způsobené některými čipy ovladačů ePaper. Zakáže rychlé obnovení. Vyžadován firmware 1.6.0+.
-      color_and_rotation: Barvy a otočení
       image_rotation: Otočení obrázku
       screen_rotation: Otočení obrazovky
       screen_rotation_not_supported: Otočení obrazovky není na vašem zařízení aktuálně podporováno.
@@ -367,9 +335,7 @@ cs:
       tidbyt_credentials: Přihlašovací údaje Tidbyt
       tidbyt_credentials_hint: Zadejte API přihlašovací údaje svého zařízení Tidbyt z aplikace Tidbyt v části Nastavení → Vývojář → Získat API klíč.
       tidbyt_api_key: API klíč Tidbyt
-      tidbyt_credentials_invalid: API přihlašovací údaje Tidbyt jsou neplatné. Zkontrolujte je a zkuste to znovu.
       tidbyt_device_id: ID zařízení
-      tidbyt_device_api_key: API klíč
       unlink: Odpojit
       unlink_confirm: Jste si jistí? Pokračujte pouze v případě, že toto zařízení předáváte někomu jinému nebo přecházíte na BYOS. Odpárování smaže veškerá nastavení pluginů a položky playlistu. Při řešení problémů kontaktujte podporu na help.trmnl.com.
       unlink_device: Odpojit zařízení
@@ -377,7 +343,6 @@ cs:
       unlink_device_learn_more: Postupujte podle kompletního průvodce __zde__.
       visibility: Viditelnost
       visibility_hint: Změňte nastavení níže, aby bylo vaše zařízení TRMNL zrcadlitelné.
-      your_device: Váš TRMNL
       upgrade_og:
         title: K dispozici je upgrade na 2bitový displej
         sub_title: Vaše zařízení lze upgradovat na podporu vylepšených stupňů šedi se 4 úrovněmi barev namísto 2.
@@ -414,9 +379,6 @@ cs:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ cs:
     index:
       title: Zařízení
       tagline: Vaše zařízení TRMNL
-      add_device_modal_title: Přidat nové zařízení
       add_first_device: Začněte přidáním svého prvního zařízení!
       go_to_settings: Přejít do nastavení
       clear_playlist: Vyprázdnit playlist
@@ -515,9 +476,6 @@ cs:
     dissociate:
       error: Chyba při odpojování zařízení
       success: Zařízení úspěšně odpojeno
-    external_credentials:
-      error: Neplatné přihlašovací údaje zařízení
-      success: Přihlašovací údaje zařízení úspěšně aktualizovány
     identify:
       error: Chyba při aktualizaci zařízení
       success: Identifikace zařízení vyžádána
@@ -556,16 +514,11 @@ cs:
         title: Nastavte personu pro %{device_label}
         subtext: Odpovězte na několik otázek, aby doporučení odpovídala roli tohoto zařízení TRMNL.
         primary_label: Nastavit personu
-  invoices:
-    rate_limit: Příliš mnoho pokusů, počkejte prosím a zkuste to znovu
-    invoice_not_found: Faktura nenalezena
   logs:
     index:
       title: Protokoly
       all: Vše
-      bulk_destroy: Hromadně smazat
       dump: Message
-      id: ID
       private_plugins: Soukromé pluginy
       source: Zdroj
       time: Time (UTC)
@@ -600,9 +553,6 @@ cs:
       live_preview: Živý náhled
       no_changes_to_save: Žádné změny k uložení
       pop_out_preview: Otevřít náhled v novém okně
-      quickstart_examples: Příklady pro rychlý start
-      quickstart_example_applied: Aplikováno!
-      quickstart_use_this_example: Použít tento příklad
       revert: Obnovit původní
       revert_confirm: Opravdu chcete změny vrátit? Všechny neuložené změny budou ztraceny.
       save_changes: Uložit změny (⌘﹢S)
@@ -666,9 +616,6 @@ cs:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: Personu můžete kdykoli nastavit nebo změnit v nastavení zařízení.
   mfa:
     disable_otp:
       success: 2FA vypnuto
@@ -694,21 +641,12 @@ cs:
   playlist_items:
     index:
       title: Playlist
-      tagline: Vyberte, co se zobrazí na
-      add_a_group: Přidat skupinu
-      add_a_plugin: Přidat plugin
       add_first_device_cta: Začněte __přidáním__ svého prvního zařízení TRMNL!
       add_to_playlist: Přidat do playlistu
-      create_first_playlist_cta: Vytvořte si svůj playlist po __připojení__ prvního pluginu!
       custom: Vlastní
       device_default: Výchozí zařízení
-      display_period_from: Zobrazovat od
-      display_period_to: do
       display_period_validation: Počáteční čas musí být před koncovým časem. Pro překlenutí nočních hodin vytvořte další skupinu.
-      every: Každý
       never_skip: Nikdy nepřeskakovat obrazovky
-      smart_playlist: Chytrý playlist
-      smart_playlist_hint: Automaticky přeskakovat obrazovky, jejichž obsah se již nějakou dobu nezměnil.
       skip_after:
         one: Přeskočit zastaralé obrazovky po 1 dni
         other: Přeskočit zastaralé obrazovky po %{count} dnech
@@ -746,9 +684,6 @@ cs:
       duplicate: Duplikovat
       duplicate_confirm: Tímto vytvoříte kopii této položky a přidáte ji na konec svého playlistu. Pokračovat?
       presentation: Prezentace
-      color_palette: Paleta barev
-      device_default: Výchozí zařízení (%{name})
-      palette_unavailable: K dispozici pouze pro zařízení s více paletami barev
       refresh_rate_disabled:
         default: Obnovovací frekvenci tohoto pluginu nelze konfigurovat.
         external: Tento plugin načítá data za chodu, takže nastavení obnovovací frekvence neplatí.
@@ -765,7 +700,6 @@ cs:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Aktualizace playlistu se nezdařila
       success: Playlist aktualizován
     destroy:
       error: Chyba při odebrání položky z playlistu
@@ -778,8 +712,6 @@ cs:
       success: Pořadí playlistu aktualizováno
     set_preferences:
       success: Předvolba Chytrého playlistu aktualizována
-    update:
-      success: Pořadí playlistu aktualizováno
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -810,23 +742,10 @@ cs:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -834,8 +753,6 @@ cs:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -846,9 +763,6 @@ cs:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -864,7 +778,6 @@ cs:
     index:
       title: Pluginy
       tagline: Co si dáte na svůj TRMNL?
-      available: Dostupné
       connected: Připojené
       supported_by_this_device: Podporováno tímto zařízením
       recipes: Recepty
@@ -876,7 +789,6 @@ cs:
         title: Moje pluginy
         tagline: Vyvíjejte pluginy pro veřejný trh
       card:
-        connections: připojení
         install: Nainstalovat
         review_are_you_sure: Jste si jistí? Tým TRMNL jej otestuje a případné dotazy vám zašle e-mailem.
         submit_for_review: Odeslat ke kontrole
@@ -906,16 +818,11 @@ cs:
     edit:
       title: Upravit plugin
       tagline: Aktualizujte podrobnosti o svém pluginu.
-      name: Název
-      description: Popis
   plugin_recipes:
     connected: Recept připojen
     connections:
       one: Připojení
       other: Připojení
-    forks:
-      one: Fork
-      other: Forky
     forked: Recept forknut
     new:
       error: Recept nenalezen
@@ -923,18 +830,14 @@ cs:
       more_by_author: Další od tohoto autora
       view_all: Zobrazit vše
   plugin_settings:
-    active: Aktivní
     copy_are_you_sure: Opravdu chcete toto nastavení zkopírovat?
     delete_are_you_sure: Opravdu chcete toto nastavení smazat?
     delete: Tímto zcela odstraníte nastavení pluginu. Chcete-li tento plugin ze zařízení pouze skrýt, smažte jej raději ze svého playlistu.
-    inactive: Neaktivní
     no_matches_found: Vašim filtrům neodpovídají žádné pluginy.
-    no_plugin_settings_found: Nebyla nalezena žádná nastavení pluginu.
     not_supported: Na aktuálním zařízení není podporováno
     refreshing_now_please_wait: Nyní probíhá obnovení, načtěte tuto stránku znovu za několik sekund.
     reset_credentials: Účet %{plugin_name} byl úspěšně obnoven
     form:
-      active_hint: Zobrazit nebo skrýt tuto instanci pluginu na vašem zařízení
       advanced_settings: Pokročilá nastavení
       back_to_playlist: Zpět do playlistu
       back_to_plugin: Zpět na %{plugin}
@@ -956,15 +859,7 @@ cs:
       health_notifications_hint: Dostávejte e-mail, když se stav tohoto pluginu změní na zhoršený nebo chybový. Obdržíte maximálně jeden e-mail na stav a incident; výstrahy se znovu aktivují, jakmile se plugin vrátí do bezchybného stavu.
       health_notifications_checkbox: Poslat e-mail, pokud se tento plugin stane nefunkčním
       learn_more: Další informace o tomto pluginu najdete v naší znalostní bázi
-      learn_more_fork: Tento plugin byl vytvořen forknutím z Receptu.
-      learn_more_fork_original: Zobrazit originál
-      learn_more_native_long: Tento plugin je nativní a je spravován společností TRMNL.
-      learn_more_native_short: Tento plugin je spravován společností TRMNL.
       learn_more_recipe_author: Potřebujete pomoc? Kontaktujte uživatele %{recipe_author} na Discordu.
-      learn_more_recipe_long: Tento plugin je komunitní Recept a není spravován společností TRMNL.
-      learn_more_recipe_short: 'Poznámka: tento plugin je Recept.'
-      learn_more_third_party_long: Tento plugin pochází od 3. strany a není spravován společností TRMNL.
-      learn_more_third_party_short: 'Poznámka: tento plugin pochází od 3. strany.'
       linked_account: Propojený účet
       linked_account_success: Úspěšně propojeno s %{plugin_name}
       link_oauth: Propojit účet
@@ -986,7 +881,6 @@ cs:
       recipe_cta_body_published: Změny se projeví u stávajících instalací i budoucích instalací/forků.
       recipe_cta_body_in_review: Tento plugin byl odeslán našemu týmu. Počkejte prosím.
       recipe_cta_body_not_published: Odeslat tento plugin, aby si jej mohli nainstalovat i ostatní. __Dozvědět se více__.
-      recipe_cta_confirm: Jste si jistí? Náš tým jej zkontroluje a během několika dní se vám ozve. V provádění změn můžete pokračovat.
       recipe_mirrored: Tato obrazovka je zrcadlena z receptu.
       recipe_visibility_title: Jak si přejete publikovat?
       recipe_visibility_edit_title: Upravit odeslaný plugin
@@ -997,8 +891,6 @@ cs:
       recipe_visibility_unlisted: Nezařazené
       recipe_visibility_unlisted_hint: Nainstalovat může kdokoli, kdo má odkaz.
       refresh_rate: Obnovovací frekvence
-      refresh_rate_hint: Určete, jak často tato instance pluginu načítá čerstvá data
-      refresh_rate_jit_hint: Tento plugin se automaticky obnovuje podle potřeby. Více se dozvíte __zde__.
       refresh_rate_not_configurable: Synchronizuje se %{refresh_rate} (nelze konfigurovat)
       refreshed: Obnoveno
       remove_plugin: Odstranit plugin
@@ -1055,10 +947,8 @@ cs:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Přidat vlastní rozvrh
       append: A během…
       no_schedule: Tato obrazovka se bude zobrazovat neustále.
-      some_schedule: Zobrazovat tuto obrazovku pouze během…
       to: do
       copy_prompt: Kopírovat rozvrh z…
       no_days_error: Vyberte prosím alespoň jeden den.
@@ -1084,11 +974,6 @@ cs:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1617,7 +1502,6 @@ cs:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -12,7 +12,6 @@ da:
   back: Tilbage
   back_to_all_blog_posts: Tilbage til alle indlæg
   blog: Blog
-  brand: Brand
   buy_now: Køb nu
   cancel: Annuller
   change_password: Skift adgangskode
@@ -26,15 +25,11 @@ da:
   copy: Kopier
   copied_to_clipboard: Kopieret!
   copy_to_clipboard: Kopier til udklipsholder
-  created: Oprettet
   create_an_account: Opret en konto
   current_device: Nuværende enhed
-  days: dage
   delete: Slet
   developers: Developers
   developer_edition_required: Udviklerudgave kræves for at aktivere denne funktion.
-  device_id: Enheds-ID
-  device: Enhed
   discard: Discard
   edit: Rediger
   email_address: Mailadresse
@@ -45,7 +40,6 @@ da:
   forgot_password_title: Her går vi igen
   friendly_id: Friendly ID
   get_started: Lad os få dig i gang!
-  hidden: hidden
   identify: Identificer
   import: Importer
   import_new: Importer ny
@@ -59,32 +53,23 @@ da:
   log_out: Log ud
   manage: Administrer
   minimum_characters: minimum tegn
-  mins: min
-  my_playlist: Min playliste
   new_password: Ny adgangskode
   password: Adgangskode
-  please_wait: Vent venligst...
   plugin_not_found: Plugin ikke fundet
   preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
   refresh_rates_hint: Lær hvordan opdateringshastigheder fungerer __her__.
   reset_password: Nulstil min adgangskode
   reset_to_defaults: Reset to defaults
   required: Required
   save: Gem
-  shown: shown
   section: Sektion
   settings: Indstillinger
   sign_in: Log ind
   sign_up: Tilmeld
   something_went_wrong: Noget gik galt
   status: Status
-  subscribe: Abonner
   help_center: Support
-  terms: Terms
   unsaved_changes: You have unsaved changes
-  update: Opdater
   view: Vis
   collaboration_request: Wanna collaborate?
   collaboration_request_hint: Partnerships, group sales, special projects, your call.
@@ -153,9 +138,6 @@ da:
       refer_and_earn_hint: Giv TRMNL som gave med en personlig kupon. Tjen pr. brug, betalt månedligt.
       refer_and_earn_redemptions: Indløsninger
       refer_and_earn_request_code: Anmod om en kode
-      device_invoice: Enhedsfaktura
-      device_invoice_label: Download kommercielle dokumenter til din revisor eller PDF-samling.
-      device_invoice_hint: Find dette på din pakkesporingsside eller i forsendelses e-mail.
       email_address_hint: Bruges til at logge ind på TRMNL og modtage systembeskeder.
       first_name_hint: Vi bruger dit navn til at gøre TRMNL-grænsefladen mere personlig.
       last_name_hint: Vi bruger dit navn til at gøre TRMNL-grænsefladen mere personlig.
@@ -234,13 +216,7 @@ da:
   dashboard:
     index:
       title: Dashboard
-      last_7_days: Sidste 7 dage
-      last_30_days: Sidste 30 dage
-      last_90_days: Sidste 90 dage
-      today: I dag
-      yesterday: I går
     health:
-      bad: Plugins oplever problemer
       good: Plugins fungerer korrekt
       next_steps: Vi vil informere dig, hvis noget ændrer sig
     news:
@@ -257,14 +233,9 @@ da:
       new_and_popular: Nye og populære
     shop:
       title: Butik
-      need_another: Har du brug for en anden TRMNL?
     time_saved:
       title: Tid sparet
-      cta: Læs om
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Godmorgen
@@ -277,7 +248,6 @@ da:
     edit:
       accepts_beta_firmware: Firmware Tidlig Udgivelse
       accepts_beta_firmware_hint: Slå til for at få de nyeste firmwareforbedringer før andre brugere.
-      back_to_devices: Tilbage til enheder
       battery_and_sleep: Battery & Sleep
       battery_consumption: Batteriforbrug
       battery_consumption_hint: Spar strøm og forlæng batterilevetiden ved at aktivere dvaletilstand.
@@ -299,7 +269,6 @@ da:
       device_model_switch_warning: Dette er en risikabel handling, læs mere __her__
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -345,7 +314,6 @@ da:
       ota_byod_not_supported: OTA understøttes ikke for BYOD-enheder. Flash en kompatibel version direkte fra trmnl.com/flash
       maximum_compatibility: Aktivér maksimal kompatibilitet
       maximum_compatibility_hint: Løser visningsproblemer forårsaget af visse ePaper driverchips. Deaktiverer hurtig opdatering. Firmware 1.6.0+ kræves.
-      color_and_rotation: Farve og rotation
       image_rotation: Image Rotation
       screen_rotation: Skærmrotation
       screen_rotation_not_supported: Skærmrotation er ikke understøttet på din enhed.
@@ -367,9 +335,7 @@ da:
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
       unlink: Fjern tilknytning
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Fjern tilknytning til enhed
@@ -377,7 +343,6 @@ da:
       unlink_device_learn_more: Følg den fulde guide __her__.
       visibility: Synlighed
       visibility_hint: Gør din TRMNL-enhed spejlbar ved at ændre indstillingerne nedenfor.
-      your_device: Din TRMNL
       upgrade_og:
         title: Opgradering til 2-bit Display tilgængelig
         sub_title: Din enhed kan opgraderes til forbedret gråtonedisplay med 4 farveniveauer i stedet for 2.
@@ -414,9 +379,6 @@ da:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ da:
     index:
       title: Enheder
       tagline: Dine TRMNL-enheder
-      add_device_modal_title: Tilføj en ny enhed
       add_first_device: Start med at tilføje din første enhed!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -516,9 +477,6 @@ da:
     dissociate:
       error: Fejl ved frakobling af enhed
       success: Enhed frakoblet med succes
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: Fejl ved opdatering af enhed
       success: Enhedsidentifikation anmodet
@@ -557,16 +515,11 @@ da:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: For mange forsøg, vent venligst og prøv igen
-    invoice_not_found: Faktura ikke fundet
   logs:
     index:
       title: Logfiler
       all: Alle
-      bulk_destroy: Bulk Destroy
       dump: Message
-      id: ID
       private_plugins: Private plugins
       source: Kilde
       time: Time (UTC)
@@ -601,9 +554,6 @@ da:
       live_preview: Live forhåndsvisning
       no_changes_to_save: Ingen ændringer at gemme
       pop_out_preview: Pop-out forhåndsvisning
-      quickstart_examples: Hurtigstart-eksempler
-      quickstart_example_applied: Anvendt!
-      quickstart_use_this_example: Brug dette eksempel
       revert: Gendan
       revert_confirm: Er du sikker på, at du vil gendanne? Alle ikke-gemte ændringer vil gå tabt.
       save_changes: Gem ændringer (⌘﹢S)
@@ -667,9 +617,6 @@ da:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA deaktiveret
@@ -695,21 +642,12 @@ da:
   playlist_items:
     index:
       title: Playliste
-      tagline: Vælg hvad der vises på
-      add_a_group: Tilføj en gruppe
-      add_a_plugin: Tilføj et plugin
       add_first_device_cta: Start med at __tilføje__ din første TRMNL-enhed!
       add_to_playlist: Tilføj til playliste
-      create_first_playlist_cta: Opret din playliste efter __tilslutning__ af dit første plugin!
       custom: Brugerdefineret
       device_default: Enhedsstandard
-      display_period_from: Vis fra
-      display_period_to: til
       display_period_validation: Starttidspunkt skal være før sluttidspunkt. Opret en ny gruppe for at dække over midnat.
-      every: Hver
       never_skip: Spring aldrig skærme over
-      smart_playlist: Smart playliste
-      smart_playlist_hint: Spring automatisk skærme over, hvis indholdet ikke har ændret sig i et stykke tid.
       skip_after:
         one: Spring forældede skærme over efter 1 dag
         other: Spring forældede skærme over efter %{count} dage
@@ -747,9 +685,6 @@ da:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -766,7 +701,6 @@ da:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Fejl ved opdatering af playliste
       success: Playliste opdateret
     destroy:
       error: Fejl ved fjernelse af element fra playliste
@@ -779,8 +713,6 @@ da:
       success: Playliste rækkefølge opdateret
     set_preferences:
       success: Smart playliste præference opdateret
-    update:
-      success: Playlistens rækkefølge opdateret
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -811,23 +743,10 @@ da:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -835,8 +754,6 @@ da:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -847,9 +764,6 @@ da:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -865,7 +779,6 @@ da:
     index:
       title: Plugins
       tagline: Hvad vil du sætte på din TRMNL?
-      available: Tilgængelig
       connected: Forbundet
       supported_by_this_device: Supported by this device
       recipes: Opskrifter
@@ -877,7 +790,6 @@ da:
         title: Mine Plugins
         tagline: Udvikl plugins til det offentlige marked
       card:
-        connections: Forbindelser
         install: Installer
         review_are_you_sure: Er du sikker? TRMNL-teamet vil teste det og kontakte dig via e-mail, hvis der er spørgsmål.
         submit_for_review: Indsend til gennemgang
@@ -907,16 +819,11 @@ da:
     edit:
       title: Rediger plugin
       tagline: Opdater dine plugin-detaljer.
-      name: Navn
-      description: Beskrivelse
   plugin_recipes:
     connected: Opskrift tilsluttet
     connections:
       one: Forbindelse
       other: Forbindelser
-    forks:
-      one: Fork
-      other: Forks
     forked: Recipe forked
     new:
       error: Opskrift ikke fundet
@@ -924,18 +831,14 @@ da:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Aktiv
     copy_are_you_sure: Er du sikker på, at du vil kopiere denne indstilling?
     delete_are_you_sure: Er du sikker på, at du vil slette denne indstilling?
     delete: Dette vil fuldstændigt fjerne pluginets indstillinger. For blot at skjule pluginet fra din enhed, skal du slette det fra din playliste i stedet.
-    inactive: Inaktiv
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: Ingen plugin-indstillinger fundet.
     not_supported: Not supported on current device
     refreshing_now_please_wait: Opdaterer nu, genindlæs siden om et par sekunder.
     reset_credentials: "%{plugin_name} konto nulstillet med succes"
     form:
-      active_hint: Vis eller skjul denne plugin-instans på din enhed
       advanced_settings: Avancerede indstillinger
       back_to_playlist: Back to Playlist
       back_to_plugin: Tilbage til %{plugin}
@@ -957,15 +860,7 @@ da:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Læs om dette plugin i vores vidensbase
-      learn_more_fork: Dette plugin blev forgrenet fra en opskrift.
-      learn_more_fork_original: Se original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
       learn_more_recipe_author: Brug for hjælp? Kontakt %{recipe_author} på Discord.
-      learn_more_recipe_long: Dette plugin er en community-opskrift og vedligeholdes ikke af TRMNL.
-      learn_more_recipe_short: 'Bemærk: dette plugin er en opskrift.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       linked_account: Tilknyttet konto
       linked_account_success: Succesfuldt tilknyttet med %{plugin_name}
       link_oauth: Link konto
@@ -987,7 +882,6 @@ da:
       recipe_cta_body_published: Ændringer vil blive afspejlet på eksisterende og fremtidige installationer/forks.
       recipe_cta_body_in_review: Dette plugin er sendt til vores team. Vent venligst.
       recipe_cta_body_not_published: Indsend dette plugin, så andre kan installere det. __Læs mere__.
-      recipe_cta_confirm: Er du sikker? Vores team vil gennemgå det og vende tilbage inden for få dage. Du kan fortsætte med at foretage ændringer.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: How would you like to publish?
       recipe_visibility_edit_title: Edit Submission
@@ -998,8 +892,6 @@ da:
       recipe_visibility_unlisted: Unlisted
       recipe_visibility_unlisted_hint: Anyone with the link can install.
       refresh_rate: Opdateringshastighed
-      refresh_rate_hint: Definer hvor ofte denne plugin-instans henter friske data
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
       refreshed: Opdateret
       remove_plugin: Fjern plugin
@@ -1056,10 +948,8 @@ da:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Tilføj en brugerdefineret tidsplan
       append: Og under…
       no_schedule: Denne skærm vil altid blive vist.
-      some_schedule: Vis kun denne skærm under…
       to: til
       copy_prompt: Kopiér tidsplan fra…
       no_days_error: Please select at least one day.
@@ -1085,11 +975,6 @@ da:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1618,7 +1503,6 @@ da:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -12,7 +12,6 @@ de-AT:
   back: Zurück
   back_to_all_blog_posts: Zurück zu allen Posts
   blog: Blog
-  brand: Marke
   buy_now: Jetzt kaufen
   cancel: Abbrechen
   change_password: Passwort ändern
@@ -26,15 +25,11 @@ de-AT:
   copy: Kopieren
   copied_to_clipboard: Kopiert!
   copy_to_clipboard: In Zwischenablage kopieren
-  created: Erstellt
   create_an_account: Konto erstellen
   current_device: Aktuelles Gerät
-  days: Tage
   delete: Löschen
   developers: Entwickler
   developer_edition_required: Die TRMNL-Entwickler-Edition wird für dieses Feature benötigt.
-  device_id: Gerätekennung
-  device: Gerät
   discard: Verwerfen
   edit: Ändern
   email_address: E-Mail-Adresse
@@ -45,7 +40,6 @@ de-AT:
   forgot_password_title: Neues Passwort vergeben
   friendly_id: Friendly ID
   get_started: Lass uns loslegen!
-  hidden: versteckt
   identify: Identifizieren
   import: Importieren
   import_new: Neu importieren
@@ -59,32 +53,23 @@ de-AT:
   log_out: Abmelden
   manage: Verwalten
   minimum_characters: Zeichen Minimum
-  mins: Min
-  my_playlist: Meine Wiedergabeliste
   new_password: Neues Passwort
   password: Passwort
-  please_wait: Bitte warten …
   plugin_not_found: Erweiterung nicht gefunden
   preview: Vorschau
-  privacy: Datenschutz
-  refresh_rate: Aktualisierungsrate
   refresh_rates_hint: Weitere Informationen zur Aktualisierungsrate __hier__.
   reset_password: Passwort zurücksetzen
   reset_to_defaults: Auf Standard zurücksetzen
   required: Erforderlich
   save: Speichern
-  shown: angezeigt
   section: Abschnitt
   settings: Einstellungen
   sign_in: Anmelden
   sign_up: Registrieren
   something_went_wrong: Etwas ist schiefgegangen
   status: Status
-  subscribe: Abonnieren
   help_center: Hilfe
-  terms: AGB
   unsaved_changes: Du hast ungespeicherte Änderungen
-  update: Aktualisieren
   view: Ansicht
   collaboration_request: Lust zusammenzuarbeiten?
   collaboration_request_hint: Partnerschaften, Großabnahme, Sonderprojekte – ganz nach Bedarf.
@@ -153,9 +138,6 @@ de-AT:
       refer_and_earn_hint: Empfehle TRMNL mit einem personalisierten Code weiter. Verdiene Geld mit jeder Einlösung, monatlich ausgezahlt.
       refer_and_earn_redemptions: Einlösungen
       refer_and_earn_request_code: Empfehlungscode anfordern
-      device_invoice: Rechnungsdownload
-      device_invoice_label: Lade die Rechnung für den Kauf deines TRMNL als PDF herunter.
-      device_invoice_hint: Die Rechnungsnummer findest du auf der Statusseite der Sendungsverfolgung oder in der Versandstatus-E-Mail.
       email_address_hint: Wird für die TRMNL-Anmeldung und den Versand von wichtigen Benachrichtigungen verwendet.
       first_name_hint: Wir verwenden deinen Vornamen, um TRMNL zu personalisieren.
       last_name_hint: Wir verwenden deinen Namen, um TRMNL zu personalisieren.
@@ -234,13 +216,7 @@ de-AT:
   dashboard:
     index:
       title: Übersicht
-      last_7_days: Letzte 7 Tage
-      last_30_days: Letzte 30 Tage
-      last_90_days: Letzte 90 Tage
-      today: Heute
-      yesterday: Gestern
     health:
-      bad: Erweiterungen mit Einschränkungen
       good: Voll funktionsfähige Erweiterungen
       next_steps: Wir werden dich über Änderungen informieren
     news:
@@ -257,14 +233,9 @@ de-AT:
       new_and_popular: Neu und beliebt
     shop:
       title: Shop
-      need_another: Brauchst du noch einen TRMNL?
     time_saved:
       title: Eingesparte Zeit
-      cta: Mehr erfahren
     discover_callout:
-      manage_persona: Persona verwalten
-      dismiss: Ausblenden
-    saved_discovery_setup:
       manage_persona: Persona verwalten
     welcome_message:
       morning_salutation: Guten Morgen
@@ -277,7 +248,6 @@ de-AT:
     edit:
       accepts_beta_firmware: Beta-Firmware
       accepts_beta_firmware_hint: Aktiviere diese Option, um vor anderen Benutzern die neuesten Firmware-Updates für das Gerät zu erhalten.
-      back_to_devices: Zurück zur Geräteübersicht
       battery_and_sleep: Batterie & Schlafmodus
       battery_consumption: Batterieverbrauch
       battery_consumption_hint: Spare Strom und verlängere die Laufzeit durch Aktivierung des Schlafmodus.
@@ -299,7 +269,6 @@ de-AT:
       device_model_switch_warning: Diese Aktion kann gefährlich sein, erfahre __hier__ mehr darüber
       device_info: Geräteinformationen
       current_firmware: Aktuelle Firmware
-      last_ping: Letzter Ping
       unknown: Unbekannt
       never: Nie
       display_calibration: Bildschirmkalibrierung
@@ -345,7 +314,6 @@ de-AT:
       ota_byod_not_supported: OTA wird für BYOD-Geräte nicht unterstützt. Überspiele eine kompatible Version direkt unter trmnl.com/flash.
       maximum_compatibility: Maximale Kompatibilität aktivieren
       maximum_compatibility_hint: Behebt Anzeigefehler aufgrund bestimmter ePaper-Treiber-Chips. Deaktiviert schnelles Rendern. Benötigt Firmware 1.6.0+.
-      color_and_rotation: Farbe & Rotation
       image_rotation: Image Rotation
       screen_rotation: Bildschirmrotation
       screen_rotation_not_supported: Bildschirmrotation ist derzeit nicht auf deinem Gerät unterstützt.
@@ -367,9 +335,7 @@ de-AT:
       tidbyt_credentials: Tidbyt-Anmeldedaten
       tidbyt_credentials_hint: Gib hier die API-Zugangsdaten deines Tidbyt-Geräts ein (Einstellungen → Entwickler → API-Schlüssel in der Tidbyt-App).
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Ungültige Tidbyt-API-Zugangsdaten. Bitte prüfen und erneut versuchen.
       tidbyt_device_id: Geräte-ID
-      tidbyt_device_api_key: API-Schlüssel
       unlink: Entkoppeln
       unlink_confirm: Bist du sicher? Fahre nur fort, wenn du das Gerät an jemand anderen weitergibst oder zu BYOS wechselst. Das Trennen löscht alle Erweiterungseinstellungen und Wiedergabelisteneinträge. Bei Problemen wende dich an den Support unter help.trmnl.com.
       unlink_device: Gerät entkoppeln
@@ -377,7 +343,6 @@ de-AT:
       unlink_device_learn_more: __Hier__ gibt es die vollständige Anleitung dazu.
       visibility: Sichtbarkeit
       visibility_hint: Macht das TRMNL öffentlich sichtbar.
-      your_device: Dein TRMNL
       upgrade_og:
         title: Upgrade auf 2-bit-Anzeige verfügbar
         sub_title: Dein Gerät kann ein Upgrade erhalten und damit eine verbesserte Graustufendarstellung mit 4 anstelle von 2 Farbwerten unterstützen.
@@ -414,9 +379,6 @@ de-AT:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ de-AT:
     index:
       title: Geräte
       tagline: Deine TRMNL-Geräte
-      add_device_modal_title: Neues Gerät hinzufügen
       add_first_device: Beginne mit dem Hinzufügen deines ersten Gerätes!
       go_to_settings: Zu den Einstellungen
       clear_playlist: Wiedergabeliste leeren
@@ -515,9 +476,6 @@ de-AT:
     dissociate:
       error: Fehler beim Trennen des Gerätes
       success: Gerät erfolgreich getrennt
-    external_credentials:
-      error: Ungültige Gerätezugangsdaten
-      success: Gerätezugangsdaten erfolgreich aktualisiert
     identify:
       error: Fehler beim Identifizieren des Gerätes
       success: Geräteidentifizierung angefordert
@@ -556,16 +514,11 @@ de-AT:
         title: Persona für %{device_label} einrichten
         subtext: Beantworte ein paar Fragen, damit die Empfehlungen zum Einsatz dieses TRMNL passen.
         primary_label: Persona einrichten
-  invoices:
-    rate_limit: Zu viele Versuche, bitte warte kurz und versuche es noch einmal
-    invoice_not_found: Rechnung nicht gefunden
   logs:
     index:
       title: Log-Dateien
       all: Alle
-      bulk_destroy: Stapel-Löschen
       dump: Message
-      id: ID
       private_plugins: Private Erweiterungen
       source: Quelle
       time: Time (UTC)
@@ -600,9 +553,6 @@ de-AT:
       live_preview: Live-Vorschau
       no_changes_to_save: Keine Änderungen zum Speichern
       pop_out_preview: Vorschau in eigenem Fenster
-      quickstart_examples: Schnellstart-Beispiele
-      quickstart_example_applied: Angewendet!
-      quickstart_use_this_example: Dieses Beispiel verwenden
       revert: Rückgängig
       revert_confirm: Wirklich rückgängig machen? Alle nicht gespeicherten Änderungen gehen verloren.
       save_changes: Speichern (⌘﹢S)
@@ -666,9 +616,6 @@ de-AT:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: Du kannst deine Persona jederzeit in den Geräteeinstellungen einrichten oder ändern.
   mfa:
     disable_otp:
       success: 2FA abgeschaltet
@@ -694,21 +641,12 @@ de-AT:
   playlist_items:
     index:
       title: Wiedergabeliste
-      tagline: Was soll auf dem Gerät angezeigt werden?
-      add_a_group: Gruppe hinzufügen
-      add_a_plugin: Erweiterung hinzufügen
       add_first_device_cta: Beginne mit dem __Hinzufügen__ des ersten TRMNL-Gerätes!
       add_to_playlist: Zu Wiedergabeliste hinzufügen
-      create_first_playlist_cta: Erste Erweiterung __verbinden__, um eine Wiedergabeliste zu starten!
       custom: Angepasst
       device_default: Geräte-Standard
-      display_period_from: Anzeige von
-      display_period_to: bis
       display_period_validation: Startzeit muss vor der Endzeit liegen. Erstelle eine weitere Gruppe, um die Nachtstunden abzudecken.
-      every: Alle
       never_skip: Niemals Inhalte überspringen
-      smart_playlist: Intelligente Wiedergabeliste
-      smart_playlist_hint: Automatisch Inhalte überspringen, die sich seit einer Weile nicht verändert haben.
       skip_after:
         one: Alte Inhalte nach 1 Tag überspringen
         other: Alte Inhalte nach %{count} Tagen überspringen
@@ -746,9 +684,6 @@ de-AT:
       duplicate: Duplizieren
       duplicate_confirm: Es wird eine Kopie dieses Eintrags erstellt und am Ende der Wiedergabeliste hinzugefügt. Fortfahren?
       presentation: Presentation
-      color_palette: Farbpalette
-      device_default: Geräte-Standard (%{name})
-      palette_unavailable: Nur verfügbar für Geräte mit mehreren Farbpaletten
       refresh_rate_disabled:
         default: Die Aktualisierungsrate dieser Erweiterung kann nicht konfiguriert werden.
         external: Diese Erweiterung ruft Daten in Echtzeit ab, daher gelten keine Aktualisierungsraten-Einstellungen.
@@ -765,7 +700,6 @@ de-AT:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Fehler beim Aktualisieren der Wiedergabeliste
       success: Wiedergabeliste aktualisiert
     destroy:
       error: Fehler beim Entfernen von der Wiedergabeliste
@@ -778,8 +712,6 @@ de-AT:
       success: Wiedergabereihenfolge aktualisiert
     set_preferences:
       success: Einstellung zur intelligenten Wiedergabeliste aktualisiert
-    update:
-      success: Wiedergabereihenfolge aktualisiert
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -810,23 +742,10 @@ de-AT:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -834,8 +753,6 @@ de-AT:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -846,9 +763,6 @@ de-AT:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -864,7 +778,6 @@ de-AT:
     index:
       title: Erweiterungen
       tagline: Was soll auf dem TRMNL angezeigt werden?
-      available: Verfügbar
       connected: Verbunden
       supported_by_this_device: Supported by this device
       recipes: Blaupausen
@@ -876,7 +789,6 @@ de-AT:
         title: Meine Erweiterungen
         tagline: Entwickele Erweiterungen für den öffentlichen Marktplatz
       card:
-        connections: Verbindungen
         install: Installieren
         review_are_you_sure: Sicher? Das TRMNL-Team wird die Erweiterung prüfen und dir ggf. Fragen zumailen.
         submit_for_review: Zur Überprüfung einreichen
@@ -906,16 +818,11 @@ de-AT:
     edit:
       title: Erweiterung bearbeiten
       tagline: Aktualisiere Details deiner Erweiterung.
-      name: Name
-      description: Beschreibung
   plugin_recipes:
     connected: Blaupause verbunden
     connections:
       one: Verbindung
       other: Verbindungen
-    forks:
-      one: Fork
-      other: Forks
     forked: Blaupause geforkt
     new:
       error: Blaupause nicht gefunden
@@ -923,18 +830,14 @@ de-AT:
       more_by_author: Mehr von diesem Autor
       view_all: Alle anzeigen
   plugin_settings:
-    active: Aktiv
     copy_are_you_sure: Möchtest du diese Einstellung wirklich kopieren?
     delete_are_you_sure: Möchtest du diese Einstellung wirklich löschen?
     delete: Hiermit werden alle Einstellungen der Erweiterung vollständig entfernt. Um sie lediglich auszublenden, entferne sie von der Wiedergabeliste.
-    inactive: Inaktiv
     no_matches_found: Keine Erweiterungen entsprechen deinen Filtern.
-    no_plugin_settings_found: Keine Einstellungen für diese Erweiterung gefunden.
     not_supported: Aktuell für dieses Gerät nicht unterstützt
     refreshing_now_please_wait: Wird aktualisiert, bitte die Seite in ein paar Sekunden neu laden.
     reset_credentials: Konto-Reset von %{plugin_name} erfolgreich
     form:
-      active_hint: Anzeigen oder Verbergen der Erweiterung auf dem Gerät
       advanced_settings: Erweiterte Einstellungen
       back_to_playlist: Zurück zur Wiedergabeliste
       back_to_plugin: Zurück zu %{plugin}
@@ -956,15 +859,7 @@ de-AT:
       health_notifications_hint: Erhalte eine E-Mail, wenn sich der Zustand dieser Erweiterung auf „eingeschränkt“ oder „fehlerhaft“ ändert. Du erhältst maximal eine E-Mail pro Zustand und Vorfall; Benachrichtigungen werden erst wieder aktiviert, sobald die Erweiterung wieder funktionsfähig ist.
       health_notifications_checkbox: Per E-Mail benachrichtigen, wenn diese Erweiterung nicht mehr funktionsfähig ist
       learn_more: Mehr Informationen zur Erweiterung in unserer Wissensdatenbank
-      learn_more_fork: Diese Erweiterung ist von einer Blaupause geforkt worden.
-      learn_more_fork_original: Original aufrufen
-      learn_more_native_long: Dies ist eine offizielle Erweiterung, die von TRMNL gewartet wird.
-      learn_more_native_short: Diese Erweiterung wird von TRMNL gewartet.
       learn_more_recipe_author: Hilfe benötigt? Kontaktiere %{recipe_author} auf Discord.
-      learn_more_recipe_long: Diese Erweiterung ist eine Community-Blaupause und wird nicht von TRMNL gewartet.
-      learn_more_recipe_short: 'Hinweis: Diese Erweiterung ist eine Blaupause.'
-      learn_more_third_party_long: Diese Erweiterung stammt von einem Drittanbieter und wird nicht von TRMNL gewartet.
-      learn_more_third_party_short: 'Hinweis: Diese Erweiterung stammt von einem Drittanbieter.'
       linked_account: Verbundener Account
       linked_account_success: Erfolgreich verbunden mit %{plugin_name}
       link_oauth: Konto verknüpfen
@@ -986,7 +881,6 @@ de-AT:
       recipe_cta_body_published: Änderungen werden sich auf aktuelle und zukünftige Installationen/Forks auswirken.
       recipe_cta_body_in_review: Diese Erweiterung wurde an unser Team übermittelt. Danke für deine Geduld!
       recipe_cta_body_not_published: Reiche diese Erweiterung ein, damit sie auch andere installieren können. __Mehr erfahren__.
-      recipe_cta_confirm: Bist du sicher? Unser Team wird sich in einigen Tagen nach erfolgter Prüfung zurückmelden. Du kannst weiterhin Änderungen vornehmen.
       recipe_mirrored: Diese Anzeige ist eine Spiegelung der Blaupause.
       recipe_visibility_title: Wie möchtest du veröffentlichen?
       recipe_visibility_edit_title: Einreichung bearbeiten
@@ -997,8 +891,6 @@ de-AT:
       recipe_visibility_unlisted: Nicht gelistet
       recipe_visibility_unlisted_hint: Jeder mit dem Link kann installieren.
       refresh_rate: Aktualisierungsrate
-      refresh_rate_hint: Definiere, wie oft die Erweiterung Daten aktualisiert
-      refresh_rate_jit_hint: Diese Erweiterung aktualisiert sich automatisch bei Bedarf. Erfahre __hier__ mehr.
       refresh_rate_not_configurable: 'Aktualisiersfrequenz: %{refresh_rate} (nicht einstellbar)'
       refreshed: Aktualisiert
       remove_plugin: Erweiterung entfernen
@@ -1055,10 +947,8 @@ de-AT:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Eigenen Zeitplan hinzufügen
       append: und von …
       no_schedule: Dieser Bildschirm wird immer angezeigt.
-      some_schedule: Zeige diesen Bildschirm nur von …
       to: bis
       copy_prompt: Zeitplan kopieren von …
       no_days_error: Bitte mindestens einen Wochentag auswählen.
@@ -1084,11 +974,6 @@ de-AT:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1617,7 +1502,6 @@ de-AT:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -12,7 +12,6 @@ de:
   back: Zurück
   back_to_all_blog_posts: Zurück zu allen Posts
   blog: Blog
-  brand: Marke
   buy_now: Jetzt kaufen
   cancel: Abbrechen
   change_password: Passwort ändern
@@ -26,15 +25,11 @@ de:
   copy: Kopieren
   copied_to_clipboard: Kopiert!
   copy_to_clipboard: In Zwischenablage kopieren
-  created: Erstellt
   create_an_account: Konto erstellen
   current_device: Aktuelles Gerät
-  days: Tage
   delete: Löschen
   developers: Entwickler
   developer_edition_required: Die TRMNL-Entwickler-Edition wird für dieses Feature benötigt.
-  device_id: Gerätekennung
-  device: Gerät
   discard: Verwerfen
   edit: Ändern
   email_address: E-Mail-Adresse
@@ -45,7 +40,6 @@ de:
   forgot_password_title: Neues Passwort vergeben
   friendly_id: Friendly ID
   get_started: Lass uns loslegen!
-  hidden: versteckt
   identify: Identifizieren
   import: Importieren
   import_new: Neu importieren
@@ -59,32 +53,23 @@ de:
   log_out: Abmelden
   manage: Verwalten
   minimum_characters: Zeichen Minimum
-  mins: Min
-  my_playlist: Meine Wiedergabeliste
   new_password: Neues Passwort
   password: Passwort
-  please_wait: Bitte warten …
   plugin_not_found: Erweiterung nicht gefunden
   preview: Vorschau
-  privacy: Datenschutz
-  refresh_rate: Aktualisierungsrate
   refresh_rates_hint: Weitere Informationen zur Aktualisierungsrate __hier__.
   reset_password: Passwort zurücksetzen
   reset_to_defaults: Auf Standard zurücksetzen
   required: Erforderlich
   save: Speichern
-  shown: angezeigt
   section: Abschnitt
   settings: Einstellungen
   sign_in: Anmelden
   sign_up: Registrieren
   something_went_wrong: Etwas ist schiefgegangen
   status: Status
-  subscribe: Abonnieren
   help_center: Hilfe
-  terms: AGB
   unsaved_changes: Du hast ungespeicherte Änderungen
-  update: Aktualisieren
   view: Ansicht
   collaboration_request: Lust zusammenzuarbeiten?
   collaboration_request_hint: Partnerschaften, Großabnahme, Sonderprojekte – ganz nach Bedarf.
@@ -153,9 +138,6 @@ de:
       refer_and_earn_hint: Empfehle TRMNL mit einem personalisierten Code weiter. Verdiene Geld mit jeder Einlösung, monatlich ausgezahlt.
       refer_and_earn_redemptions: Einlösungen
       refer_and_earn_request_code: Empfehlungscode anfordern
-      device_invoice: Rechnungsdownload
-      device_invoice_label: Lade die Rechnung für den Kauf deines TRMNL als PDF herunter.
-      device_invoice_hint: Die Rechnungsnummer findest du auf der Statusseite der Sendungsverfolgung oder in der Versandstatus-E-Mail.
       email_address_hint: Wird für die TRMNL-Anmeldung und den Versand von wichtigen Benachrichtigungen verwendet.
       first_name_hint: Wir verwenden deinen Vornamen, um TRMNL zu personalisieren.
       last_name_hint: Wir verwenden deinen Namen, um TRMNL zu personalisieren.
@@ -234,13 +216,7 @@ de:
   dashboard:
     index:
       title: Übersicht
-      last_7_days: Letzte 7 Tage
-      last_30_days: Letzte 30 Tage
-      last_90_days: Letzte 90 Tage
-      today: Heute
-      yesterday: Gestern
     health:
-      bad: Erweiterungen mit Einschränkungen
       good: Voll funktionsfähige Erweiterungen
       next_steps: Wir werden dich über Änderungen informieren
     news:
@@ -257,14 +233,9 @@ de:
       new_and_popular: Neu und beliebt
     shop:
       title: Shop
-      need_another: Brauchst du noch einen TRMNL?
     time_saved:
       title: Eingesparte Zeit
-      cta: Mehr erfahren
     discover_callout:
-      manage_persona: Persona verwalten
-      dismiss: Ausblenden
-    saved_discovery_setup:
       manage_persona: Persona verwalten
     welcome_message:
       morning_salutation: Guten Morgen
@@ -277,7 +248,6 @@ de:
     edit:
       accepts_beta_firmware: Beta-Firmware
       accepts_beta_firmware_hint: Aktiviere diese Option, um vor anderen Benutzern die neuesten Firmware-Updates für das Gerät zu erhalten.
-      back_to_devices: Zurück zur Geräteübersicht
       battery_and_sleep: Batterie & Schlafmodus
       battery_consumption: Batterieverbrauch
       battery_consumption_hint: Spare Strom und verlängere die Laufzeit durch Aktivierung des Schlafmodus.
@@ -299,7 +269,6 @@ de:
       device_model_switch_warning: Diese Aktion kann gefährlich sein, erfahre __hier__ mehr darüber
       device_info: Geräteinformationen
       current_firmware: Aktuelle Firmware
-      last_ping: Letzter Ping
       unknown: Unbekannt
       never: Nie
       display_calibration: Bildschirmkalibrierung
@@ -345,7 +314,6 @@ de:
       ota_byod_not_supported: OTA wird für BYOD-Geräte nicht unterstützt. Überspiele eine kompatible Version direkt unter trmnl.com/flash.
       maximum_compatibility: Maximale Kompatibilität aktivieren
       maximum_compatibility_hint: Behebt Anzeigefehler aufgrund bestimmter ePaper-Treiber-Chips. Deaktiviert schnelles Rendern. Benötigt Firmware 1.6.0+.
-      color_and_rotation: Farbe & Rotation
       image_rotation: Image Rotation
       screen_rotation: Bildschirmrotation
       screen_rotation_not_supported: Bildschirmrotation ist derzeit nicht auf deinem Gerät unterstützt.
@@ -367,9 +335,7 @@ de:
       tidbyt_credentials: Tidbyt-Anmeldedaten
       tidbyt_credentials_hint: Gib hier die API-Zugangsdaten deines Tidbyt-Geräts ein (Einstellungen → Entwickler → API-Schlüssel in der Tidbyt-App).
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Ungültige Tidbyt-API-Zugangsdaten. Bitte prüfen und erneut versuchen.
       tidbyt_device_id: Geräte-ID
-      tidbyt_device_api_key: API-Schlüssel
       unlink: Entkoppeln
       unlink_confirm: Bist du sicher? Fahre nur fort, wenn du das Gerät an jemand anderen weitergibst oder zu BYOS wechselst. Das Trennen löscht alle Erweiterungseinstellungen und Wiedergabelisteneinträge. Bei Problemen wende dich an den Support unter help.trmnl.com.
       unlink_device: Gerät entkoppeln
@@ -377,7 +343,6 @@ de:
       unlink_device_learn_more: __Hier__ gibt es die vollständige Anleitung dazu.
       visibility: Sichtbarkeit
       visibility_hint: Macht das TRMNL öffentlich sichtbar.
-      your_device: Dein TRMNL
       upgrade_og:
         title: Upgrade auf 2-bit-Anzeige verfügbar
         sub_title: Dein Gerät kann ein Upgrade erhalten und damit eine verbesserte Graustufendarstellung mit 4 anstelle von 2 Farbwerten unterstützen.
@@ -414,9 +379,6 @@ de:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ de:
     index:
       title: Geräte
       tagline: Deine TRMNL-Geräte
-      add_device_modal_title: Neues Gerät hinzufügen
       add_first_device: Beginne mit dem Hinzufügen deines ersten Gerätes!
       go_to_settings: Zu den Einstellungen
       clear_playlist: Wiedergabeliste leeren
@@ -515,9 +476,6 @@ de:
     dissociate:
       error: Fehler beim Trennen des Gerätes
       success: Gerät erfolgreich getrennt
-    external_credentials:
-      error: Ungültige Gerätezugangsdaten
-      success: Gerätezugangsdaten erfolgreich aktualisiert
     identify:
       error: Fehler beim Identifizieren des Gerätes
       success: Geräteidentifizierung angefordert
@@ -556,16 +514,11 @@ de:
         title: Persona für %{device_label} einrichten
         subtext: Beantworte ein paar Fragen, damit die Empfehlungen zum Einsatz dieses TRMNL passen.
         primary_label: Persona einrichten
-  invoices:
-    rate_limit: Zu viele Versuche, bitte warte kurz und versuche es noch einmal
-    invoice_not_found: Rechnung nicht gefunden
   logs:
     index:
       title: Log-Dateien
       all: Alle
-      bulk_destroy: Stapel-Löschen
       dump: Message
-      id: ID
       private_plugins: Private Erweiterungen
       source: Quelle
       time: Time (UTC)
@@ -600,9 +553,6 @@ de:
       live_preview: Live-Vorschau
       no_changes_to_save: Keine Änderungen zum Speichern
       pop_out_preview: Vorschau in eigenem Fenster
-      quickstart_examples: Schnellstart-Beispiele
-      quickstart_example_applied: Angewendet!
-      quickstart_use_this_example: Dieses Beispiel verwenden
       revert: Rückgängig
       revert_confirm: Wirklich rückgängig machen? Alle nicht gespeicherten Änderungen gehen verloren.
       save_changes: Speichern (⌘﹢S)
@@ -666,9 +616,6 @@ de:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: Du kannst deine Persona jederzeit in den Geräteeinstellungen einrichten oder ändern.
   mfa:
     disable_otp:
       success: 2FA abgeschaltet
@@ -694,21 +641,12 @@ de:
   playlist_items:
     index:
       title: Wiedergabeliste
-      tagline: Was soll auf dem Gerät angezeigt werden?
-      add_a_group: Gruppe hinzufügen
-      add_a_plugin: Erweiterung hinzufügen
       add_first_device_cta: Beginne mit dem __Hinzufügen__ des ersten TRMNL-Gerätes!
       add_to_playlist: Zu Wiedergabeliste hinzufügen
-      create_first_playlist_cta: Erste Erweiterung __verbinden__, um eine Wiedergabeliste zu starten!
       custom: Angepasst
       device_default: Geräte-Standard
-      display_period_from: Anzeige von
-      display_period_to: bis
       display_period_validation: Startzeit muss vor der Endzeit liegen. Erstelle eine weitere Gruppe, um die Nachtstunden abzudecken.
-      every: Alle
       never_skip: Niemals Inhalte überspringen
-      smart_playlist: Intelligente Wiedergabeliste
-      smart_playlist_hint: Automatisch Inhalte überspringen, die sich seit einer Weile nicht verändert haben.
       skip_after:
         one: Alte Inhalte nach 1 Tag überspringen
         other: Alte Inhalte nach %{count} Tagen überspringen
@@ -746,9 +684,6 @@ de:
       duplicate: Duplizieren
       duplicate_confirm: Es wird eine Kopie dieses Eintrags erstellt und am Ende der Wiedergabeliste hinzugefügt. Fortfahren?
       presentation: Presentation
-      color_palette: Farbpalette
-      device_default: Geräte-Standard (%{name})
-      palette_unavailable: Nur verfügbar für Geräte mit mehreren Farbpaletten
       refresh_rate_disabled:
         default: Die Aktualisierungsrate dieser Erweiterung kann nicht konfiguriert werden.
         external: Diese Erweiterung ruft Daten in Echtzeit ab, daher gelten keine Aktualisierungsraten-Einstellungen.
@@ -765,7 +700,6 @@ de:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Fehler beim Aktualisieren der Wiedergabeliste
       success: Wiedergabeliste aktualisiert
     destroy:
       error: Fehler beim Entfernen von der Wiedergabeliste
@@ -778,8 +712,6 @@ de:
       success: Wiedergabereihenfolge aktualisiert
     set_preferences:
       success: Einstellung zur intelligenten Wiedergabeliste aktualisiert
-    update:
-      success: Wiedergabereihenfolge aktualisiert
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -810,23 +742,10 @@ de:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -834,8 +753,6 @@ de:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -846,9 +763,6 @@ de:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -864,7 +778,6 @@ de:
     index:
       title: Erweiterungen
       tagline: Was soll auf dem TRMNL angezeigt werden?
-      available: Verfügbar
       connected: Verbunden
       supported_by_this_device: Supported by this device
       recipes: Blaupausen
@@ -876,7 +789,6 @@ de:
         title: Meine Erweiterungen
         tagline: Entwickele Erweiterungen für den öffentlichen Marktplatz
       card:
-        connections: Verbindungen
         install: Installieren
         review_are_you_sure: Sicher? Das TRMNL-Team wird die Erweiterung prüfen und dir ggf. Fragen zumailen.
         submit_for_review: Zur Überprüfung einreichen
@@ -906,16 +818,11 @@ de:
     edit:
       title: Erweiterung bearbeiten
       tagline: Aktualisiere Details deiner Erweiterung.
-      name: Name
-      description: Beschreibung
   plugin_recipes:
     connected: Blaupause verbunden
     connections:
       one: Verbindung
       other: Verbindungen
-    forks:
-      one: Fork
-      other: Forks
     forked: Blaupause geforkt
     new:
       error: Blaupause nicht gefunden
@@ -923,18 +830,14 @@ de:
       more_by_author: Mehr von diesem Autor
       view_all: Alle anzeigen
   plugin_settings:
-    active: Aktiv
     copy_are_you_sure: Möchtest du diese Einstellung wirklich kopieren?
     delete_are_you_sure: Möchtest du diese Einstellung wirklich löschen?
     delete: Hiermit werden alle Einstellungen der Erweiterung vollständig entfernt. Um sie lediglich auszublenden, entferne sie von der Wiedergabeliste.
-    inactive: Inaktiv
     no_matches_found: Keine Erweiterungen entsprechen deinen Filtern.
-    no_plugin_settings_found: Keine Einstellungen für diese Erweiterung gefunden.
     not_supported: Aktuell für dieses Gerät nicht unterstützt
     refreshing_now_please_wait: Wird aktualisiert, bitte die Seite in ein paar Sekunden neu laden.
     reset_credentials: Konto-Reset von %{plugin_name} erfolgreich
     form:
-      active_hint: Anzeigen oder Verbergen der Erweiterung auf dem Gerät
       advanced_settings: Erweiterte Einstellungen
       back_to_playlist: Zurück zur Wiedergabeliste
       back_to_plugin: Zurück zu %{plugin}
@@ -956,15 +859,7 @@ de:
       health_notifications_hint: Erhalte eine E-Mail, wenn sich der Zustand dieser Erweiterung auf „eingeschränkt“ oder „fehlerhaft“ ändert. Du erhältst maximal eine E-Mail pro Zustand und Vorfall; Benachrichtigungen werden erst wieder aktiviert, sobald die Erweiterung wieder funktionsfähig ist.
       health_notifications_checkbox: Per E-Mail benachrichtigen, wenn diese Erweiterung nicht mehr funktionsfähig ist
       learn_more: Mehr Informationen zur Erweiterung in unserer Wissensdatenbank
-      learn_more_fork: Diese Erweiterung ist von einer Blaupause geforkt worden.
-      learn_more_fork_original: Original aufrufen
-      learn_more_native_long: Dies ist eine offizielle Erweiterung, die von TRMNL gewartet wird.
-      learn_more_native_short: Diese Erweiterung wird von TRMNL gewartet.
       learn_more_recipe_author: Hilfe benötigt? Kontaktiere %{recipe_author} auf Discord.
-      learn_more_recipe_long: Diese Erweiterung ist eine Community-Blaupause und wird nicht von TRMNL gewartet.
-      learn_more_recipe_short: 'Hinweis: Diese Erweiterung ist eine Blaupause.'
-      learn_more_third_party_long: Diese Erweiterung stammt von einem Drittanbieter und wird nicht von TRMNL gewartet.
-      learn_more_third_party_short: 'Hinweis: Diese Erweiterung stammt von einem Drittanbieter.'
       linked_account: Verbundener Account
       linked_account_success: Erfolgreich verbunden mit %{plugin_name}
       link_oauth: Konto verknüpfen
@@ -986,7 +881,6 @@ de:
       recipe_cta_body_published: Änderungen werden sich auf aktuelle und zukünftige Installationen/Forks auswirken.
       recipe_cta_body_in_review: Diese Erweiterung wurde an unser Team übermittelt. Danke für deine Geduld!
       recipe_cta_body_not_published: Reiche diese Erweiterung ein, damit sie auch andere installieren können. __Mehr erfahren__.
-      recipe_cta_confirm: Bist du sicher? Unser Team wird sich in einigen Tagen nach erfolgter Prüfung zurückmelden. Du kannst weiterhin Änderungen vornehmen.
       recipe_mirrored: Diese Anzeige ist eine Spiegelung der Blaupause.
       recipe_visibility_title: Wie möchtest du veröffentlichen?
       recipe_visibility_edit_title: Einreichung bearbeiten
@@ -997,8 +891,6 @@ de:
       recipe_visibility_unlisted: Nicht gelistet
       recipe_visibility_unlisted_hint: Jeder mit dem Link kann installieren.
       refresh_rate: Aktualisierungsrate
-      refresh_rate_hint: Definiere, wie oft die Erweiterung Daten aktualisiert
-      refresh_rate_jit_hint: Diese Erweiterung aktualisiert sich automatisch bei Bedarf. Erfahre __hier__ mehr.
       refresh_rate_not_configurable: 'Aktualisiersfrequenz: %{refresh_rate} (nicht einstellbar)'
       refreshed: Aktualisiert
       remove_plugin: Erweiterung entfernen
@@ -1055,10 +947,8 @@ de:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Eigenen Zeitplan hinzufügen
       append: und von …
       no_schedule: Dieser Bildschirm wird immer angezeigt.
-      some_schedule: Zeige diesen Bildschirm nur von …
       to: bis
       copy_prompt: Zeitplan kopieren von …
       no_days_error: Bitte mindestens einen Wochentag auswählen.
@@ -1084,11 +974,6 @@ de:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1617,7 +1502,6 @@ de:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -12,7 +12,6 @@ en-AU:
   back: Back
   back_to_all_blog_posts: Back to all posts
   blog: Blog
-  brand: Brand
   buy_now: Buy Now
   cancel: Cancel
   change_password: Change Password
@@ -26,15 +25,11 @@ en-AU:
   copy: Copy
   copied_to_clipboard: Copied!
   copy_to_clipboard: Copy to clipboard
-  created: Created
   create_an_account: Create an account
   current_device: Current device
-  days: days
   delete: Delete
   developers: Developers
   developer_edition_required: Developer edition is required to enable this feature.
-  device_id: Device ID
-  device: Device
   discard: Discard
   edit: Edit
   email_address: Email address
@@ -45,7 +40,6 @@ en-AU:
   forgot_password_title: Here we go again
   friendly_id: Friendly ID
   get_started: Let's get you started!
-  hidden: hidden
   identify: Identify
   import: Import
   import_new: Import new
@@ -59,32 +53,23 @@ en-AU:
   log_out: Log out
   manage: Manage
   minimum_characters: characters minimum
-  mins: mins
-  my_playlist: My Playlist
   new_password: New password
   password: Password
-  please_wait: Please Wait...
   plugin_not_found: Plugin not found
   preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
   refresh_rates_hint: Learn how refresh rates work __here__.
   reset_password: Reset my password
   reset_to_defaults: Reset to defaults
   required: Required
   save: Save
-  shown: shown
   section: Section
   settings: Settings
   sign_in: Sign in
   sign_up: Sign up
   something_went_wrong: Something went wrong
   status: Status
-  subscribe: Subscribe
   help_center: Support
-  terms: Terms
   unsaved_changes: You have unsaved changes
-  update: Update
   view: View
   collaboration_request: Wanna collaborate?
   collaboration_request_hint: Partnerships, group sales, special projects, your call.
@@ -153,9 +138,6 @@ en-AU:
       refer_and_earn_hint: Give the gift of TRMNL with a personalized coupon. Earn per use, paid monthly.
       refer_and_earn_redemptions: Redemptions
       refer_and_earn_request_code: Request a Code
-      device_invoice: Device Invoice
-      device_invoice_label: Download commercial documents for your accountant or (weird) PDF collection.
-      device_invoice_hint: Find this on your package tracking page or shipment notification email.
       email_address_hint: Used to sign into TRMNL and receive system messages.
       first_name_hint: We use your name to make the TRMNL interface more comfortable.
       last_name_hint: We use your name to make the TRMNL interface more comfortable.
@@ -234,13 +216,7 @@ en-AU:
   dashboard:
     index:
       title: Dashboard
-      last_7_days: Last 7 days
-      last_30_days: Last 30 days
-      last_90_days: Last 90 days
-      today: Today
-      yesterday: Yesterday
     health:
-      bad: Plugins are experiencing issues
       good: Plugins are healthy
       next_steps: We will inform you if anything changes
     news:
@@ -257,14 +233,9 @@ en-AU:
       new_and_popular: New and Popular
     shop:
       title: Shop
-      need_another: Need another TRMNL?
     time_saved:
       title: Time saved
-      cta: Read about
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Good morning
@@ -277,7 +248,6 @@ en-AU:
     edit:
       accepts_beta_firmware: Firmware Early Release
       accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
-      back_to_devices: Back to Devices
       battery_and_sleep: Battery & Sleep
       battery_consumption: Battery Consumption
       battery_consumption_hint: Save power and enjoy a longer battery life by enabling Sleep Mode.
@@ -299,7 +269,6 @@ en-AU:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -345,7 +314,6 @@ en-AU:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
-      color_and_rotation: Color & Rotation
       image_rotation: Image Rotation
       screen_rotation: Screen Rotation
       screen_rotation_not_supported: Screen rotation is currently not supported on your device.
@@ -367,9 +335,7 @@ en-AU:
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
       unlink: Unlink
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Unlink Device
@@ -377,7 +343,6 @@ en-AU:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
-      your_device: Your TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -414,9 +379,6 @@ en-AU:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ en-AU:
     index:
       title: Devices
       tagline: Your TRMNL devices
-      add_device_modal_title: Add a new device
       add_first_device: Start by adding your first device!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -515,9 +476,6 @@ en-AU:
     dissociate:
       error: Error disconnecting device
       success: Device successfully unlinked
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: Error updating device
       success: Device identification requested
@@ -556,16 +514,11 @@ en-AU:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Too many attempts, please wait and try again
-    invoice_not_found: Invoice not found
   logs:
     index:
       title: Logs
       all: All
-      bulk_destroy: Bulk Destroy
       dump: Message
-      id: ID
       private_plugins: Private plugins
       source: Source
       time: Time (UTC)
@@ -600,9 +553,6 @@ en-AU:
       live_preview: Live Preview
       no_changes_to_save: No changes to save
       pop_out_preview: Pop Out Preview
-      quickstart_examples: Quick-start Examples
-      quickstart_example_applied: Applied!
-      quickstart_use_this_example: Use this example
       revert: Revert
       revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
       save_changes: Save Changes (⌘﹢S)
@@ -666,9 +616,6 @@ en-AU:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA Disabled
@@ -694,21 +641,12 @@ en-AU:
   playlist_items:
     index:
       title: Playlist
-      tagline: Choose what's shown on
-      add_a_group: Add a Group
-      add_a_plugin: Add a Plugin
       add_first_device_cta: Start by __adding__ your first TRMNL device!
       add_to_playlist: Add to playlist
-      create_first_playlist_cta: Create your Playlist after __connecting__ your first plugin!
       custom: Custom
       device_default: Device default
-      display_period_from: Display from
-      display_period_to: to
       display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
       never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
       skip_after:
         one: Skip stale screens after 1 day
         other: Skip stale screens after %{count} days
@@ -746,9 +684,6 @@ en-AU:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -765,7 +700,6 @@ en-AU:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Failed to update Playlist
       success: Playlist updated
     destroy:
       error: Error removing item from playlist
@@ -778,8 +712,6 @@ en-AU:
       success: Playlist order updated
     set_preferences:
       success: Smart Playlist preference updated
-    update:
-      success: Playlist order updated
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -810,23 +742,10 @@ en-AU:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -834,8 +753,6 @@ en-AU:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -846,9 +763,6 @@ en-AU:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -864,7 +778,6 @@ en-AU:
     index:
       title: Plugins
       tagline: What will you put on your TRMNL?
-      available: Available
       connected: Connected
       supported_by_this_device: Supported by this device
       recipes: Recipes
@@ -876,7 +789,6 @@ en-AU:
         title: My Plugins
         tagline: Develop Plugins for the public marketplace
       card:
-        connections: connections
         install: Install
         review_are_you_sure: Are you sure? The TRMNL team will test it and email you any questions.
         submit_for_review: Submit for Review
@@ -906,16 +818,11 @@ en-AU:
     edit:
       title: Edit Plugin
       tagline: Update your plugin details.
-      name: Name
-      description: Description
   plugin_recipes:
     connected: Recipe connected
     connections:
       one: Connection
       other: Connections
-    forks:
-      one: Fork
-      other: Forks
     forked: Recipe forked
     new:
       error: Recipe not found
@@ -923,18 +830,14 @@ en-AU:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Active
     copy_are_you_sure: Are you sure you want to copy this setting?
     delete_are_you_sure: Are you sure you want to delete this setting?
     delete: This will completely remove the plugin's settings. To simply hide this plugin from your device, delete it from your playlist instead.
-    inactive: Inactive
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: No plugin settings found.
     not_supported: Not supported on current device
     refreshing_now_please_wait: Refreshing now, reload this page in a few seconds.
     reset_credentials: "%{plugin_name} account reset successfully"
     form:
-      active_hint: Show or hide this plugin instance on your device
       advanced_settings: Advanced Settings
       back_to_playlist: Back to Playlist
       back_to_plugin: Back to %{plugin}
@@ -956,15 +859,7 @@ en-AU:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Learn about this plugin in our knowledge base
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
       learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       linked_account: Linked Account
       linked_account_success: Successfully linked with %{plugin_name}
       link_oauth: Link Account
@@ -986,7 +881,6 @@ en-AU:
       recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
       recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
       recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: How would you like to publish?
       recipe_visibility_edit_title: Edit Submission
@@ -997,8 +891,6 @@ en-AU:
       recipe_visibility_unlisted: Unlisted
       recipe_visibility_unlisted_hint: Anyone with the link can install.
       refresh_rate: Refresh rate
-      refresh_rate_hint: Define how frequently this plugin instance fetches fresh data
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
       refreshed: Refreshed
       remove_plugin: Remove plugin
@@ -1055,10 +947,8 @@ en-AU:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Add a custom schedule
       append: And during…
       no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
       to: to
       copy_prompt: Copy schedule from…
       no_days_error: Please select at least one day.
@@ -1084,11 +974,6 @@ en-AU:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1617,7 +1502,6 @@ en-AU:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -12,7 +12,6 @@ en-GB:
   back: Back
   back_to_all_blog_posts: Back to all posts
   blog: Blog
-  brand: Brand
   buy_now: Buy Now
   cancel: Cancel
   change_password: Change Password
@@ -26,15 +25,11 @@ en-GB:
   copy: Copy
   copied_to_clipboard: Copied!
   copy_to_clipboard: Copy to clipboard
-  created: Created
   create_an_account: Create an account
   current_device: Current device
-  days: days
   delete: Delete
   developers: Developers
   developer_edition_required: Developer edition is required to enable this feature.
-  device_id: Device ID
-  device: Device
   discard: Discard
   edit: Edit
   email_address: Email address
@@ -45,7 +40,6 @@ en-GB:
   forgot_password_title: Here we go again
   friendly_id: Friendly ID
   get_started: Let's get you started!
-  hidden: hidden
   identify: Identify
   import: Import
   import_new: Import new
@@ -59,32 +53,23 @@ en-GB:
   log_out: Log out
   manage: Manage
   minimum_characters: characters minimum
-  mins: mins
-  my_playlist: My Playlist
   new_password: New password
   password: Password
-  please_wait: Please Wait...
   plugin_not_found: Plugin not found
   preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
   refresh_rates_hint: Learn how refresh rates work __here__.
   reset_password: Reset my password
   reset_to_defaults: Reset to defaults
   required: Required
   save: Save
-  shown: shown
   section: Section
   settings: Settings
   sign_in: Sign in
   sign_up: Sign up
   something_went_wrong: Something went wrong
   status: Status
-  subscribe: Subscribe
   help_center: Support
-  terms: Terms
   unsaved_changes: You have unsaved changes
-  update: Update
   view: View
   collaboration_request: Wanna collaborate?
   collaboration_request_hint: Partnerships, group sales, special projects, your call.
@@ -153,9 +138,6 @@ en-GB:
       refer_and_earn_hint: Give the gift of TRMNL with a personalized coupon. Earn per use, paid monthly.
       refer_and_earn_redemptions: Redemptions
       refer_and_earn_request_code: Request a Code
-      device_invoice: Device Invoice
-      device_invoice_label: Download commercial documents for your accountant or (weird) PDF collection.
-      device_invoice_hint: Find this on your package tracking page or shipment notification email.
       email_address_hint: Used to sign into TRMNL and receive system messages.
       first_name_hint: We use your name to make the TRMNL interface more comfortable.
       last_name_hint: We use your name to make the TRMNL interface more comfortable.
@@ -234,13 +216,7 @@ en-GB:
   dashboard:
     index:
       title: Dashboard
-      last_7_days: Last 7 days
-      last_30_days: Last 30 days
-      last_90_days: Last 90 days
-      today: Today
-      yesterday: Yesterday
     health:
-      bad: Plugins are experiencing issues
       good: Plugins are healthy
       next_steps: We will inform you if anything changes
     news:
@@ -257,14 +233,9 @@ en-GB:
       new_and_popular: New and Popular
     shop:
       title: Shop
-      need_another: Need another TRMNL?
     time_saved:
       title: Time saved
-      cta: Read about
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Good morning
@@ -277,7 +248,6 @@ en-GB:
     edit:
       accepts_beta_firmware: Firmware Early Release
       accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
-      back_to_devices: Back to Devices
       battery_and_sleep: Battery & Sleep
       battery_consumption: Battery Consumption
       battery_consumption_hint: Save power and enjoy a longer battery life by enabling Sleep Mode.
@@ -299,7 +269,6 @@ en-GB:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -345,7 +314,6 @@ en-GB:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
-      color_and_rotation: Colour & Rotation
       image_rotation: Image Rotation
       screen_rotation: Screen Rotation
       screen_rotation_not_supported: Screen rotation is currently not supported on your device.
@@ -367,9 +335,7 @@ en-GB:
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
       unlink: Unlink
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Unlink Device
@@ -377,7 +343,6 @@ en-GB:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
-      your_device: Your TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 colour levels instead of 2.
@@ -414,9 +379,6 @@ en-GB:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ en-GB:
     index:
       title: Devices
       tagline: Your TRMNL devices
-      add_device_modal_title: Add a new device
       add_first_device: Start by adding your first device!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -516,9 +477,6 @@ en-GB:
     dissociate:
       error: Error disconnecting device
       success: Device successfully unlinked
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: Error updating device
       success: Device identification requested
@@ -557,16 +515,11 @@ en-GB:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Too many attempts, please wait and try again
-    invoice_not_found: Invoice not found
   logs:
     index:
       title: Logs
       all: All
-      bulk_destroy: Bulk Destroy
       dump: Message
-      id: ID
       private_plugins: Private plugins
       source: Source
       time: Time (UTC)
@@ -601,9 +554,6 @@ en-GB:
       live_preview: Live Preview
       no_changes_to_save: No changes to save
       pop_out_preview: Pop Out Preview
-      quickstart_examples: Quick-start Examples
-      quickstart_example_applied: Applied!
-      quickstart_use_this_example: Use this example
       revert: Revert
       revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
       save_changes: Save Changes (⌘﹢S)
@@ -667,9 +617,6 @@ en-GB:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA Disabled
@@ -695,21 +642,12 @@ en-GB:
   playlist_items:
     index:
       title: Playlist
-      tagline: Choose what's shown on
-      add_a_group: Add a Group
-      add_a_plugin: Add a Plugin
       add_first_device_cta: Start by __adding__ your first TRMNL device!
       add_to_playlist: Add to playlist
-      create_first_playlist_cta: Create your Playlist after __connecting__ your first plugin!
       custom: Custom
       device_default: Device default
-      display_period_from: Display from
-      display_period_to: to
       display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
       never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
       skip_after:
         one: Skip stale screens after 1 day
         other: Skip stale screens after %{count} days
@@ -747,9 +685,6 @@ en-GB:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Colour Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple colour palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -766,7 +701,6 @@ en-GB:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Failed to update Playlist
       success: Playlist updated
     destroy:
       error: Error removing item from playlist
@@ -779,8 +713,6 @@ en-GB:
       success: Playlist order updated
     set_preferences:
       success: Smart Playlist preference updated
-    update:
-      success: Playlist order updated
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -811,23 +743,10 @@ en-GB:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -835,8 +754,6 @@ en-GB:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -847,9 +764,6 @@ en-GB:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -865,7 +779,6 @@ en-GB:
     index:
       title: Plugins
       tagline: What will you put on your TRMNL?
-      available: Available
       connected: Connected
       supported_by_this_device: Supported by this device
       recipes: Recipes
@@ -877,7 +790,6 @@ en-GB:
         title: My Plugins
         tagline: Develop Plugins for the public marketplace
       card:
-        connections: connections
         install: Install
         review_are_you_sure: Are you sure? The TRMNL team will test it and email you any questions.
         submit_for_review: Submit for Review
@@ -907,16 +819,11 @@ en-GB:
     edit:
       title: Edit Plugin
       tagline: Update your plugin details.
-      name: Name
-      description: Description
   plugin_recipes:
     connected: Recipe connected
     connections:
       one: Connection
       other: Connections
-    forks:
-      one: Fork
-      other: Forks
     forked: Recipe forked
     new:
       error: Recipe not found
@@ -924,18 +831,14 @@ en-GB:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Active
     copy_are_you_sure: Are you sure you want to copy this setting?
     delete_are_you_sure: Are you sure you want to delete this setting?
     delete: This will completely remove the plugin's settings. To simply hide this plugin from your device, delete it from your playlist instead.
-    inactive: Inactive
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: No plugin settings found.
     not_supported: Not supported on current device
     refreshing_now_please_wait: Refreshing now, reload this page in a few seconds.
     reset_credentials: "%{plugin_name} account reset successfully"
     form:
-      active_hint: Show or hide this plugin instance on your device
       advanced_settings: Advanced Settings
       back_to_playlist: Back to Playlist
       back_to_plugin: Back to %{plugin}
@@ -957,15 +860,7 @@ en-GB:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Learn about this plugin in our knowledge base
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
       learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       linked_account: Linked Account
       linked_account_success: Successfully linked with %{plugin_name}
       link_oauth: Link Account
@@ -987,7 +882,6 @@ en-GB:
       recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
       recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
       recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: How would you like to publish?
       recipe_visibility_edit_title: Edit Submission
@@ -998,8 +892,6 @@ en-GB:
       recipe_visibility_unlisted: Unlisted
       recipe_visibility_unlisted_hint: Anyone with the link can install.
       refresh_rate: Refresh rate
-      refresh_rate_hint: Define how frequently this plugin instance fetches fresh data
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
       refreshed: Refreshed
       remove_plugin: Remove plugin
@@ -1056,10 +948,8 @@ en-GB:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Add a custom schedule
       append: And during…
       no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
       to: to
       copy_prompt: Copy schedule from…
       no_days_error: Please select at least one day.
@@ -1085,11 +975,6 @@ en-GB:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1618,7 +1503,6 @@ en-GB:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -12,7 +12,6 @@ en:
   back: Back
   back_to_all_blog_posts: Back to all posts
   blog: Blog
-  brand: Brand
   buy_now: Buy Now
   cancel: Cancel
   change_password: Change Password
@@ -26,15 +25,11 @@ en:
   copy: Copy
   copied_to_clipboard: Copied!
   copy_to_clipboard: Copy to clipboard
-  created: Created
   create_an_account: Create an account
   current_device: Current device
-  days: days
   delete: Delete
   developers: Developers
   developer_edition_required: Developer edition is required to enable this feature.
-  device_id: Device ID
-  device: Device
   discard: Discard
   edit: Edit
   email_address: Email address
@@ -45,7 +40,6 @@ en:
   forgot_password_title: Here we go again
   friendly_id: Friendly ID
   get_started: Let's get you started!
-  hidden: hidden
   identify: Identify
   import: Import
   import_new: Import new
@@ -59,32 +53,23 @@ en:
   log_out: Log out
   manage: Manage
   minimum_characters: characters minimum
-  mins: mins
-  my_playlist: My Playlist
   new_password: New password
   password: Password
-  please_wait: Please Wait...
   plugin_not_found: Plugin not found
   preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
   refresh_rates_hint: Learn how refresh rates work __here__.
   reset_password: Reset my password
   reset_to_defaults: Reset to defaults
   required: Required
   save: Save
-  shown: shown
   section: Section
   settings: Settings
   sign_in: Sign in
   sign_up: Sign up
   something_went_wrong: Something went wrong
   status: Status
-  subscribe: Subscribe
   help_center: Support
-  terms: Terms
   unsaved_changes: You have unsaved changes
-  update: Update
   view: View
   collaboration_request: Wanna collaborate?
   collaboration_request_hint: Partnerships, group sales, special projects, your call.
@@ -153,9 +138,6 @@ en:
       refer_and_earn_hint: Give the gift of TRMNL with a personalized coupon. Earn per use, paid monthly.
       refer_and_earn_redemptions: Redemptions
       refer_and_earn_request_code: Request a Code
-      device_invoice: Device Invoice
-      device_invoice_label: Download commercial documents for your accountant or (weird) PDF collection.
-      device_invoice_hint: Find this on your package tracking page or shipment notification email.
       email_address_hint: Used to sign into TRMNL and receive system messages.
       first_name_hint: We use your name to make the TRMNL interface more comfortable.
       last_name_hint: We use your name to make the TRMNL interface more comfortable.
@@ -234,13 +216,7 @@ en:
   dashboard:
     index:
       title: Dashboard
-      last_7_days: Last 7 days
-      last_30_days: Last 30 days
-      last_90_days: Last 90 days
-      today: Today
-      yesterday: Yesterday
     health:
-      bad: Plugins are experiencing issues
       good: Plugins are healthy
       next_steps: We will inform you if anything changes
     news:
@@ -257,14 +233,9 @@ en:
       new_and_popular: New and Popular
     shop:
       title: Shop
-      need_another: Need another TRMNL?
     time_saved:
       title: Time saved
-      cta: Read about
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Good morning
@@ -277,7 +248,6 @@ en:
     edit:
       accepts_beta_firmware: Firmware Early Release
       accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
-      back_to_devices: Back to Devices
       battery_and_sleep: Battery & Sleep
       battery_consumption: Battery Consumption
       battery_consumption_hint: Save power and enjoy a longer battery life by enabling Sleep Mode.
@@ -299,7 +269,6 @@ en:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -345,7 +314,6 @@ en:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
-      color_and_rotation: Color & Rotation
       image_rotation: Image Rotation
       screen_rotation: Screen Rotation
       screen_rotation_not_supported: Screen rotation is currently not supported on your device.
@@ -367,9 +335,7 @@ en:
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
       unlink: Unlink
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Unlink Device
@@ -377,7 +343,6 @@ en:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
-      your_device: Your TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -414,9 +379,6 @@ en:
       waits_for_next_render_hint: If only one item can be on screen right now, this device waits for that item's next update instead of checking in at the refresh rate above. That's a single plugin, a mashup, or a playlist where schedules leave one item showing. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ en:
     index:
       title: Devices
       tagline: Your TRMNL devices
-      add_device_modal_title: Add a new device
       add_first_device: Start by adding your first device!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -515,9 +476,6 @@ en:
     dissociate:
       error: Error disconnecting device
       success: Device successfully unlinked
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: Error updating device
       success: Device identification requested
@@ -556,16 +514,11 @@ en:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Too many attempts, please wait and try again
-    invoice_not_found: Invoice not found
   logs:
     index:
       title: Logs
       all: All
-      bulk_destroy: Bulk Destroy
       dump: Message
-      id: ID
       private_plugins: Private plugins
       source: Source
       time: Time (UTC)
@@ -600,9 +553,6 @@ en:
       live_preview: Live Preview
       no_changes_to_save: No changes to save
       pop_out_preview: Pop Out Preview
-      quickstart_examples: Quick-start Examples
-      quickstart_example_applied: Applied!
-      quickstart_use_this_example: Use this example
       revert: Revert
       revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
       save_changes: Save Changes (⌘﹢S)
@@ -666,9 +616,6 @@ en:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA Disabled
@@ -694,21 +641,12 @@ en:
   playlist_items:
     index:
       title: Playlist
-      tagline: Choose what's shown on
-      add_a_group: Add a Group
-      add_a_plugin: Add a Plugin
       add_first_device_cta: Start by __adding__ your first TRMNL device!
       add_to_playlist: Add to playlist
-      create_first_playlist_cta: Create your Playlist after __connecting__ your first plugin!
       custom: Custom
       device_default: Device default
-      display_period_from: Display from
-      display_period_to: to
       display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
       never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
       skip_after:
         one: Skip stale screens after 1 day
         other: Skip stale screens after %{count} days
@@ -746,9 +684,6 @@ en:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -765,7 +700,6 @@ en:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Failed to update Playlist
       success: Playlist updated
     destroy:
       error: Error removing item from playlist
@@ -778,8 +712,6 @@ en:
       success: Playlist order updated
     set_preferences:
       success: Smart Playlist preference updated
-    update:
-      success: Playlist order updated
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -810,23 +742,10 @@ en:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -834,8 +753,6 @@ en:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -846,9 +763,6 @@ en:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -864,7 +778,6 @@ en:
     index:
       title: Plugins
       tagline: What will you put on your TRMNL?
-      available: Available
       connected: Connected
       supported_by_this_device: Supported by this device
       recipes: Recipes
@@ -876,7 +789,6 @@ en:
         title: My Plugins
         tagline: Develop Plugins for the public marketplace
       card:
-        connections: connections
         install: Install
         review_are_you_sure: Are you sure? The TRMNL team will test it and email you any questions.
         submit_for_review: Submit for Review
@@ -906,16 +818,11 @@ en:
     edit:
       title: Edit Plugin
       tagline: Update your plugin details.
-      name: Name
-      description: Description
   plugin_recipes:
     connected: Recipe connected
     connections:
       one: Connection
       other: Connections
-    forks:
-      one: Fork
-      other: Forks
     forked: Recipe forked
     new:
       error: Recipe not found
@@ -923,18 +830,14 @@ en:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Active
     copy_are_you_sure: Are you sure you want to copy this setting?
     delete_are_you_sure: Are you sure you want to delete this setting?
     delete: This will completely remove the plugin's settings. To simply hide this plugin from your device, delete it from your playlist instead.
-    inactive: Inactive
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: No plugin settings found.
     not_supported: Not supported on current device
     refreshing_now_please_wait: Refreshing now, reload this page in a few seconds.
     reset_credentials: "%{plugin_name} account reset successfully"
     form:
-      active_hint: Show or hide this plugin instance on your device
       advanced_settings: Advanced Settings
       back_to_playlist: Back to Playlist
       back_to_plugin: Back to %{plugin}
@@ -956,15 +859,7 @@ en:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Learn about this plugin in our knowledge base
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
       learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       linked_account: Linked Account
       linked_account_success: Successfully linked with %{plugin_name}
       link_oauth: Link Account
@@ -986,7 +881,6 @@ en:
       recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
       recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
       recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: How would you like to publish?
       recipe_visibility_edit_title: Edit Submission
@@ -997,8 +891,6 @@ en:
       recipe_visibility_unlisted: Unlisted
       recipe_visibility_unlisted_hint: Anyone with the link can install.
       refresh_rate: Refresh rate
-      refresh_rate_hint: Define how frequently this plugin instance fetches fresh data
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
       refreshed: Refreshed
       remove_plugin: Remove plugin
@@ -1055,10 +947,8 @@ en:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Add a custom schedule
       append: And during…
       no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
       to: to
       copy_prompt: Copy schedule from…
       no_days_error: Please select at least one day.
@@ -1084,11 +974,6 @@ en:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1617,7 +1502,6 @@ en:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -12,7 +12,6 @@ es-ES:
   back: Atrás
   back_to_all_blog_posts: Volver a todas las publicaciones
   blog: Blog
-  brand: Marca
   buy_now: Comprar ahora
   cancel: Cancelar
   change_password: Cambiar contraseña
@@ -26,15 +25,11 @@ es-ES:
   copy: Copiar
   copied_to_clipboard: "¡Copiado!"
   copy_to_clipboard: Copiar al portapapeles
-  created: Creada
   create_an_account: Crear una cuenta
   current_device: Dispositivo actual
-  days: días
   delete: Eliminar
   developers: Desarrolladores
   developer_edition_required: Se requiere la Edición para Desarrolladores para activar esta función.
-  device_id: ID del dispositivo
-  device: Dispositivo
   discard: Discard
   edit: Editar
   email_address: Dirección de correo electrónico
@@ -45,7 +40,6 @@ es-ES:
   forgot_password_title: Recuperar contraseña
   friendly_id: ID amigable
   get_started: "¡Empecemos!"
-  hidden: Oculto
   identify: Identificar
   import: Importar
   import_new: Importar nuevo
@@ -59,32 +53,23 @@ es-ES:
   log_out: Cerrar sesión
   manage: Administrar
   minimum_characters: Caracteres mínimos
-  mins: min
-  my_playlist: Mi lista de reproducción
   new_password: Nueva contraseña
   password: Contraseña
-  please_wait: Por favor, espera...
   plugin_not_found: Plugin no encontrado
   preview: Vista previa
-  privacy: Privacidad
-  refresh_rate: Tasa de refresco
   refresh_rates_hint: Aprende cómo funcionan las tasas de refresco __aquí__.
   reset_password: Restablecer mi contraseña
   reset_to_defaults: Restablecer valores predeterminados
   required: Obligatorio
   save: Guardar
-  shown: mostrado
   section: Sección
   settings: Ajustes
   sign_in: Iniciar sesión
   sign_up: Registrarse
   something_went_wrong: Algo salió mal
   status: Estado
-  subscribe: Suscribirse
   help_center: Soporte
-  terms: Términos
   unsaved_changes: You have unsaved changes
-  update: Actualizar
   view: Ver
   collaboration_request: "¿Quieres colaborar?"
   collaboration_request_hint: Asociaciones, ventas grupales, proyectos especiales — tú decides.
@@ -153,9 +138,6 @@ es-ES:
       refer_and_earn_hint: Comparte TRMNL con un cupón personalizado. Gana por uso, pagado mensualmente.
       refer_and_earn_redemptions: Reembolsos
       refer_and_earn_request_code: Solicita un código
-      device_invoice: Factura del dispositivo
-      device_invoice_label: Descarga documentos comerciales para tu gestor o tu (extraña) colección de PDFs.
-      device_invoice_hint: Encuéntralo en tu página de seguimiento de envío o en el correo de notificación de envío.
       email_address_hint: Se usa para conectarse a TRMNL y recibir mensajes.
       first_name_hint: Usamos tu nombre para hacer que la interfaz de TRMNL sea más cómoda.
       last_name_hint: Usamos tu apellido para hacer que la interfaz de TRMNL sea más cómoda.
@@ -234,13 +216,7 @@ es-ES:
   dashboard:
     index:
       title: Panel de control
-      last_7_days: Últimos 7 días
-      last_30_days: Últimos 30 días
-      last_90_days: Últimos 90 días
-      today: Hoy
-      yesterday: Ayer
     health:
-      bad: Algunos plugins tienen problemas
       good: Los plugins funcionan correctamente
       next_steps: Te informaremos si algo cambia
     news:
@@ -257,14 +233,9 @@ es-ES:
       new_and_popular: Nuevos y Populares
     shop:
       title: Tienda
-      need_another: "¿Necesitas otro TRMNL?"
     time_saved:
       title: Tiempo ahorrado
-      cta: Leer más
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: "¡Buenos días,"
@@ -277,7 +248,6 @@ es-ES:
     edit:
       accepts_beta_firmware: Firmware de versión de pruebas
       accepts_beta_firmware_hint: Activa para obtener las últimas mejoras de firmware del dispositivo antes que otros usuarios.
-      back_to_devices: Volver a Dispositivos
       battery_and_sleep: Batería y suspensión
       battery_consumption: Consumo de batería
       battery_consumption_hint: Ahorra energía y mejora el uso de batería habilitando el Modo de suspensión.
@@ -299,7 +269,6 @@ es-ES:
       device_model_switch_warning: Esta es una operación peligrosa, aprende más __aquí__
       device_info: Información del dispositivo
       current_firmware: Firmware actual
-      last_ping: Último ping
       unknown: Desconocido
       never: Nunca
       display_calibration: Calibración de pantalla
@@ -345,7 +314,6 @@ es-ES:
       ota_byod_not_supported: OTA no es compatible con dispositivos BYOD. Flashea una versión compatible directamente desde trmnl.com/flash
       maximum_compatibility: Habilitar Compatibilidad Máxima
       maximum_compatibility_hint: Resuelve problemas de visualización causados por ciertos chips de tinta electrónica. Desactiva la actualización rápida. Firmware 1.6.0+ requerido.
-      color_and_rotation: Color & Rotación
       image_rotation: Image Rotation
       screen_rotation: Rotación de pantalla
       screen_rotation_not_supported: La rotación de pantalla no está actualmente soportada en tu dispositivo.
@@ -367,9 +335,7 @@ es-ES:
       tidbyt_credentials: Credenciales Tidbyt
       tidbyt_credentials_hint: Introduce las credenciales API de tu dispositivo Tidbyt desde la app de Tidbyt en Ajustes → Developer → Obtener clave API.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Las credenciales API de Tidbyt no son válidas. Por favor, comprueba y vuelve a intentarlo.
       tidbyt_device_id: ID del dispositivo
-      tidbyt_device_api_key: Clave API
       unlink: Desvincular
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Desvincular dispositivo
@@ -377,7 +343,6 @@ es-ES:
       unlink_device_learn_more: Sigue la guía completa __aquí__.
       visibility: Visibilidad
       visibility_hint: Haz que tu dispositivo TRMNL pueda ser replicado cambiando la configuración a continuación.
-      your_device: Tu TRMNL
       upgrade_og:
         title: Actualización a pantalla de 2 bits disponible
         sub_title: Tu dispositivo puede actualizarse para soportar una pantalla de escala de grises mejorada con 4 niveles de color en lugar de 2.
@@ -414,9 +379,6 @@ es-ES:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ es-ES:
     index:
       title: Dispositivos
       tagline: Tus dispositivos TRMNL
-      add_device_modal_title: Añadir un nuevo dispositivo
       add_first_device: "¡Añade tu primer dispositivo!"
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -516,9 +477,6 @@ es-ES:
     dissociate:
       error: Error al desconectar el dispositivo
       success: Dispositivo desvinculado correctamente
-    external_credentials:
-      error: Credenciales del dispositivo inválidas
-      success: Credenciales del dispositivo actualizadas correctamente
     identify:
       error: Error al actualizar el dispositivo
       success: Identificación del dispositivo solicitada
@@ -557,16 +515,11 @@ es-ES:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Demasiados intentos, por favor, espera e inténtalo de nuevo
-    invoice_not_found: Factura no encontrada
   logs:
     index:
       title: Registros
       all: Todos
-      bulk_destroy: Eliminar masivamente
       dump: Message
-      id: ID
       private_plugins: Plugins privados
       source: Fuente
       time: Time (UTC)
@@ -601,9 +554,6 @@ es-ES:
       live_preview: Vista previa en vivo
       no_changes_to_save: No hay cambios para guardar
       pop_out_preview: Abrir vista previa en ventana separada
-      quickstart_examples: Ejemplos rápidos
-      quickstart_example_applied: "¡Aplicado!"
-      quickstart_use_this_example: Usa este ejemplo
       revert: Revertir
       revert_confirm: "¿Seguro que quieres revertir? Todos los cambios sin guardar se perderán."
       save_changes: Guardar cambios (⌘﹢S)
@@ -667,9 +617,6 @@ es-ES:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA deshabilitado
@@ -695,21 +642,12 @@ es-ES:
   playlist_items:
     index:
       title: Lista de reproducción
-      tagline: Elige lo que se muestra en
-      add_a_group: Añadir un grupo
-      add_a_plugin: Añadir un plugin
       add_first_device_cta: "¡Empieza __añadiendo__ tu primer dispositivo TRMNL!"
       add_to_playlist: Añadir a la lista
-      create_first_playlist_cta: "¡Crea tu lista de reproducción después de __conectar__ tu primer plugin!"
       custom: Personalizado
       device_default: Predeterminado del dispositivo
-      display_period_from: Mostrar desde
-      display_period_to: hasta
       display_period_validation: La hora de inicio debe ser antes de la hora de fin. Crea otro grupo para abarcar horas nocturnas.
-      every: Cada
       never_skip: Nunca omitir pantallas
-      smart_playlist: Lista inteligente
-      smart_playlist_hint: Omitir automáticamente pantallas cuyos contenidos no han cambiado durante un tiempo.
       skip_after:
         one: Omitir pantallas obsoletas después de 1 día
         other: Omitir pantallas obsoletas después de %{count} días
@@ -747,9 +685,6 @@ es-ES:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: La tasa de actualización de este plugin no se puede configurar.
         external: Este plugin obtiene datos al vuelo, por lo que la configuración de la tasa de actualización no se aplica.
@@ -766,7 +701,6 @@ es-ES:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Falló la actualización de la lista
       success: Lista actualizada
     destroy:
       error: Error al eliminar el elemento de la lista
@@ -779,8 +713,6 @@ es-ES:
       success: Orden de la lista actualizado
     set_preferences:
       success: Preferencias de lista inteligente actualizadas
-    update:
-      success: Orden de la lista actualizado
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -811,23 +743,10 @@ es-ES:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -835,8 +754,6 @@ es-ES:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -847,9 +764,6 @@ es-ES:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -865,7 +779,6 @@ es-ES:
     index:
       title: Plugins
       tagline: "¿Qué pondrás en tu TRMNL?"
-      available: Disponible
       connected: Conectado
       supported_by_this_device: Supported by this device
       recipes: Recetas
@@ -877,7 +790,6 @@ es-ES:
         title: Mis plugins
         tagline: Desarrolla para el mercado de plugins
       card:
-        connections: Conexiones
         install: Instalar
         review_are_you_sure: "¿Estás seguro? El equipo de TRMNL lo revisará y te enviará un email con cualquier duda."
         submit_for_review: Mandar a revisión
@@ -907,16 +819,11 @@ es-ES:
     edit:
       title: Editar plugin
       tagline: Actualizar la información de tu plugin.
-      name: Nombre
-      description: Descripción
   plugin_recipes:
     connected: Receta conectada
     connections:
       one: Conexión
       other: Conexiones
-    forks:
-      one: Fork
-      other: Forks
     forked: Recipe forked
     new:
       error: Receta no encontrada
@@ -924,18 +831,14 @@ es-ES:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Activo
     copy_are_you_sure: "¿Estás seguro de que quieres copiar este plugin?"
     delete_are_you_sure: "¿Estás seguro de que quieres eliminar este plugin?"
     delete: Esto borrará completamente la configuración del plugin. Para ocultar este plugin de tu dispositivo, elimínalo de tu lista de reproducción.
-    inactive: Inactivo
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: No se encontraron configuraciones del plugin.
     not_supported: No compatible con el dispositivo actual
     refreshing_now_please_wait: Actualizando, refresca la página en unos segundos.
     reset_credentials: Cuenta de %{plugin_name} restablecida con éxito
     form:
-      active_hint: Mostrar u ocultar este plugin en tu dispositivo
       advanced_settings: Ajustes avanzados
       back_to_playlist: Volver a la lista
       back_to_plugin: Volver a %{plugin}
@@ -957,15 +860,7 @@ es-ES:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Aprende sobre este plugin en nuestra base de conocimientos
-      learn_more_fork: Este plugin fue bifurcado de una receta.
-      learn_more_fork_original: Ver original
-      learn_more_native_long: Este plugin es nativo y está mantenido por TRMNL.
-      learn_more_native_short: Mantenido por TRMNL.
       learn_more_recipe_author: "¿Necesitas ayuda? Contacta a %{recipe_author} en Discord."
-      learn_more_recipe_long: Este plugin es una receta de la comunidad y no es mantenido por TRMNL.
-      learn_more_recipe_short: 'Nota: este plugin es una receta.'
-      learn_more_third_party_long: Este plugin es de un tercero y no está mantenido por TRMNL.
-      learn_more_third_party_short: 'Nota: este plugin es de un tercero.'
       linked_account: Cuenta vinculada
       linked_account_success: Vinculado con éxito a %{plugin_name}
       link_oauth: Vincular cuenta
@@ -987,7 +882,6 @@ es-ES:
       recipe_cta_body_published: Los cambios se reflejarán en instalaciones existentes y futuras, así como en futuros forks.
       recipe_cta_body_in_review: Este plugin ha sido enviado a nuestro equipo. Mantente a la espera.
       recipe_cta_body_not_published: Envía este plugin para que otros lo instalen. __Aprende más__.
-      recipe_cta_confirm: "¿Seguro? Nuestro equipo revisará y responderá en un par de días. Puedes continuar haciendo cambios."
       recipe_mirrored: Esta pantalla está replicada desde la receta.
       recipe_visibility_title: "¿Cómo te gustaría publicarlo?"
       recipe_visibility_edit_title: Editar envío
@@ -998,8 +892,6 @@ es-ES:
       recipe_visibility_unlisted: No listado
       recipe_visibility_unlisted_hint: Cualquiera con el enlace puede instalarlo.
       refresh_rate: Tasa de refresco
-      refresh_rate_hint: Define con qué frecuencia esta instancia de plugin obtiene nuevos datos
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Sincroniza %{refresh_rate} (no configurable)
       refreshed: Refrescado
       remove_plugin: Eliminar plugin
@@ -1056,10 +948,8 @@ es-ES:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Añade una programación personalizada
       append: Y durante…
       no_schedule: Esta pantalla se mostrará en todo momento.
-      some_schedule: Solo mostrar esta pantalla durante…
       to: a
       copy_prompt: Copiar programación de…
       no_days_error: Please select at least one day.
@@ -1085,11 +975,6 @@ es-ES:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1618,7 +1503,6 @@ es-ES:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -12,7 +12,6 @@ fr:
   back: Retour
   back_to_all_blog_posts: Retour à tous les articles
   blog: Blog
-  brand: Marque
   buy_now: Acheter maintenant
   cancel: Annuler
   change_password: Changer le mot de passe
@@ -26,15 +25,11 @@ fr:
   copy: Copier
   copied_to_clipboard: Copié !
   copy_to_clipboard: Copier dans le presse-papiers
-  created: Créé
   create_an_account: Créer un compte
   current_device: Appareil actuel
-  days: jours
   delete: Supprimer
   developers: Développeurs
   developer_edition_required: Édition développeur nécessaire pour activer cette fonctionnalité.
-  device_id: ID de l'appareil
-  device: Appareil
   discard: Discard
   edit: Modifier
   email_address: Adresse email
@@ -45,7 +40,6 @@ fr:
   forgot_password_title: Réinitialiser le mot de passe
   friendly_id: Friendly ID
   get_started: Commençons !
-  hidden: masqué
   identify: Identifier
   import: Importer
   import_new: Importer
@@ -59,32 +53,23 @@ fr:
   log_out: Se déconnecter
   manage: Gérer
   minimum_characters: caractères minimum
-  mins: min
-  my_playlist: Ma playlist
   new_password: Nouveau mot de passe
   password: Mot de passe
-  please_wait: Veuillez patienter...
   plugin_not_found: Plugin introuvable
   preview: Aperçu
-  privacy: Confidentialité
-  refresh_rate: Refresh rate
   refresh_rates_hint: Apprenez comment le taux de rafraîchissement fonctionne __ici__.
   reset_password: Réinitialiser mon mot de passe
   reset_to_defaults: Reset to defaults
   required: Requis
   save: Enregistrer
-  shown: affiché
   section: Section
   settings: Paramètres
   sign_in: S'identifier
   sign_up: S'inscrire
   something_went_wrong: Une erreur est survenue
   status: Statut
-  subscribe: S'abonner
   help_center: Support
-  terms: Conditions
   unsaved_changes: You have unsaved changes
-  update: Mise à jour
   view: Vue
   collaboration_request: Envie de collaborer ?
   collaboration_request_hint: Partenariats, ventes groupées, projets spéciaux, c'est vous qui décidez.
@@ -155,9 +140,6 @@ fr:
       refer_and_earn_hint: Partagez votre coupon TRMNL personnalisé. Recevez une rémunération pour chaque utilisation, versée chaque mois."
       refer_and_earn_redemptions: Utilisations du code
       refer_and_earn_request_code: Demander un code
-      device_invoice: Facture de l'appareil
-      device_invoice_label: "Téléchargez les documents commerciaux pour votre comptable (ou pour votre collection de PDF, si vous en avez une \U0001F609)."
-      device_invoice_hint: Retrouvez ce numéro sur la page de suivi de votre colis ou dans l'e-mail de notification de l'envoi.
       email_address_hint: Utilisé pour s'identifier dans TRMNL et recevoir des messages du système.
       first_name_hint: Nous utilisons votre prénom pour rendre l'interface de TRMNL plus agréable.
       last_name_hint: Nous utilisons votre nom pour rendre l'interface de TRMNL plus agréable.
@@ -236,13 +218,7 @@ fr:
   dashboard:
     index:
       title: Tableau de bord
-      last_7_days: 7 derniers jours
-      last_30_days: 30 derniers jours
-      last_90_days: 90 derniers jours
-      today: Aujourd'hui
-      yesterday: Hier
     health:
-      bad: Les plugins rencontrent des problèmes
       good: Les plugins fonctionnent correctement
       next_steps: Nous vous informerons si quelque chose change
     news:
@@ -259,14 +235,9 @@ fr:
       new_and_popular: Récents et populaires
     shop:
       title: Boutique
-      need_another: Besoin d'un autre TRMNL ?
     time_saved:
       title: Temps économisé
-      cta: À propos
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Bonjour
@@ -279,7 +250,6 @@ fr:
     edit:
       accepts_beta_firmware: Mise à jour en accès anticipé
       accepts_beta_firmware_hint: Activer pour obtenir les dernières améliorations du firmware de l'appareil avant les autres utilisateurs.
-      back_to_devices: Retour aux appareils
       battery_and_sleep: Batterie et veille
       battery_consumption: Consommation de la batterie
       battery_consumption_hint: Économisez de l'énergie et appréciez une meilleure durée de vie de la batterie en activant le Mode Veille.
@@ -301,7 +271,6 @@ fr:
       device_model_switch_warning: Cette opération est dangereuse, en savoir plus __ici__
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -347,7 +316,6 @@ fr:
       ota_byod_not_supported: L'OTA n'est pas pris en charge pour les appareils BYOD. Flashez une version compatible directement depuis trmnl.com/flash
       maximum_compatibility: Activer la compatibilité maximale
       maximum_compatibility_hint: Résout les problèmes d'affichage causés par certaines puces de pilote ePaper. Désactive le rafraîchissement rapide. Firmware 1.6.0+ requis.
-      color_and_rotation: Couleur & Rotation
       image_rotation: Image Rotation
       screen_rotation: Rotation de l'écran
       screen_rotation_not_supported: La rotation de l'écran n'est pas actuellement prise en charge sur votre appareil.
@@ -369,9 +337,7 @@ fr:
       tidbyt_credentials: Identifiants Tidbyt
       tidbyt_credentials_hint: Entrez les identifiants API de votre appareil Tidbyt depuis l'app Tidbyt sous Paramètres → Développeur → Obtenir la clé API.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Les identifiants API Tidbyt sont invalides. Veuillez vérifier et réessayer.
       tidbyt_device_id: ID de l'appareil
-      tidbyt_device_api_key: Clé API
       unlink: Dissocier
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Dissocier l'appareil
@@ -379,7 +345,6 @@ fr:
       unlink_device_learn_more: Suivez le guide complet __ici__.
       visibility: Visibilité
       visibility_hint: Synchroniser votre appareil TRMNL en changeant la configuration ci-dessous.
-      your_device: Votre TRMNL
       upgrade_og:
         title: Mise à niveau vers écran 2 bits disponible
         sub_title: Votre appareil peut être mis à niveau pour prendre en charge un affichage en niveaux de gris amélioré avec 4 niveaux au lieu de 2.
@@ -416,9 +381,6 @@ fr:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -492,7 +454,6 @@ fr:
     index:
       title: Appareils
       tagline: Vos appareils TRMNL
-      add_device_modal_title: Ajouter un nouvel appareil
       add_first_device: Commencez en ajoutant votre premier appareil !
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -518,9 +479,6 @@ fr:
     dissociate:
       error: Erreur lors de la dissociation de l'appareil
       success: Appareil dissocié avec succès
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: Erreur lors de l'identification de l'appareil
       success: Appareil identifié avec succès
@@ -559,16 +517,11 @@ fr:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Trop de tentatives, veuillez patienter et réessayer
-    invoice_not_found: Facture introuvable
   logs:
     index:
       title: Logs
       all: Tous
-      bulk_destroy: Bulk Destroy
       dump: Message
-      id: ID
       private_plugins: Plugins privés
       source: Source
       time: Time (UTC)
@@ -603,9 +556,6 @@ fr:
       live_preview: Aperçu en direct
       no_changes_to_save: Pas de modifications à enregistrer
       pop_out_preview: Aperçu détaché
-      quickstart_examples: Exemples de démarrage rapide
-      quickstart_example_applied: Appliqué !
-      quickstart_use_this_example: Utiliser cet exemple
       revert: Annuler
       revert_confirm: Êtes-vous sûr de vouloir annuler ? Toutes modifications non enregistrées seront perdues.
       save_changes: Enregistrer les modifications (⌘﹢S)
@@ -669,9 +619,6 @@ fr:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: A2F désactivée
@@ -697,21 +644,12 @@ fr:
   playlist_items:
     index:
       title: Playlist
-      tagline: Choisir ce qui est affiché
-      add_a_group: Ajouter un groupe
-      add_a_plugin: Ajouter un plugin
       add_first_device_cta: Commencez par __ajouter__ votre premier appareil TRMNL !
       add_to_playlist: Ajouter à la playlist
-      create_first_playlist_cta: Créez votre playlist après avoir __connecté__ votre premier plugin !
       custom: Personnalisé
       device_default: Configuration par défaut
-      display_period_from: Afficher entre
-      display_period_to: et
       display_period_validation: L'heure de début doit précéder l'heure de fin. Créez un autre groupe pour couvrir les heures de nuit.
-      every: Tous les
       never_skip: Ne jamais ignorer les écrans
-      smart_playlist: Playlist intelligente
-      smart_playlist_hint: Ignore automatiquement les écrans dont le contenu n'a pas changé depuis un moment.
       skip_after:
         one: Ignorer les écrans inchangés après 1 jour
         other: Ignorer les écrans inchangés après %{count} jours
@@ -749,9 +687,6 @@ fr:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -768,7 +703,6 @@ fr:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Échec de la mise à jour de la playlist
       success: Playlist mise à jour
     destroy:
       error: Erreur lors de la suppression de l'élément de la playlist
@@ -781,8 +715,6 @@ fr:
       success: Ordre de la playlist mis à jour
     set_preferences:
       success: Préférences de la playlist intelligente mises à jour
-    update:
-      success: Ordre de la playlist mis à jour
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -813,23 +745,10 @@ fr:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -837,8 +756,6 @@ fr:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -849,9 +766,6 @@ fr:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -867,7 +781,6 @@ fr:
     index:
       title: Plugins
       tagline: Qu'allez-vous afficher sur votre TRMNL ?
-      available: Disponible
       connected: Connecté
       supported_by_this_device: Supported by this device
       recipes: Recettes
@@ -879,7 +792,6 @@ fr:
         title: Mes plugins
         tagline: Développer des plugins pour le marketplace
       card:
-        connections: connexions
         install: Installer
         review_are_you_sure: Êtes-vous sûr ? L'équipe TRMNL va le tester et vous contactera en cas de questions.
         submit_for_review: Soumettre pour revue
@@ -909,16 +821,11 @@ fr:
     edit:
       title: Modifier le plugin
       tagline: Mettre à jour les détails de votre plugin.
-      name: Nom
-      description: Description
   plugin_recipes:
     connected: Recette connectée
     connections:
       one: Connexion
       other: Connexions
-    forks:
-      one: Duplication
-      other: Duplications
     forked: Recipe forked
     new:
       error: Recette introuvable
@@ -926,18 +833,14 @@ fr:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Actif
     copy_are_you_sure: Êtes-vous sûr de vouloir copier ce paramètre ?
     delete_are_you_sure: Êtes-vous sûr de vouloir supprimer ce paramètre ?
     delete: Cela va entièrement supprimer les paramètres du plugin. Pour simplement masquer le plugin de votre appareil, supprimez-le plutôt de la playlist.
-    inactive: Inactif
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: Aucun paramètre pour le plugin trouvé.
     not_supported: Non pris en charge sur l'appareil actuel
     refreshing_now_please_wait: Actualisation en cours, veuillez recharger cette page dans quelques secondes.
     reset_credentials: Compte %{plugin_name} réinitialisé avec succès
     form:
-      active_hint: Afficher ou masquer cette instance de plugin sur votre appareil
       advanced_settings: Paramètres avancés
       back_to_playlist: Back to Playlist
       back_to_plugin: Retour à %{plugin}
@@ -959,15 +862,7 @@ fr:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Plus d'informations sur ce plugin dans notre base de connaissances
-      learn_more_fork: Ce plugin a été dupliqué à partir d'une Recette.
-      learn_more_fork_original: Voir l'original
-      learn_more_native_long: Ce plugin est natif et maintenu par TRMNL.
-      learn_more_native_short: Ce plugin est maintenu par TRMNL.
       learn_more_recipe_author: Besoin d'aide ? Contactez %{recipe_author} sur Discord.
-      learn_more_recipe_long: Ce plugin est une Recette communautaire et n'est pas maintenu par TRMNL.
-      learn_more_recipe_short: 'Note : ce plugin est une Recette.'
-      learn_more_third_party_long: Ce plugin est tiers et n'est pas maintenu par TRMNL.
-      learn_more_third_party_short: 'Note : ce plugin est tiers.'
       linked_account: Compte lié
       linked_account_success: Lié avec succès à %{plugin_name}
       link_oauth: Lier un compte
@@ -989,7 +884,6 @@ fr:
       recipe_cta_body_published: Les modifications seront appliquées aux installations existantes et futures (y compris les duplications).
       recipe_cta_body_in_review: Ce plugin a été soumis à notre équipe. Merci de patienter.
       recipe_cta_body_not_published: Soumettez ce plugin pour que d'autres puissent l'installer. __En savoir plus__.
-      recipe_cta_confirm: Êtes-vous sûr ? Notre équipe va l'examiner et vous recontacter dans quelques jours. Vous pouvez continuer à apporter des modifications.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: Comment souhaitez-vous publier ?
       recipe_visibility_edit_title: Modifier la soumission
@@ -1000,8 +894,6 @@ fr:
       recipe_visibility_unlisted: Non répertorié
       recipe_visibility_unlisted_hint: Toute personne disposant du lien peut l'installer.
       refresh_rate: Taux de rafraîchissement
-      refresh_rate_hint: Définit la fréquence à laquelle cette instance de plugin récupérera les nouvelles données
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Synchronise %{refresh_rate} (non configurable)
       refreshed: Rafraîchi
       remove_plugin: Retirer le plugin
@@ -1058,10 +950,8 @@ fr:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Ajouter un horaire personnalisé
       append: Et pendant…
       no_schedule: Cet écran sera toujours affiché.
-      some_schedule: Afficher cet écran uniquement pendant…
       to: à
       copy_prompt: Copier l'horaire depuis…
       no_days_error: Please select at least one day.
@@ -1087,11 +977,6 @@ fr:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1620,7 +1505,6 @@ fr:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -12,7 +12,6 @@ he:
   back: Back
   back_to_all_blog_posts: Back to all posts
   blog: Blog
-  brand: Brand
   buy_now: Buy Now
   cancel: Cancel
   change_password: Change Password
@@ -26,15 +25,11 @@ he:
   copy: Copy
   copied_to_clipboard: Copied!
   copy_to_clipboard: Copy to clipboard
-  created: Created
   create_an_account: Create an account
   current_device: Current device
-  days: days
   delete: Delete
   developers: Developers
   developer_edition_required: Developer edition is required to enable this feature.
-  device_id: Device ID
-  device: Device
   discard: Discard
   edit: Settings
   email_address: Email address
@@ -45,7 +40,6 @@ he:
   forgot_password_title: Here we go again
   friendly_id: Friendly ID
   get_started: Let's get you started!
-  hidden: hidden
   identify: Identify
   import: Import
   import_new: Import new
@@ -59,32 +53,23 @@ he:
   log_out: Log out
   manage: Manage
   minimum_characters: characters minimum
-  mins: mins
-  my_playlist: My Playlist
   new_password: New password
   password: Password
-  please_wait: Please Wait...
   plugin_not_found: Plugin not found
   preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
   refresh_rates_hint: Learn how refresh rates work __here__.
   reset_password: Reset my password
   reset_to_defaults: Reset to defaults
   required: Required
   save: Save
-  shown: shown
   section: Section
   settings: Settings
   sign_in: Sign in
   sign_up: Sign up
   something_went_wrong: Something went wrong
   status: Status
-  subscribe: Subscribe
   help_center: Support
-  terms: Terms
   unsaved_changes: You have unsaved changes
-  update: Update
   view: View
   collaboration_request: Wanna collaborate?
   collaboration_request_hint: Partnerships, group sales, special projects, your call.
@@ -155,9 +140,6 @@ he:
       refer_and_earn_hint: Give the gift of TRMNL with a personalized coupon. Earn per use, paid monthly.
       refer_and_earn_redemptions: Redemptions
       refer_and_earn_request_code: Request a Code
-      device_invoice: Device Invoice
-      device_invoice_label: Download commercial documents for your accountant or (weird) PDF collection.
-      device_invoice_hint: Find this on your package tracking page or shipment notification email.
       email_address_hint: Used to sign into TRMNL and receive system messages.
       first_name_hint: We use your name to make the TRMNL interface more comfortable.
       last_name_hint: We use your name to make the TRMNL interface more comfortable.
@@ -236,13 +218,7 @@ he:
   dashboard:
     index:
       title: Dashboard
-      last_7_days: Last 7 days
-      last_30_days: Last 30 days
-      last_90_days: Last 90 days
-      today: Today
-      yesterday: Yesterday
     health:
-      bad: Plugins are experiencing issues
       good: Plugins are healthy
       next_steps: We will inform you if anything changes
     news:
@@ -259,14 +235,9 @@ he:
       new_and_popular: New and Popular
     shop:
       title: Shop
-      need_another: Need another TRMNL?
     time_saved:
       title: Time saved
-      cta: Read about
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Good morning
@@ -279,7 +250,6 @@ he:
     edit:
       accepts_beta_firmware: Firmware Early Release
       accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
-      back_to_devices: Back to Devices
       battery_and_sleep: Battery & Sleep
       battery_consumption: Battery Consumption
       battery_consumption_hint: Save power and enjoy a longer battery life by enabling Sleep Mode.
@@ -301,7 +271,6 @@ he:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -347,7 +316,6 @@ he:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
-      color_and_rotation: Color & Rotation
       image_rotation: Image Rotation
       screen_rotation: Screen Rotation
       screen_rotation_not_supported: Screen rotation is currently not supported on your device.
@@ -369,9 +337,7 @@ he:
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
       unlink: Unlink
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Unlink Device
@@ -379,7 +345,6 @@ he:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
-      your_device: Your TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -416,9 +381,6 @@ he:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -492,7 +454,6 @@ he:
     index:
       title: Devices
       tagline: Your TRMNL devices
-      add_device_modal_title: Add a new device
       add_first_device: Start by adding your first device!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -518,9 +479,6 @@ he:
     dissociate:
       error: Error disconnecting device
       success: Device successfully unlinked
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: Error updating device
       success: Device identification requested
@@ -559,16 +517,11 @@ he:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Too many attempts, please wait and try again
-    invoice_not_found: Invoice not found
   logs:
     index:
       title: Logs
       all: All
-      bulk_destroy: Bulk Destroy
       dump: Message
-      id: ID
       private_plugins: Private plugins
       source: Source
       time: Time (UTC)
@@ -603,9 +556,6 @@ he:
       live_preview: Live Preview
       no_changes_to_save: No changes to save
       pop_out_preview: Pop Out Preview
-      quickstart_examples: Quick-start Examples
-      quickstart_example_applied: Applied!
-      quickstart_use_this_example: Use this example
       revert: Revert
       revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
       save_changes: Save Changes (⌘﹢S)
@@ -669,9 +619,6 @@ he:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA Disabled
@@ -697,21 +644,12 @@ he:
   playlist_items:
     index:
       title: Playlist
-      tagline: Choose what's shown on
-      add_a_group: Add a Group
-      add_a_plugin: Add a Plugin
       add_first_device_cta: Start by __adding__ your first TRMNL device!
       add_to_playlist: Add to Playlist
-      create_first_playlist_cta: Create your playlist after __connecting__ your first plugin!
       custom: Custom
       device_default: Device default
-      display_period_from: Display from
-      display_period_to: to
       display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
       never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
       skip_after:
         one: Skip stale screens after 1 day
         other: Skip stale screens after %{count} days
@@ -749,9 +687,6 @@ he:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -768,7 +703,6 @@ he:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Failed to update playlist
       success: Playlist updated
     destroy:
       error: Error removing item from playlist
@@ -781,8 +715,6 @@ he:
       success: Playlist order updated
     set_preferences:
       success: Smart playlist preference updated
-    update:
-      success: Playlist order updated
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -813,23 +745,10 @@ he:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -837,8 +756,6 @@ he:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -849,9 +766,6 @@ he:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -867,7 +781,6 @@ he:
     index:
       title: Plugins
       tagline: What will you put on your TRMNL?
-      available: Available
       connected: Connected
       supported_by_this_device: Supported by this device
       recipes: Recipes
@@ -879,7 +792,6 @@ he:
         title: My Plugins
         tagline: Develop Plugins for the public marketplace
       card:
-        connections: connections
         install: Install
         review_are_you_sure: Are you sure? The TRMNL team will test it and email you any questions.
         submit_for_review: Submit for Review
@@ -909,16 +821,11 @@ he:
     edit:
       title: Edit Plugin
       tagline: Update your plugin details.
-      name: Name
-      description: Description
   plugin_recipes:
     connected: Recipe connected
     connections:
       one: Connection
       other: Connections
-    forks:
-      one: Fork
-      other: Forks
     forked: Recipe forked
     new:
       error: Recipe not found
@@ -926,18 +833,14 @@ he:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Active
     copy_are_you_sure: Are you sure you want to copy this setting?
     delete_are_you_sure: Are you sure you want to delete this setting?
     delete: This will completely remove the plugin's settings. To simply hide this plugin from your device, delete it from your Playlist instead.
-    inactive: Inactive
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: No plugin settings found.
     not_supported: Not supported on current device
     refreshing_now_please_wait: Refreshing now, reload this page in a few seconds.
     reset_credentials: "%{plugin_name} account reset successfully"
     form:
-      active_hint: Show or hide this plugin instance on your device
       advanced_settings: Advanced Settings
       back_to_playlist: Back to Playlist
       back_to_plugin: Back to %{plugin}
@@ -959,15 +862,7 @@ he:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Learn about this plugin in our knowledge base
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
       learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       linked_account: Linked Account
       linked_account_success: Successfully linked with %{plugin_name}
       link_oauth: Link Account
@@ -989,7 +884,6 @@ he:
       recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
       recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
       recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: How would you like to publish?
       recipe_visibility_edit_title: Edit Submission
@@ -1000,8 +894,6 @@ he:
       recipe_visibility_unlisted: Unlisted
       recipe_visibility_unlisted_hint: Anyone with the link can install.
       refresh_rate: Refresh rate
-      refresh_rate_hint: Define how frequently this plugin instance fetches fresh data
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
       refreshed: Refreshed
       remove_plugin: Remove plugin
@@ -1058,10 +950,8 @@ he:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Add a custom schedule
       append: And during…
       no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
       to: to
       copy_prompt: Copy schedule from…
       no_days_error: Please select at least one day.
@@ -1087,11 +977,6 @@ he:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1620,7 +1505,6 @@ he:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -12,7 +12,6 @@ hu:
   back: Vissza
   back_to_all_blog_posts: Vissza az összes bejegyzéshez
   blog: Blog
-  brand: Brand
   buy_now: Megveszem
   cancel: Mégsem
   change_password: Jelszó módosítása
@@ -26,15 +25,11 @@ hu:
   copy: Másolás
   copied_to_clipboard: Másolva!
   copy_to_clipboard: Másolás a vágólapra
-  created: Létrehozva
   create_an_account: Fiók létrehozása
   current_device: Jelenlegi eszköz
-  days: nap
   delete: Törlés
   developers: Developers
   developer_edition_required: A funkció használatához fejlesztői kiadás szükséges.
-  device_id: Eszközazonosító
-  device: Eszköz
   discard: Discard
   edit: Szerkesztés
   email_address: E-mail cím
@@ -45,7 +40,6 @@ hu:
   forgot_password_title: Semmi gond, megoldjuk!
   friendly_id: Friendly ID
   get_started: Kezdjük el!
-  hidden: hidden
   identify: Azonosítás
   import: Importálás
   import_new: Új importálása
@@ -59,32 +53,23 @@ hu:
   log_out: Kijelentkezés
   manage: Kezelés
   minimum_characters: minimum karakter
-  mins: perc
-  my_playlist: Saját lejátszási lista
   new_password: Új jelszó
   password: Jelszó
-  please_wait: Kérlek, várj...
   plugin_not_found: A bővítmény nem található
   preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
   refresh_rates_hint: Itt megtudhatod, hogyan működnek a frissítési gyakoriságok __itt__.
   reset_password: Jelszó visszaállítása
   reset_to_defaults: Reset to defaults
   required: Required
   save: Mentés
-  shown: shown
   section: Szakasz
   settings: Beállítások
   sign_in: Bejelentkezés
   sign_up: Regisztráció
   something_went_wrong: Valami hiba történt
   status: Status
-  subscribe: Feliratkozás
   help_center: Technikai támogatás
-  terms: Terms
   unsaved_changes: You have unsaved changes
-  update: Frissítés
   view: Megtekintés
   collaboration_request: Wanna collaborate?
   collaboration_request_hint: Partnerships, group sales, special projects, your call.
@@ -153,9 +138,6 @@ hu:
       refer_and_earn_hint: Ajándékozd meg barátaidat egy személyre szabott TRMNL-kuponnal, és szerezz jutalmat minden használat után (havonta fizetve).
       refer_and_earn_redemptions: Beváltások
       refer_and_earn_request_code: Kód igénylése
-      device_invoice: Eszköz számla
-      device_invoice_label: Töltsd le a számlád.
-      device_invoice_hint: Ezt megtalálod a csomagkövetési oldalon vagy a szállítási értesítő e-mailben.
       email_address_hint: A TRMNL-ba való bejelentkezéshez és rendszerüzenetek fogadásához használjuk.
       first_name_hint: A keresztneved segít személyesebbé tenni a TRMNL felületét.
       last_name_hint: A vezetékneved segít személyesebbé tenni a TRMNL felületét.
@@ -234,13 +216,7 @@ hu:
   dashboard:
     index:
       title: Irányítópult
-      last_7_days: Az elmúlt 7 napban
-      last_30_days: Az elmúlt 30 napban
-      last_90_days: Az elmúlt 90 napban
-      today: Ma
-      yesterday: Tegnap
     health:
-      bad: A bővítmények hibákat tapasztalnak
       good: A bővítmények rendben működnek
       next_steps: Értesítünk, ha bármi változás történik
     news:
@@ -257,14 +233,9 @@ hu:
       new_and_popular: Új és népszerű
     shop:
       title: Áruház
-      need_another: Szükséged van egy másik TRMNL-re?
     time_saved:
       title: Megtakarított idő
-      cta: Olvass róla
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Jó reggelt
@@ -277,7 +248,6 @@ hu:
     edit:
       accepts_beta_firmware: Korai firmware kiadás
       accepts_beta_firmware_hint: Kapcsold be, hogy a legújabb firmware-fejlesztéseket a többiek előtt megkapd.
-      back_to_devices: Vissza az eszközökhöz
       battery_and_sleep: Battery & Sleep
       battery_consumption: Akkumulátorhasználat
       battery_consumption_hint: Spórolj energiát és élvezd a hosszabb üzemidőt az alvó mód bekapcsolásával.
@@ -299,7 +269,6 @@ hu:
       device_model_switch_warning: Ez veszélyes művelet, tudj meg róla többet __itt__.
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -345,7 +314,6 @@ hu:
       ota_byod_not_supported: Az OTA nem támogatott a saját eszközök (BYOD) esetén. Tölts le egy kompatibilis verziót közvetlenül a trmnl.com/flash oldalról.
       maximum_compatibility: Maximális kompatibilitás engedélyezése
       maximum_compatibility_hint: Kijavítja az egyes ePaper kijelzőchipek által okozott megjelenítési hibákat. Kikapcsolja a gyors frissítést. Firmware 1.6.0+ szükséges.
-      color_and_rotation: Szín & forgatás
       image_rotation: Image Rotation
       screen_rotation: Képernyő forgatása
       screen_rotation_not_supported: A képernyő forgatása jelenleg nem támogatott a te eszközödön.
@@ -367,9 +335,7 @@ hu:
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
       unlink: Leválasztás
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Eszköz leválasztása
@@ -377,7 +343,6 @@ hu:
       unlink_device_learn_more: Kövesd a teljes útmutatót __itt__.
       visibility: Láthatóság
       visibility_hint: Állítsd be, hogy a TRMNL eszközöd tükrözhető legyen az alábbi beállításokkal.
-      your_device: A te TRMNL-ed
       upgrade_og:
         title: Elérhető 2-bites kijelző frissítés
         sub_title: Az eszközöd frissíthető, hogy 2 helyett 4 szürkeárnyalati szintet támogasson.
@@ -414,9 +379,6 @@ hu:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ hu:
     index:
       title: Eszközök
       tagline: A te TRMNL eszközeid
-      add_device_modal_title: Új eszköz hozzáadása
       add_first_device: Kezdd az első eszközöd hozzáadásával!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -516,9 +477,6 @@ hu:
     dissociate:
       error: Hiba az eszköz leválasztása közben
       success: Az eszköz sikeresen leválasztva
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: Hiba az eszköz frissítésekor
       success: Eszközazonosítási kérés elküldve
@@ -557,16 +515,11 @@ hu:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Túl sok próbálkozás, kérlek várj, majd próbáld újra
-    invoice_not_found: A számla nem található
   logs:
     index:
       title: Naplók
       all: Összes
-      bulk_destroy: Bulk Destroy
       dump: Message
-      id: Azonosító
       private_plugins: Saját bővítmények
       source: Forrás
       time: Time (UTC)
@@ -601,9 +554,6 @@ hu:
       live_preview: Élő előnézet
       no_changes_to_save: Nincs mentendő módosítás
       pop_out_preview: Előnézet megnyitása külön ablakban
-      quickstart_examples: Gyorsindítási példák
-      quickstart_example_applied: Alkalmazva!
-      quickstart_use_this_example: Használd ezt a példát
       revert: Visszaállítás
       revert_confirm: Biztosan vissza szeretnéd állítani? Minden nem mentett változtatás elvész.
       save_changes: Módosítások mentése (⌘﹢S)
@@ -667,9 +617,6 @@ hu:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: Kétlépcsős azonosítás kikapcsolva
@@ -695,21 +642,12 @@ hu:
   playlist_items:
     index:
       title: Lejátszási lista
-      tagline: Válaszd ki, mi jelenjen meg a
-      add_a_group: Csoport hozzáadása
-      add_a_plugin: Bővítmény hozzáadása
       add_first_device_cta: Kezdd azzal, hogy __hozzáadod__ az első TRMNL eszközödet!
       add_to_playlist: Hozzáadás a lejátszási listához
-      create_first_playlist_cta: Hozd létre az első lejátszási listádat, miután __összekapcsoltad__ az első bővítményedet!
       custom: Egyéni
       device_default: Eszköz alapértelmezés
-      display_period_from: Megjelenítés ettől
-      display_period_to: "-ig"
       display_period_validation: A kezdési időpontnak a befejezés előtt kell lennie. Hozz létre egy másik csoportot az éjszakai órák lefedéséhez.
-      every: Minden
       never_skip: Soha ne hagyja ki a képernyőket
-      smart_playlist: Intelligens lejátszási lista
-      smart_playlist_hint: Automatikusan kihagyja azokat a képernyőket, amelyek tartalma egy ideje nem változott.
       skip_after:
         one: A régi képernyők kihagyása 1 nap után
         other: A régi képernyők kihagyása %{count} nap után
@@ -747,9 +685,6 @@ hu:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -766,7 +701,6 @@ hu:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Hiba történt a lejátszási lista frissítésekor
       success: Lejátszási lista frissítve
     destroy:
       error: Hiba történt az elem eltávolításakor a lejátszási listáról
@@ -779,8 +713,6 @@ hu:
       success: A lejátszási lista sorrendje frissítve
     set_preferences:
       success: Az intelligens lejátszási lista beállítása frissítve
-    update:
-      success: Playlist order updated
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -811,23 +743,10 @@ hu:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -835,8 +754,6 @@ hu:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -847,9 +764,6 @@ hu:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -865,7 +779,6 @@ hu:
     index:
       title: Bővítmények
       tagline: Mit szeretnél megjeleníteni a TRMNL-on?
-      available: Elérhető
       connected: Csatlakoztatva
       supported_by_this_device: Supported by this device
       recipes: Receptek
@@ -877,7 +790,6 @@ hu:
         title: Saját bővítményeim
         tagline: Készíts bővítményeket a nyilvános piactérre
       card:
-        connections: kapcsolatok
         install: Telepítés
         review_are_you_sure: Biztosan szeretnéd? A TRMNL csapat tesztelni fogja, és e-mailben keres, ha kérdés merül fel.
         submit_for_review: Beküldés ellenőrzésre
@@ -907,16 +819,11 @@ hu:
     edit:
       title: Bővítmény szerkesztése
       tagline: Frissítsd a bővítmény részleteit.
-      name: Név
-      description: Leírás
   plugin_recipes:
     connected: Recept csatlakoztatva
     connections:
       one: Kapcsolat
       other: Kapcsolatok
-    forks:
-      one: Fork
-      other: Forks
     forked: Recipe forked
     new:
       error: A recept nem található
@@ -924,18 +831,14 @@ hu:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Aktív
     copy_are_you_sure: Biztosan másolni szeretnéd ezt a beállítást?
     delete_are_you_sure: Biztosan törölni szeretnéd ezt a beállítást?
     delete: Ez teljesen eltávolítja a bővítmény beállításait. Ha csak elrejteni szeretnéd a bővítményt az eszközödről, töröld azt a lejátszási listádról.
-    inactive: Inaktív
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: Nem találhatók bővítménybeállítások.
     not_supported: Not supported on current device
     refreshing_now_please_wait: Frissítés folyamatban, kérlek frissítsd az oldalt néhány másodperc múlva.
     reset_credentials: "%{plugin_name} fiók sikeresen visszaállítva"
     form:
-      active_hint: Megjeleníti vagy elrejti ezt a bővítmény példányt az eszközödön
       advanced_settings: Speciális beállítások
       back_to_playlist: Back to Playlist
       back_to_plugin: 'Vissza ide: %{plugin}'
@@ -957,15 +860,7 @@ hu:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Tudj meg többet erről a bővítményről a tudásbázisunkban
-      learn_more_fork: Ez a bővítmény egy receptből lett létrehozva.
-      learn_more_fork_original: Eredeti megtekintése
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
       learn_more_recipe_author: Segítségre van szükséged? Lépj kapcsolatba %{recipe_author}-ral Discordon.
-      learn_more_recipe_long: Ez a bővítmény egy közösségi recept, amelyet nem a TRMNL tart karban.
-      learn_more_recipe_short: 'Megjegyzés: ez a bővítmény egy recept.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       linked_account: Összekapcsolt fiók
       linked_account_success: 'Sikeres összekapcsolás a következővel: %{plugin_name}'
       link_oauth: Fiók összekapcsolása
@@ -987,7 +882,6 @@ hu:
       recipe_cta_body_published: A változások megjelennek a meglévő és a jövőbeli telepítéseknél is.
       recipe_cta_body_in_review: Ez a bővítmény be lett nyújtva a csapatunkhoz. Kérlek, várj türelemmel.
       recipe_cta_body_not_published: Küldd be a bővítményt, hogy mások is telepíthessék. __Tudj meg többet__.
-      recipe_cta_confirm: Biztos vagy benne? A csapatunk pár napon belül visszajelez. Közben folytathatod a módosításokat.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: Hogyan szeretnéd közzétenni?
       recipe_visibility_edit_title: Beküldés szerkesztése
@@ -998,8 +892,6 @@ hu:
       recipe_visibility_unlisted: Rejtett
       recipe_visibility_unlisted_hint: Bárki, aki ismeri a linket, telepítheti.
       refresh_rate: Frissítési gyakoriság
-      refresh_rate_hint: Add meg, milyen gyakran frissítse ez a bővítmény az adatokat
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
       refreshed: Frissítve
       remove_plugin: Bővítmény eltávolítása
@@ -1056,10 +948,8 @@ hu:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Egyéni ütemezés hozzáadása
       append: És ez idő alatt…
       no_schedule: Ez a képernyő mindig megjelenik.
-      some_schedule: Csak ebben az időszakban jelenjen meg…
       to: "-ig"
       copy_prompt: Ütemezés másolása innen…
       no_days_error: Please select at least one day.
@@ -1085,11 +975,6 @@ hu:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1618,7 +1503,6 @@ hu:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -12,7 +12,6 @@ id:
   back: Kembali
   back_to_all_blog_posts: Back to all posts
   blog: Blog
-  brand: Brand
   buy_now: Beli Sekarang
   cancel: Batal
   change_password: Ubah Kata Sandi
@@ -26,15 +25,11 @@ id:
   copy: Copy
   copied_to_clipboard: Copied!
   copy_to_clipboard: Copy to clipboard
-  created: Created
   create_an_account: Buat akun baru
   current_device: Current device
-  days: hari
   delete: Hapus
   developers: Developers
   developer_edition_required: Developer edition is required to enable this feature.
-  device_id: ID Perangkat
-  device: Device
   discard: Discard
   edit: Pengaturan
   email_address: Alamat Email
@@ -45,7 +40,6 @@ id:
   forgot_password_title: Atur ulang kata sandi
   friendly_id: Friendly ID
   get_started: Mari kita mulai!
-  hidden: hidden
   identify: Identifikasi
   import: Import
   import_new: Import new
@@ -59,32 +53,23 @@ id:
   log_out: Keluar
   manage: Manage
   minimum_characters: karakter minimal
-  mins: menit
-  my_playlist: My Playlist
   new_password: Kata sandi baru
   password: Kata Sandi
-  please_wait: Please Wait...
   plugin_not_found: Plugin not found
   preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
   refresh_rates_hint: Learn how refresh rates work __here__.
   reset_password: Atur Ulang Kata Sandi
   reset_to_defaults: Reset to defaults
   required: Required
   save: Simpan
-  shown: shown
   section: Section
   settings: Settings
   sign_in: Masuk
   sign_up: Daftar
   something_went_wrong: Something went wrong
   status: Status
-  subscribe: Subscribe
   help_center: Support
-  terms: Terms
   unsaved_changes: You have unsaved changes
-  update: Perbarui
   view: Lihat
   collaboration_request: Wanna collaborate?
   collaboration_request_hint: Partnerships, group sales, special projects, your call.
@@ -155,9 +140,6 @@ id:
       refer_and_earn_hint: Give the gift of TRMNL with a personalized coupon. Earn per use, paid monthly.
       refer_and_earn_redemptions: Redemptions
       refer_and_earn_request_code: Request a Code
-      device_invoice: Device Invoice
-      device_invoice_label: Download commercial documents for your accountant or (weird) PDF collection.
-      device_invoice_hint: Find this on your package tracking page or shipment notification email.
       email_address_hint: Digunakan untuk masuk ke TRMNL dan menerima pesan sistem.
       first_name_hint: Kami menggunakan nama Anda untuk membuat antarmuka TRMNL lebih nyaman.
       last_name_hint: Kami menggunakan nama Anda untuk membuat antarmuka TRMNL lebih nyaman.
@@ -236,13 +218,7 @@ id:
   dashboard:
     index:
       title: Dasbor
-      last_7_days: 7 hari terakhir
-      last_30_days: 30 hari terakhir
-      last_90_days: 90 hari terakhir
-      today: Hari ini
-      yesterday: Kemarin
     health:
-      bad: Plugin mengalami kendala
       good: Plugin berfungsi dengan baik
       next_steps: Kami akan memberi tahu Anda jika ada perubahan
     news:
@@ -259,14 +235,9 @@ id:
       new_and_popular: Baru dan Populer
     shop:
       title: Shop
-      need_another: Need another TRMNL?
     time_saved:
       title: Waktu yang dihemat
-      cta: Pelajari lebih lanjut
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Good morning
@@ -279,7 +250,6 @@ id:
     edit:
       accepts_beta_firmware: Firmware tahap Beta
       accepts_beta_firmware_hint: Aktifkan untuk mendapatkan pembaruan firmware perangkat terbaru sebelum pengguna lain.
-      back_to_devices: Kembali ke Perangkat
       battery_and_sleep: Battery & Sleep
       battery_consumption: Penggunaan Baterai
       battery_consumption_hint: Hemat daya dan nikmati masa pakai baterai yang lebih lama dengan mengaktifkan Mode Tidur.
@@ -301,7 +271,6 @@ id:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -347,7 +316,6 @@ id:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
-      color_and_rotation: Warna dan Rotasi Layar
       image_rotation: Image Rotation
       screen_rotation: Rotasi Layar
       screen_rotation_not_supported: Rotasi layar saat ini tidak didukung pada perangkat Anda.
@@ -369,9 +337,7 @@ id:
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
       unlink: Lepas Tautan
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Lepaskan Tautan Perangkat
@@ -379,7 +345,6 @@ id:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibilitas
       visibility_hint: Jadikan perangkat TRMNL Anda dapat di-mirroring dengan mengubah pengaturan di bawah ini.
-      your_device: TRMNL Anda
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -416,9 +381,6 @@ id:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -492,7 +454,6 @@ id:
     index:
       title: Perangkat
       tagline: Perangkat TRMNL Anda
-      add_device_modal_title: Tambah perangkat baru
       add_first_device: Mulai dengan menambahkan perangkat pertama Anda!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -518,9 +479,6 @@ id:
     dissociate:
       error: Terjadi kesalahan saat melepaskan tautan perangkat
       success: Perangkat berhasil dilepaskan tautannya
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: Terjadi kesalahan saat memperbarui perangkat
       success: Permintaan identifikasi perangkat berhasil
@@ -559,16 +517,11 @@ id:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Too many attempts, please wait and try again
-    invoice_not_found: Invoice not found
   logs:
     index:
       title: Logs
       all: All
-      bulk_destroy: Bulk Destroy
       dump: Message
-      id: ID
       private_plugins: Private plugins
       source: Source
       time: Time (UTC)
@@ -603,9 +556,6 @@ id:
       live_preview: Live Preview
       no_changes_to_save: No changes to save
       pop_out_preview: Pop Out Preview
-      quickstart_examples: Quick-start Examples
-      quickstart_example_applied: Applied!
-      quickstart_use_this_example: Use this example
       revert: Revert
       revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
       save_changes: Save Changes (⌘﹢S)
@@ -669,9 +619,6 @@ id:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA Disabled
@@ -697,21 +644,12 @@ id:
   playlist_items:
     index:
       title: Daftar Putar
-      tagline: Pilih apa yang ingin Anda tampilkan di
-      add_a_group: Add a Group
-      add_a_plugin: Add a Plugin
       add_first_device_cta: Mulai dengan __menambahkan__ perangkat TRMNL pertama Anda!
       add_to_playlist: Tambahkan ke Daftar Putar
-      create_first_playlist_cta: Buat daftar putar setelah __menghubungkan__ plugin pertama Anda!
       custom: Custom
       device_default: Device default
-      display_period_from: Display from
-      display_period_to: to
       display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
       never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
       skip_after:
         one: Skip stale screens after 1 day
         other: Skip stale screens after %{count} days
@@ -749,9 +687,6 @@ id:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -768,7 +703,6 @@ id:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Gagal memperbarui daftar putar
       success: Daftar putar berhasil diperbarui
     destroy:
       error: Terjadi kesalahan saat menghapus item dari daftar putar
@@ -781,8 +715,6 @@ id:
       success: Playlist order updated
     set_preferences:
       success: Smart playlist preference updated
-    update:
-      success: Urutan daftar putar berhasil diperbarui
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -813,23 +745,10 @@ id:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -837,8 +756,6 @@ id:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -849,9 +766,6 @@ id:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -867,7 +781,6 @@ id:
     index:
       title: Plugin
       tagline: Apa yang ingin Anda tampilkan di TRMNL Anda?
-      available: Tersedia
       connected: Terhubung
       supported_by_this_device: Supported by this device
       recipes: Recipes
@@ -879,7 +792,6 @@ id:
         title: Plugin Saya
         tagline: Kembangkan Plugin Anda untuk lokapasar plugin
       card:
-        connections: connections
         install: Install
         review_are_you_sure: Are you sure? The TRMNL team will test it and email you any questions.
         submit_for_review: Ajukan untuk ditinjau
@@ -909,16 +821,11 @@ id:
     edit:
       title: Ubah Plugin
       tagline: Perbarui detail plugin Anda.
-      name: Nama
-      description: Deskripsi
   plugin_recipes:
     connected: Recipe connected
     connections:
       one: Connection
       other: Connections
-    forks:
-      one: Fork
-      other: Forks
     forked: Recipe forked
     new:
       error: Recipe not found
@@ -926,18 +833,14 @@ id:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Aktif
     copy_are_you_sure: Are you sure you want to copy this setting?
     delete_are_you_sure: Are you sure you want to delete this setting?
     delete: Ini akan sepenuhnya menghapus pengaturan plugin. Untuk hanya menyembunyikan plugin ini dari perangkat Anda, hapus dari Daftar Putar Anda.
-    inactive: Tidak Aktif
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: Tidak ditemukan pengaturan plugin.
     not_supported: Not supported on current device
     refreshing_now_please_wait: Refreshing now, reload this page in a few seconds.
     reset_credentials: "%{plugin_name} account reset successfully"
     form:
-      active_hint: Tampilkan atau sembunyikan plugin ini di perangkat Anda
       advanced_settings: Advanced Settings
       back_to_playlist: Back to Playlist
       back_to_plugin: Kembali ke %{plugin}
@@ -959,15 +862,7 @@ id:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Pelajari tentang plugin ini di basis pengetahuan kami
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
       learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       linked_account: Linked Account
       linked_account_success: Successfully linked with %{plugin_name}
       link_oauth: Tautkan Akun
@@ -989,7 +884,6 @@ id:
       recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
       recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
       recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: How would you like to publish?
       recipe_visibility_edit_title: Edit Submission
@@ -1000,8 +894,6 @@ id:
       recipe_visibility_unlisted: Unlisted
       recipe_visibility_unlisted_hint: Anyone with the link can install.
       refresh_rate: Tingkat Penyegaran
-      refresh_rate_hint: Tentukan seberapa sering plugin ini mengambil data baru
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
       refreshed: Diperbarui
       remove_plugin: Remove plugin
@@ -1058,10 +950,8 @@ id:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Add a custom schedule
       append: And during…
       no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
       to: to
       copy_prompt: Copy schedule from…
       no_days_error: Please select at least one day.
@@ -1087,11 +977,6 @@ id:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1620,7 +1505,6 @@ id:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -12,7 +12,6 @@ is:
   back: Til baka
   back_to_all_blog_posts: Til baka í allar færslur
   blog: Blogg
-  brand: Brand
   buy_now: Kaupa núna
   cancel: Hætta við
   change_password: Breyta lykilorði
@@ -26,15 +25,11 @@ is:
   copy: Afrita
   copied_to_clipboard: Afritað!
   copy_to_clipboard: Afrita í klemmuspjald
-  created: Búið til
   create_an_account: Stofna aðgang
   current_device: Núverandi tæki
-  days: dagar
   delete: Eyða
   developers: Developers
   developer_edition_required: Þróunarútgáfa er nauðsynleg til að virkja þennan eiginleika.
-  device_id: Kennimerki tækis
-  device: Tæki
   discard: Discard
   edit: Breyta
   email_address: Netfang
@@ -45,7 +40,6 @@ is:
   forgot_password_title: Nú förum við aftur af stað
   friendly_id: Friendly ID
   get_started: Byrjum!
-  hidden: hidden
   identify: Auðkenna
   import: Flytja inn
   import_new: Flytja inn nýtt
@@ -59,32 +53,23 @@ is:
   log_out: Útskrá
   manage: Stjórna
   minimum_characters: lágmarks stafir
-  mins: mín
-  my_playlist: Spilunarlistinn minn
   new_password: Nýtt lykilorð
   password: Lykilorð
-  please_wait: Vinsamlegast bíðið...
   plugin_not_found: Viðbót fannst ekki
   preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
   refresh_rates_hint: Lestu um uppfærslutíðni __hér__.
   reset_password: Endurstilla lykilorð
   reset_to_defaults: Reset to defaults
   required: Required
   save: Vista
-  shown: shown
   section: Hluti
   settings: Stillingar
   sign_in: Skrá inn
   sign_up: Skrá nýjan aðgang
   something_went_wrong: Eitthvað fór úrskeiðis
   status: Status
-  subscribe: Gerast áskrifandi
   help_center: Aðstoð
-  terms: Terms
   unsaved_changes: You have unsaved changes
-  update: Uppfæra
   view: Skoða
   collaboration_request: Wanna collaborate?
   collaboration_request_hint: Partnerships, group sales, special projects, your call.
@@ -153,9 +138,6 @@ is:
       refer_and_earn_hint: Deildu TRMNL afsláttarkóða og fáðu greitt mánaðarlega fyrir notkun.
       refer_and_earn_redemptions: Innlausnir
       refer_and_earn_request_code: Biðja um kóða
-      device_invoice: Reikningur fyrir tæki
-      device_invoice_label: Sækja skjöl fyrir bókara eða safnið þitt.
-      device_invoice_hint: Finndu þetta á rekjunarvef eða í sendingartilkynningu.
       email_address_hint: Notað til að skrá þig inn  á TRMNL og fá kerfistilkynningar.
       first_name_hint: Nafnið þitt birtist í TRMNL viðmótinu.
       last_name_hint: Nafnið þitt birtist í TRMNL viðmótinu.
@@ -234,13 +216,7 @@ is:
   dashboard:
     index:
       title: Stjórnborð
-      last_7_days: Síðustu 7 dagar
-      last_30_days: Síðustu 30 dagar
-      last_90_days: Síðustu 90 dagar
-      today: Í dag
-      yesterday: Í gær
     health:
-      bad: Vandamál með viðbætur
       good: Viðbætur eru í lagi
       next_steps: Við látum þig vita ef eitthvað breytist
     news:
@@ -257,14 +233,9 @@ is:
       new_and_popular: Nýjar og vinsælar
     shop:
       title: Verslun
-      need_another: Þarftu annað TRMNL?
     time_saved:
       title: Sparaður tími
-      cta: Lesa meira
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Góðan dag
@@ -277,7 +248,6 @@ is:
     edit:
       accepts_beta_firmware: Snemmútgáfa fastbúnaðar
       accepts_beta_firmware_hint: Kveiktu á þessu til að fá nýjustu fastbúnaðaruppfærslur á undan öðrum.
-      back_to_devices: Til baka í tæki
       battery_and_sleep: Battery & Sleep
       battery_consumption: Rafhlöðunotkun
       battery_consumption_hint: Sparaðu orku og lengdu rafhlöðuendingu með því að virkja svefnham.
@@ -299,7 +269,6 @@ is:
       device_model_switch_warning: Þetta er hættuleg aðgerð, lestu meira __hér__
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -345,7 +314,6 @@ is:
       ota_byod_not_supported: OTA er ekki stutt fyrir BYOD-tæki. "Flassaðu" samhæfða útgáfu beint frá trmnl.com/flash
       maximum_compatibility: Hámarkssamhæfni
       maximum_compatibility_hint: Leysir skjávandamál af völdum sumra ePaper rekla. Slekkur á hraðri uppfærslu. Krefst fastbúnaðar 1.6.0+.
-      color_and_rotation: Litur og Snúningur
       image_rotation: Image Rotation
       screen_rotation: Skjásnúningur
       screen_rotation_not_supported: Skjásnúningur er ekki í boði fyrir þetta tæki.
@@ -367,9 +335,7 @@ is:
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
       unlink: Aftengja
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Aftengja tæki
@@ -377,7 +343,6 @@ is:
       unlink_device_learn_more: Fylgdu leiðbeiningum __hér__.
       visibility: Sýnileiki
       visibility_hint: Gera TRMNL tækið þitt speglanlegt með því að breyta stillingunum hér að neðan.
-      your_device: Þitt TRMNL tæki
       upgrade_og:
         title: Uppfærsla í 2-bita skjá í boði
         sub_title: Tækið þitt getur verið uppfært til að styðja betri grátóna með 4 litastigum í stað 2.
@@ -414,9 +379,6 @@ is:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ is:
     index:
       title: Tæki
       tagline: TRMNL tækin þín
-      add_device_modal_title: Bæta við nýju tæki
       add_first_device: Byrjaðu á því að bæta við fyrsta tækinu þínu!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -516,9 +477,6 @@ is:
     dissociate:
       error: Villa við að aftengja tæki
       success: Tæki aftengt
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: Villa við að uppfæra tæki
       success: Beiðni um auðkenningu send
@@ -557,16 +515,11 @@ is:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Of margar tilraunir, vinsamlegast bíðið og reynið aftur
-    invoice_not_found: Reikningur fannst ekki
   logs:
     index:
       title: Atburðaskrár
       all: Allt
-      bulk_destroy: Bulk Destroy
       dump: Message
-      id: ID
       private_plugins: Einkaviðbætur
       source: Uppruni
       time: Time (UTC)
@@ -601,9 +554,6 @@ is:
       live_preview: Lifandi forskoðun
       no_changes_to_save: Engar breytingar til að vista
       pop_out_preview: Forskoðun í nýjum glugga
-      quickstart_examples: Sýnidæmi
-      quickstart_example_applied: Virkjað!
-      quickstart_use_this_example: Nota þetta sýnidæmi
       revert: Hætta við breytingar
       revert_confirm: Ertu viss? Allar óvistaðar breytingar munu tapast.
       save_changes: Vista breytingar (⌘﹢S)
@@ -667,9 +617,6 @@ is:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA óvirkt
@@ -695,21 +642,12 @@ is:
   playlist_items:
     index:
       title: Spilunarlisti
-      tagline: Veldu hvað birtist á
-      add_a_group: Bæta við hópi
-      add_a_plugin: Bæta við viðbót
       add_first_device_cta: Byrjaðu á því að __bæta við__ fyrsta TRMNL tækinu þínu!
       add_to_playlist: Bæta við spilunarlista
-      create_first_playlist_cta: Búðu til spilunarlistann þinn eftir að þú hefur __tengt__ fyrstu viðbótina!
       custom: Sérsniðið
       device_default: Sjálfgefið fyrir tæki
-      display_period_from: Sýna frá
-      display_period_to: til
       display_period_validation: Byrjunartími verður að vera fyrir lokatíma. Bættu við hópi til að spanna nóttina.
-      every: Sérhver
       never_skip: Aldrei sleppa skjám
-      smart_playlist: Snjall spilunarlisti
-      smart_playlist_hint: Sleppir sjálfkrafa skjámyndum sem hafa ekki breyst í einhvern tíma.
       skip_after:
         one: Sleppa skjámyndum eftir 1 dag
         other: Sleppa skjámyndum eftir %{count} daga
@@ -747,9 +685,6 @@ is:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -766,7 +701,6 @@ is:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Gat ekki uppfært spilunarlista
       success: Spilunarlisti uppfærður
     destroy:
       error: Villa við að fjarlægja atriði úr spilunarlista
@@ -779,8 +713,6 @@ is:
       success: Röðun spilunarlista uppfærð
     set_preferences:
       success: Stillingar snjallspilunarlista uppfærðar
-    update:
-      success: Playlist order updated
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -811,23 +743,10 @@ is:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -835,8 +754,6 @@ is:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -847,9 +764,6 @@ is:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -865,7 +779,6 @@ is:
     index:
       title: Viðbætur
       tagline: Hvað viltu setja á TRMNL tækið þitt?
-      available: Tiltækar
       connected: Tengdar
       supported_by_this_device: Supported by this device
       recipes: Uppskriftir
@@ -877,7 +790,6 @@ is:
         title: Viðbæturnar mínar
         tagline: Þróaðu viðbætur fyrir markaðinn
       card:
-        connections: tengingar
         install: Setja upp
         review_are_you_sure: Ertu viss? TRMNL teymið mun prófa viðbótina og hafa samband ef spurningar vakna.
         submit_for_review: Senda í skoðun
@@ -907,16 +819,11 @@ is:
     edit:
       title: Breyta viðbót
       tagline: Uppfæra upplýsingar viðbótarinnar.
-      name: Heiti
-      description: Lýsing
   plugin_recipes:
     connected: Uppskrift tengd
     connections:
       one: Tenging
       other: Tengingar
-    forks:
-      one: Sjálfun
-      other: Sjálfanir
     forked: Recipe forked
     new:
       error: Uppskrift fannst ekki
@@ -924,18 +831,14 @@ is:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Virkt
     copy_are_you_sure: Ertu viss um að þú viljir afrita þessa stillingu?
     delete_are_you_sure: Ertu viss um að þú viljir eyða þessari stillingu?
     delete: Þetta fjarlægir allar stillingar viðbótarinnar. Til að fela hana, fjarlægðu hana úr spilunarlistanum í staðinn.
-    inactive: Óvirkt
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: Engar stillingar fundust.
     not_supported: Not supported on current device
     refreshing_now_please_wait: Glæði, endurhlaðið síðuna eftir nokkrar sekúndur.
     reset_credentials: "%{plugin_name} aðgangur endurstilltur"
     form:
-      active_hint: Sýna eða fela þessa viðbót á tækinu þínu
       advanced_settings: Ítarlegar stillingar
       back_to_playlist: Back to Playlist
       back_to_plugin: Til baka í %{plugin}
@@ -957,15 +860,7 @@ is:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Lesa meira um þessa viðbót í hjálpargagnasafni
-      learn_more_fork: Þessi viðbót er afrituð úr uppskrift.
-      learn_more_fork_original: Skoða upprunalega
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
       learn_more_recipe_author: Þarftu hjálp? Hafðu samband við %{recipe_author} á Discord.
-      learn_more_recipe_long: Þessi viðbót er frá samfélaginu og er ekki viðhaldið af TRMNL.
-      learn_more_recipe_short: 'Athugið: þessi viðbót er uppskrift.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       linked_account: Tengt notandanafni
       linked_account_success: Tókst að tengja við %{plugin_name}
       link_oauth: Tengja aðgang
@@ -987,7 +882,6 @@ is:
       recipe_cta_body_published: Breytingar verða sýnilegar á núverandi og komandi uppsetningum.
       recipe_cta_body_in_review: Viðbótin hefur verið send inn til skoðunar. Hinkraðu.
       recipe_cta_body_not_published: Senda viðbótina til annarra. __Lesa meira__.
-      recipe_cta_confirm: Ertu viss? Teymið okkar mun skoða þetta næstdu daga. Þú getur haldið áfram að breyta á meðan.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: How would you like to publish?
       recipe_visibility_edit_title: Edit Submission
@@ -998,8 +892,6 @@ is:
       recipe_visibility_unlisted: Unlisted
       recipe_visibility_unlisted_hint: Anyone with the link can install.
       refresh_rate: Uppfærslutíðni
-      refresh_rate_hint: Stilltu hversu oft þessi viðbót sækir gögn
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
       refreshed: Uppfært
       remove_plugin: Fjarlægja viðbót
@@ -1056,10 +948,8 @@ is:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Bæta við sérsniðinni tímasetningu
       append: Og á meðan…
       no_schedule: Þessi skjár verður alltaf sýndur.
-      some_schedule: Sýna þennan skjá aðeins á…
       to: til
       copy_prompt: Afrita tímasetningu frá…
       no_days_error: Please select at least one day.
@@ -1085,11 +975,6 @@ is:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1618,7 +1503,6 @@ is:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -12,7 +12,6 @@ it:
   back: Indietro
   back_to_all_blog_posts: Torna a tutt i post
   blog: Blog
-  brand: Brand
   buy_now: Compra ora
   cancel: Annulla
   change_password: Cambia Password
@@ -26,15 +25,11 @@ it:
   copy: Copia
   copied_to_clipboard: Copiato!
   copy_to_clipboard: Copia negli appunti
-  created: Creato
   create_an_account: Crea un profilo
   current_device: Dispositivo attuale
-  days: giorni
   delete: Cancella
   developers: Sviluppatori
   developer_edition_required: Developer edition è richiesta per abilitare questa funzione
-  device_id: ID Dispositivo
-  device: Dispositivi
   discard: Discard
   edit: Modifica
   email_address: Indirizzo email
@@ -45,7 +40,6 @@ it:
   forgot_password_title: Ci risiamo
   friendly_id: Friendly ID
   get_started: Iniziamo!
-  hidden: hidden
   identify: Identifica
   import: Importa
   import_new: Importa nuovo
@@ -59,32 +53,23 @@ it:
   log_out: Esci
   manage: Gestisci
   minimum_characters: caratteri minimi
-  mins: min
-  my_playlist: La mia Playlist
   new_password: Nuova password
   password: Password
-  please_wait: Attendi...
   plugin_not_found: Plugin non trovato
   preview: Anteprima
-  privacy: Privacy
-  refresh_rate: Refresh rate
   refresh_rates_hint: Scopri come i gli aggiornamenti fuzionano __qui__.
   reset_password: Reimposta password
   reset_to_defaults: Reset to defaults
   required: Richiesto
   save: Salva
-  shown: Mostrato
   section: Sezione
   settings: Impostazioni
   sign_in: Accedi
   sign_up: Registrati
   something_went_wrong: Qualcosa è andato storto
   status: Stato
-  subscribe: Iscriviti
   help_center: Supporto
-  terms: Termini
   unsaved_changes: You have unsaved changes
-  update: Aggiorna
   view: Visualizza
   collaboration_request: Vuoi Collaborare?
   collaboration_request_hint: Collaborazioni, Vendite di gruppo, progetti speciali.
@@ -153,9 +138,6 @@ it:
       refer_and_earn_hint: Regala un TRMNL con un codice sconto personalizzato. Guadagna per l'uso, pagato mensilmente.
       refer_and_earn_redemptions: Utilizzi
       refer_and_earn_request_code: Richiedi un codice
-      device_invoice: Fattura dispositivo
-      device_invoice_label: Scarica il documento commerciale per il tuo commercialista oppure (strana) collezione PDF.
-      device_invoice_hint: Trovi questo nella pagiana di spedizione o nella email di spedizione.
       email_address_hint: Usato per accedere a TRMNL e ricevere messaggi di sistema.
       first_name_hint: Usiamo il tuo nome per migliorare l'interfaccia TRMNL.
       last_name_hint: Usiamo il tuo cognome per migliorare l'interfaccia TRMNL.
@@ -234,13 +216,7 @@ it:
   dashboard:
     index:
       title: Dashboard
-      last_7_days: Ultimi 7 giorni
-      last_30_days: Ultimi 30 giorni
-      last_90_days: Ultimi 90 giorni
-      today: Oggi
-      yesterday: Ieri
     health:
-      bad: I Plugin stanno avendo qualche problema
       good: I Plugin stanno bene
       next_steps: Ti faremo sapere se ci saranno cambiamenti
     news:
@@ -257,14 +233,9 @@ it:
       new_and_popular: Nuovi e Popolari
     shop:
       title: Negozio
-      need_another: Vuoi un altro TRMNL?
     time_saved:
       title: Tempo risparmiato
-      cta: Maggiori informazioni
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Buongiorno
@@ -277,7 +248,6 @@ it:
     edit:
       accepts_beta_firmware: Firmware Accesso Anticipato
       accepts_beta_firmware_hint: Attiva per riceve gli aggiornamenti del firmware più recenti prima degli degli altri utenti.
-      back_to_devices: Torna a Dispositivi
       battery_and_sleep: Batteria & Riposo
       battery_consumption: Consumo Batteria
       battery_consumption_hint: Risparmia energia e aumenta la durata della batteria attivando la Modalità Riposo.
@@ -299,7 +269,6 @@ it:
       device_model_switch_warning: Questa è un operazione pericolosa, scopri di più __qui__
       device_info: Informazioni Dispositivo
       current_firmware: Current firmware
-      last_ping: Ultimo Ping
       unknown: Unknown
       never: Mai
       display_calibration: Calibrazione Schermo
@@ -345,7 +314,6 @@ it:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Abilita compatibilità massima
       maximum_compatibility_hint: Risolve problemi dello schermo causati da alcuni chip driver per ePaper. Disattiva il fast refresh. Richiede Firmware 1.6.0 o successivo.
-      color_and_rotation: Colore e Rotazione
       image_rotation: Image Rotation
       screen_rotation: Rotazione Schermo
       screen_rotation_not_supported: La rotazione dello schermo non è attualmente supportata sul tuo dispositivo.
@@ -367,9 +335,7 @@ it:
       tidbyt_credentials: Credenziali Tidbyt.
       tidbyt_credentials_hint: Inserisci le tue credenziali API per il dispositivo Tidbyt dall'applicazione Tidbyt nelle impostazioni -> Sviluppo -> Ottieni chiave API.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Credenziali API Tidbyt API Invalide. Perfavore controlla e riprova.
       tidbyt_device_id: ID Dispositivo
-      tidbyt_device_api_key: Chiave API
       unlink: Scollega
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Scollega Dispositivo
@@ -377,7 +343,6 @@ it:
       unlink_device_learn_more: Segui la guida completa __qui__.
       visibility: Visibilità
       visibility_hint: Permetti la duplicazione di questo dispositivo TRMNL modificando le impostazioni seguenti.
-      your_device: Il tuo TRMNL
       upgrade_og:
         title: Aggiornamento per display a 2-bit disponibile
         sub_title: Il tuo dispositivo può essere aggiornato per suportare una migliorata visualizzazione di grigi a quattro liveli al posto di 2.
@@ -414,9 +379,6 @@ it:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ it:
     index:
       title: Dispositivi
       tagline: I tuoi dispositivi TRMNL
-      add_device_modal_title: Aggiungi un nuovo dispositivo
       add_first_device: Inizia aggiungendo il tuo primo dispositivo!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -516,9 +477,6 @@ it:
     dissociate:
       error: Errore nella disconnessione del dispositivo
       success: Dispositivo scollegato con successo
-    external_credentials:
-      error: Credenziali dispositivo invalide
-      success: Credenziali dispositivo aggiornate correttamente
     identify:
       error: Errore nell'aggiornamento del dispositivo
       success: Richiesta identificazione del dispositivo
@@ -557,16 +515,11 @@ it:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Troppi tentativi, riprova più tardi
-    invoice_not_found: Fattura non trovata
   logs:
     index:
       title: Logs
       all: Tutti
-      bulk_destroy: Eliminazione massiva
       dump: Message
-      id: ID
       private_plugins: Plugin Privati
       source: Sorgente
       time: Time (UTC)
@@ -601,9 +554,6 @@ it:
       live_preview: Anteprima in tempo reale
       no_changes_to_save: Nessuna modifica da salvare
       pop_out_preview: Anteprima pop out
-      quickstart_examples: Esempi Rapidi
-      quickstart_example_applied: Applicato!
-      quickstart_use_this_example: Usa questo esempio
       revert: Annulla
       revert_confirm: Sei sicuro di voler annullare? Tutti i cambiamenti non salvati andranno persi.
       save_changes: Salva cambiamenti (⌘﹢S)
@@ -667,9 +617,6 @@ it:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA Disabilitato
@@ -695,21 +642,12 @@ it:
   playlist_items:
     index:
       title: Playlist
-      tagline: Scegli cosa mostrare
-      add_a_group: Aggiungi un gruppo
-      add_a_plugin: Aggiungi un Plugin
       add_first_device_cta: Comincia __aggiungendo__ il tuo primo dispositivo TRMNL!
       add_to_playlist: Aggiungi a Playlist
-      create_first_playlist_cta: Crea la tua playlist, ma prima __connetti__ il tuo primo plugin!
       custom: Custom
       device_default: Device default
-      display_period_from: Mostra dalle
-      display_period_to: alle
       display_period_validation: L'ora di inizio deve essere inferiore all'ora di fine. Crea un altro gruppo per le ore notturne.
-      every: Ogni
       never_skip: Non saltare schermate.
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Salta automaticamente le schermate nelle quali il contenuto non è campiato per un po' di tempo.
       skip_after:
         one: Salta schermate stagnanti dopo 1 giorno
         other: Salta schermate stagnanti dopo %{count} giorni
@@ -747,9 +685,6 @@ it:
       duplicate: Duplica
       duplicate_confirm: Verrà creata una copia di questo articolo e aggiunta alla fine della playlist. Vuoi continuare?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Dispositivo Default (%{name})
-      palette_unavailable: Disponibile solo per dispositivi con pattern a più colori
       refresh_rate_disabled:
         default: La frequenza di aggiornamento per questo plugin non può essere configurata.
         external: Questo plugin ottiene dati in tempo reale, la frequenza di aggiornamento non viene consierata.
@@ -766,7 +701,6 @@ it:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Aggiornamento Playlist fallito
       success: Playlist aggiornata
     destroy:
       error: Errore nella rimozione dell'elemento dalla Playlist
@@ -779,8 +713,6 @@ it:
       success: Ordine Playlist aggiornato
     set_preferences:
       success: Smart playlist preference updated
-    update:
-      success: Ordinamento Playlist aggiornato
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -811,23 +743,10 @@ it:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -835,8 +754,6 @@ it:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -847,9 +764,6 @@ it:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -865,7 +779,6 @@ it:
     index:
       title: Plugin
       tagline: Cosa metterai sul tuo TRMNL?
-      available: Disponibile
       connected: Connesso
       supported_by_this_device: Supported by this device
       recipes: Recipes
@@ -877,7 +790,6 @@ it:
         title: I Miei Plugin
         tagline: Crea Plugin per il marketplace
       card:
-        connections: Connessioni
         install: Installa
         review_are_you_sure: Sei sicuro? Il team TRMNL proverà e ti manderà una mail con qualsiasi domanda.
         submit_for_review: Invia per revisione
@@ -907,16 +819,11 @@ it:
     edit:
       title: Modifica Plugin
       tagline: Aggiorna i dettagli del tuo plugin.
-      name: Nome
-      description: Descrizione
   plugin_recipes:
     connected: Recipe connessa
     connections:
       one: Connessione
       other: Connessioni
-    forks:
-      one: Fork
-      other: Forks
     forked: Recipe forked
     new:
       error: Recipe non trovata
@@ -924,18 +831,14 @@ it:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Attivo
     copy_are_you_sure: Sei sicuro di voler copiare queste impostazioni?
     delete_are_you_sure: Sei sicuro di voler eliminare queste impostazioni?
     delete: Questo cancellerà qualunque impostazione del plugin. Per nascondere questo plugin dal dispositivo, rimuoverlo invece dalla Playlist.
-    inactive: Inattivo
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: Impostazioni per plugin non trovate.
     not_supported: Not supported on current device
     refreshing_now_please_wait: Aggiornamento, ricarica questa pagina tra qualche secondo.
     reset_credentials: "%{plugin_name} Account resettato con successo"
     form:
-      active_hint: Mostra o nascondi questo plugin sul tuo dispositivo
       advanced_settings: Impostazioni Avanzate
       back_to_playlist: Back to Playlist
       back_to_plugin: Torna a %{plugin}
@@ -957,15 +860,7 @@ it:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Maggiori informazioni su questo plugin sono nella nostra knowledge base
-      learn_more_fork: Questo plugin è un fork di una Recipe.
-      learn_more_fork_original: Mostra Originale
-      learn_more_native_long: Questo plugin è nativo e manutenuto da TRMNL.
-      learn_more_native_short: Questo plugin è manutenuto da  TRMNL.
       learn_more_recipe_author: Hai bisogno di aiuto? Contatta %{recipe_author} su Discord.
-      learn_more_recipe_long: Questi plugin è una Recipe della comunità e non viene manutenuta da TRMNL.
-      learn_more_recipe_short: 'Note: questo plugin è una Recipe'
-      learn_more_third_party_long: Questo pliugin è creato da terzi e non viene manutenuto da TRMNL.
-      learn_more_third_party_short: 'Note: Questo plugin è creato da terzi.'
       linked_account: Account Connesso
       linked_account_success: Connesso correttamente con %{plugin_name}
       link_oauth: Collega Profilo
@@ -987,7 +882,6 @@ it:
       recipe_cta_body_published: I cambiamenti verranno replicati su istallazioni/fork esistenti e future.
       recipe_cta_body_in_review: Questo plugin è stato inviato al nostro team. Attendi.
       recipe_cta_body_not_published: Invia questo plugin per essere installabile da altri. __Scopri di più__.
-      recipe_cta_confirm: Sei sicuro? Il nostro team verificherà e ti farà sapere in alcuni giorni. Potrai continuare a fare modifiche.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: Come vorresti che venga pubblicata?
       recipe_visibility_edit_title: Modifica Invio
@@ -998,8 +892,6 @@ it:
       recipe_visibility_unlisted: Non in lista
       recipe_visibility_unlisted_hint: Tutti con il link possono installarla.
       refresh_rate: Frequenza di aggiornamento
-      refresh_rate_hint: Definisce con quale frequenza questo plugin recupera dati aggiornati
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
       refreshed: Aggiornato
       remove_plugin: Rimuovi plugin
@@ -1056,10 +948,8 @@ it:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Aggiungi programmazione personalizzata
       append: E durante…
       no_schedule: Questo schermo verrà visualizzato a tutte le ore.
-      some_schedule: Mostra questo schermo solo durante…
       to: alle
       copy_prompt: Copia programmazione da…
       no_days_error: Please select at least one day.
@@ -1085,11 +975,6 @@ it:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1618,7 +1503,6 @@ it:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -12,7 +12,6 @@ ja:
   back: 戻る
   back_to_all_blog_posts: すべてのブログ記事へ戻る
   blog: ブログ
-  brand: Brand
   buy_now: 今すぐ購入
   cancel: キャンセル
   change_password: パスワード変更
@@ -26,15 +25,11 @@ ja:
   copy: コピー
   copied_to_clipboard: コピーしました！
   copy_to_clipboard: クリップボードにコピー
-  created: 作成時刻
   create_an_account: アカウントを作成する
   current_device: 現在のデバイス
-  days: 日
   delete: 削除
   developers: Developers
   developer_edition_required: この機能を有効にするには、開発者エディションが必要です。
-  device_id: デバイスID
-  device: デバイス
   discard: Discard
   edit: 編集
   email_address: メールアドレス
@@ -45,7 +40,6 @@ ja:
   forgot_password_title: さあ、再スタートです
   friendly_id: Friendly ID
   get_started: 始めましょう！
-  hidden: hidden
   identify: 確認する
   import: Import
   import_new: Import new
@@ -59,32 +53,23 @@ ja:
   log_out: ログアウト
   manage: Manage
   minimum_characters: 最小文字数
-  mins: 分
-  my_playlist: マイプレイリスト
   new_password: 新しいパスワード
   password: パスワード
-  please_wait: しばらくお待ちください...
   plugin_not_found: プラグインが見つかりません
   preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
   refresh_rates_hint: リフレッシュレートの仕組みについては__こちら__をご覧ください。
   reset_password: パスワードをリセット
   reset_to_defaults: Reset to defaults
   required: Required
   save: 保存
-  shown: shown
   section: セクション
   settings: Settings
   sign_in: サインインする
   sign_up: サインアップ
   something_went_wrong: 問題が発生しました
   status: Status
-  subscribe: Subscribe
   help_center: サポート
-  terms: Terms
   unsaved_changes: You have unsaved changes
-  update: 更新
   view: 表示
   collaboration_request: Wanna collaborate?
   collaboration_request_hint: Partnerships, group sales, special projects, your call.
@@ -153,9 +138,6 @@ ja:
       refer_and_earn_hint: パーソナライズされたクーポンでTRMNLをプレゼントしましょう。利用ごとに報酬が発生し、毎月お支払いします。
       refer_and_earn_redemptions: 利用回数
       refer_and_earn_request_code: コードをリクエスト
-      device_invoice: デバイスの請求書
-      device_invoice_label: 会計士向けの商用ドキュメントをダウンロードしてください。
-      device_invoice_hint: 配送追跡ページまたは発送通知メールに記載されています。
       email_address_hint: TRMNLへのサインアップ時に使用し、システムメッセージを受信するメールアドレスです。
       first_name_hint: TRMNLインターフェースをより快適に使用するため、あなたの名前を使用します。
       last_name_hint: TRMNLインターフェースをより快適に使用するため、あなたの名前を使用します。
@@ -234,13 +216,7 @@ ja:
   dashboard:
     index:
       title: ダッシュボード
-      last_7_days: 過去7日間
-      last_30_days: 過去30日間
-      last_90_days: 過去90日間
-      today: 今日
-      yesterday: 昨日
     health:
-      bad: 現在、プラグインにエラーがあります
       good: すべてのプラグインが正常です
       next_steps: 変化があれば通知します
     news:
@@ -257,14 +233,9 @@ ja:
       new_and_popular: 新着＆人気のプラグイン
     shop:
       title: ショップ
-      need_another: Need another TRMNL?
     time_saved:
       title: 節約した時間
-      cta: 詳しく見る
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: おはようございます
@@ -277,7 +248,6 @@ ja:
     edit:
       accepts_beta_firmware: 新しいファームウェアを受け入れる
       accepts_beta_firmware_hint: 通常のユーザーよりも早く新しいデバイスファームウェアを使用するには、ボタンを押してください。
-      back_to_devices: デバイス管理画面に戻る
       battery_and_sleep: Battery & Sleep
       battery_consumption: バッテリー消費
       battery_consumption_hint: デバイスをスリープ モードにすると、バッテリー寿命を延ばすことができます
@@ -299,7 +269,6 @@ ja:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -345,7 +314,6 @@ ja:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
-      color_and_rotation: 色と回転
       image_rotation: Image Rotation
       screen_rotation: 画面回転
       screen_rotation_not_supported: 画面回転は現在、あなたのデバイスではサポートされていません。
@@ -367,9 +335,7 @@ ja:
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
       unlink: 接続解除
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: デバイス接続を解除する
@@ -377,7 +343,6 @@ ja:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: 共有設定
       visibility_hint: 以下の設定を使用して、TRMNLデバイスをミラーモードにすることができます。
-      your_device: あなたのTRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -414,9 +379,6 @@ ja:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ ja:
     index:
       title: デバイス管理
       tagline: あなたのTRMNLデバイス
-      add_device_modal_title: 新しいデバイスを追加
       add_first_device: 始めるには最初のデバイスを追加してください！
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -516,9 +477,6 @@ ja:
     dissociate:
       error: デバイス接続解除エラー
       success: デバイスの接続が正常に解除されました
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: デバイス更新エラー
       success: デバイスの確認が要求されました
@@ -557,16 +515,11 @@ ja:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: 試行回数が多すぎます。しばらく待ってから再度お試しください。
-    invoice_not_found: 請求書が見つかりませんでした。
   logs:
     index:
       title: ログ
       all: すべて
-      bulk_destroy: Bulk Destroy
       dump: Message
-      id: ID
       private_plugins: プライベートプラグイン
       source: ソース
       time: Time (UTC)
@@ -601,9 +554,6 @@ ja:
       live_preview: ライブプレビュー
       no_changes_to_save: 保存する変更はありません
       pop_out_preview: Pop Out Preview
-      quickstart_examples: クイックスタート例
-      quickstart_example_applied: 適用済み！
-      quickstart_use_this_example: この例を使用
       revert: 元に戻す
       revert_confirm: 元に戻してもよろしいですか？保存されていない変更はすべて失われます。
       save_changes: 変更を保存 (⌘﹢S)
@@ -667,9 +617,6 @@ ja:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2段階認証を無効化しました
@@ -695,21 +642,12 @@ ja:
   playlist_items:
     index:
       title: プレイリスト
-      tagline: 画面に表示するものを選んでください
-      add_a_group: グループを追加
-      add_a_plugin: プラグインを追加
       add_first_device_cta: 始めるには最初のTRMNLデバイスを__追加__してください！
       add_to_playlist: プレイリストに追加
-      create_first_playlist_cta: プレイリストを作成するには最初のプラグインを__接続__してください！
       custom: Custom
       device_default: Device default
-      display_period_from: 表示期間：
-      display_period_to: "〜"
       display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
       never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
       skip_after:
         one: Skip stale screens after 1 day
         other: Skip stale screens after %{count} days
@@ -747,9 +685,6 @@ ja:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -766,7 +701,6 @@ ja:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: プレイリストの更新に失敗しました
       success: プレイリストが更新されました
     destroy:
       error: プレイリスト内のプラグイン削除エラー
@@ -779,8 +713,6 @@ ja:
       success: Playlist order updated
     set_preferences:
       success: Smart playlist preference updated
-    update:
-      success: 新しいプレイリストの順序が更新されました
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -811,23 +743,10 @@ ja:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -835,8 +754,6 @@ ja:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -847,9 +764,6 @@ ja:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -865,7 +779,6 @@ ja:
     index:
       title: プラグイン管理
       tagline: TRMNLに何を表示しますか？
-      available: 利用可能なプラグイン
       connected: 接続済み
       supported_by_this_device: Supported by this device
       recipes: レシピ
@@ -877,7 +790,6 @@ ja:
         title: マイプラグイン
         tagline: 公開マーケットプレイス向けのプラグインを開発
       card:
-        connections: コネクション
         install: インストール
         review_are_you_sure: よろしいですか？TRMNLチームがテストを行い、質問があればメールでご連絡します。
         submit_for_review: レビューのために提出
@@ -907,16 +819,11 @@ ja:
     edit:
       title: プラグインの編集
       tagline: プラグインの詳細を更新します。
-      name: 名前
-      description: 説明
   plugin_recipes:
     connected: Recipe connected
     connections:
       one: Connection
       other: Connections
-    forks:
-      one: Fork
-      other: Forks
     forked: Recipe forked
     new:
       error: レシピが見つかりません
@@ -924,18 +831,14 @@ ja:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: アクティブ
     copy_are_you_sure: この設定をコピーしてもよろしいですか？
     delete_are_you_sure: この設定を削除してもよろしいですか？
     delete: プラグインの設定を完全に削除します。デバイスからプラグインを単に隠したいだけなら、プレイリストから削除してください。
-    inactive: 非アクティブ
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: プラグインが見つかりません。
     not_supported: Not supported on current device
     refreshing_now_please_wait: 更新中です。数秒後にこのページを再読み込みしてください。
     reset_credentials: "%{plugin_name}アカウントが正常にリセットされました"
     form:
-      active_hint: デバイスにこのプラグインインスタンスを表示または非表示にする
       advanced_settings: Advanced Settings
       back_to_playlist: Back to Playlist
       back_to_plugin: "%{plugin}に戻る"
@@ -957,15 +860,7 @@ ja:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: このプラグインについてもっと知りたい場合は、ドキュメントをご参照ください
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
       learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       linked_account: 連携済みアカウント
       linked_account_success: 成功
       link_oauth: アカウント連携
@@ -987,7 +882,6 @@ ja:
       recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
       recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
       recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: How would you like to publish?
       recipe_visibility_edit_title: Edit Submission
@@ -998,8 +892,6 @@ ja:
       recipe_visibility_unlisted: Unlisted
       recipe_visibility_unlisted_hint: Anyone with the link can install.
       refresh_rate: リフレッシュ頻度
-      refresh_rate_hint: このプラグインインスタンスがどれくらい頻繁に新しいデータを取得するかを決定します
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
       refreshed: リフレッシュ完了
       remove_plugin: プラグインを削除
@@ -1056,10 +948,8 @@ ja:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Add a custom schedule
       append: And during…
       no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
       to: to
       copy_prompt: Copy schedule from…
       no_days_error: Please select at least one day.
@@ -1085,11 +975,6 @@ ja:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1618,7 +1503,6 @@ ja:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -12,7 +12,6 @@ ko:
   back: 뒤로가기
   back_to_all_blog_posts: 모든 포스트 보기로 돌아가기
   blog: 블로그
-  brand: 브랜드
   buy_now: 바로 구매
   cancel: 취소
   change_password: 비밀번호 변경
@@ -26,15 +25,11 @@ ko:
   copy: 복사하기
   copied_to_clipboard: 복사완료!
   copy_to_clipboard: 클립보드로 복사하기
-  created: 생성됨
   create_an_account: 계정 만들기
   current_device: 현재 기기
-  days: 일
   delete: 삭제하기
   developers: 개발자
   developer_edition_required: 이 기능은 개발자 에디션이 필요해요.
-  device_id: 기기 ID
-  device: 기기
   discard: Discard
   edit: 수정
   email_address: 이메일 주소
@@ -45,7 +40,6 @@ ko:
   forgot_password_title: 자, 다시 갑시다
   friendly_id: Friendly ID
   get_started: 시작해 볼까요!
-  hidden: 숨김
   identify: 확인하기
   import: 불러오기
   import_new: 새로 불러오기
@@ -59,32 +53,23 @@ ko:
   log_out: 로그아웃
   manage: 관리
   minimum_characters: 최소 글자 수
-  mins: 분
-  my_playlist: 내 플레이리스트
   new_password: 새 비밀번호
   password: 비밀번호
-  please_wait: 잠시만 기다려주세요...
   plugin_not_found: 플러그인을 찾을 수 없음
   preview: 미리보기
-  privacy: 개인정보 보호
-  refresh_rate: 새로고침 주기
   refresh_rates_hint: 새로고침 주기가 어떻게 작동하는지 __여기서__ 알아보세요.
   reset_password: 비밀번호 재설정
   reset_to_defaults: 기본값으로 초기화
   required: 필수
   save: 저장
-  shown: 표시
   section: 섹션
   settings: 설정
   sign_in: 로그인하기
   sign_up: 가입하기
   something_went_wrong: 문제가 발생했어요
   status: 상태
-  subscribe: 구독
   help_center: 고객지원
-  terms: 이용약관
   unsaved_changes: You have unsaved changes
-  update: 업데이트
   view: 보기
   collaboration_request: 함께 해볼까요?
   collaboration_request_hint: 파트너십, 단체 구매, 특별 프로젝트 등 무엇이든 좋아요.
@@ -153,9 +138,6 @@ ko:
       refer_and_earn_hint: 개인 쿠폰으로 TRMNL을 선물하세요. 사용 횟수당 보상을 받고, 매달 지급돼요.
       refer_and_earn_redemptions: 사용 횟수
       refer_and_earn_request_code: 코드 요청하기
-      device_invoice: 기기 인보이스
-      device_invoice_label: 회계용 문서를 다운로드하거나, (이상한) PDF 컬렉션에 추가하세요.
-      device_invoice_hint: 택배 조회 페이지 또는 배송 알림 이메일에서 확인하세요.
       email_address_hint: TRMNL 가입과 시스템 메시지 수신에 사용돼요.
       first_name_hint: TRMNL을 더 편안하게 만드는 데 사용돼요.
       last_name_hint: TRMNL을 더 편안하게 만드는 데 사용돼요.
@@ -234,13 +216,7 @@ ko:
   dashboard:
     index:
       title: 대시보드
-      last_7_days: 지난 7일
-      last_30_days: 지난 30일
-      last_90_days: 지난 90일
-      today: 오늘
-      yesterday: 어제
     health:
-      bad: 플러그인에 문제가 있어요
       good: 플러그인 모두 정상
       next_steps: 변화가 있으면 알려드릴게요
     news:
@@ -257,14 +233,9 @@ ko:
       new_and_popular: 인기 급상승 & 새 플러그인
     shop:
       title: 쇼핑
-      need_another: TRMNL이 하나 더 필요하세요?
     time_saved:
       title: 절약한 시간
-      cta: 더 알아보기
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: 좋은 아침
@@ -277,7 +248,6 @@ ko:
     edit:
       accepts_beta_firmware: 펌웨어 조기 배포
       accepts_beta_firmware_hint: 다른 사용자보다 먼저 최신 펌웨어를 받아보세요.
-      back_to_devices: 기기 목록으로 돌아가기
       battery_and_sleep: 배터리 & 절전
       battery_consumption: 배터리 소모
       battery_consumption_hint: 절전 모드로 배터리를 더 오래 쓸 수 있어요.
@@ -299,7 +269,6 @@ ko:
       device_model_switch_warning: 위험한 작업이에요. __여기서__ 자세히 알아보세요.
       device_info: 기기 정보
       current_firmware: 현재 펌웨어
-      last_ping: 마지막 응답
       unknown: 알 수 없음
       never: 없음
       display_calibration: 디스플레이 보정
@@ -345,7 +314,6 @@ ko:
       ota_byod_not_supported: BYOD 기기는 OTA를 지원하지 않아요. trmnl.com/flash에서 직접 플래시하세요.
       maximum_compatibility: 최대 호환성 활성화
       maximum_compatibility_hint: 특정 ePaper 드라이버 칩의 디스플레이 문제를 해결해요. 빠른 새로고침이 비활성화돼요. 펌웨어 1.6.0 이상 필요.
-      color_and_rotation: 색상과 회전
       image_rotation: Image Rotation
       screen_rotation: 화면 회전
       screen_rotation_not_supported: 화면 회전은 현재 지원되지 않아요.
@@ -367,9 +335,7 @@ ko:
       tidbyt_credentials: Tidbyt 인증 정보
       tidbyt_credentials_hint: Tidbyt 앱의 설정 → 개발자 → API 키 받기에서 기기 API 인증 정보를 입력하세요.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API 인증 정보가 올바르지 않아요. 다시 확인해주세요.
       tidbyt_device_id: 기기 ID
-      tidbyt_device_api_key: API 키
       unlink: 연결 해제
       unlink_confirm: 정말요? 기기를 다른 사람에게 주거나 BYOS로 전환할 때만 진행하세요. 연결 해제 시 모든 플러그인 설정과 플레이리스트가 삭제돼요. 문제 해결 중이라면 help.trmnl.com에서 고객지원에 문의하세요.
       unlink_device: 기기 연결 해제
@@ -377,7 +343,6 @@ ko:
       unlink_device_learn_more: 전체 가이드를 __여기서__ 확인하세요.
       visibility: 공개 설정
       visibility_hint: 아래 설정을 바꾸면 다른 기기에서 미러링할 수 있어요.
-      your_device: 내 TRMNL
       upgrade_og:
         title: 2-bit 디스플레이 업그레이드 가능
         sub_title: 4단계 그레이스케일 디스플레이로 업그레이드할 수 있어요.
@@ -414,9 +379,6 @@ ko:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ ko:
     index:
       title: 기기 관리
       tagline: 내 TRMNL 기기
-      add_device_modal_title: 새 기기 추가하기
       add_first_device: 첫 기기를 추가해서 시작하세요!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -516,9 +477,6 @@ ko:
     dissociate:
       error: 기기 연결 해제 오류
       success: 기기 연결을 해제했어요
-    external_credentials:
-      error: 기기 인증 정보가 올바르지 않아요
-      success: 기기 인증 정보를 업데이트했어요
     identify:
       error: 기기 업데이트 오류
       success: 기기 식별을 요청했어요
@@ -557,16 +515,11 @@ ko:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: 너무 많이 시도했어요. 잠시 후 다시 해주세요.
-    invoice_not_found: 인보이스를 찾을 수 없음
   logs:
     index:
       title: 로그
       all: 전체
-      bulk_destroy: 일괄 삭제
       dump: Message
-      id: ID
       private_plugins: 비공개 플러그인
       source: 소스
       time: Time (UTC)
@@ -601,9 +554,6 @@ ko:
       live_preview: 실시간 미리보기
       no_changes_to_save: 저장할 변경사항이 없어요
       pop_out_preview: 미리보기 팝업
-      quickstart_examples: 빠른 시작 예시
-      quickstart_example_applied: 적용됨!
-      quickstart_use_this_example: 이 예시 사용하기
       revert: 되돌리기
       revert_confirm: 되돌릴까요? 저장하지 않은 변경사항이 모두 사라져요.
       save_changes: 저장하기 (⌘﹢S)
@@ -667,9 +617,6 @@ ko:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2단계 인증 비활성화됨
@@ -695,21 +642,12 @@ ko:
   playlist_items:
     index:
       title: 플레이리스트
-      tagline: 화면에 표시할 것을 선택하세요
-      add_a_group: 그룹 추가
-      add_a_plugin: 플러그인 추가
       add_first_device_cta: 첫 TRMNL 기기를 __추가__해서 시작하세요!
       add_to_playlist: 플레이리스트에 추가
-      create_first_playlist_cta: 첫 플러그인을 __연결__하면 플레이리스트를 만들 수 있어요!
       custom: 커스텀
       device_default: 기기 기본값
-      display_period_from: 시작
-      display_period_to: 종료
       display_period_validation: 시작 시간이 종료 시간보다 빨라야 해요. 야간 시간대를 포함하려면 그룹을 하나 더 만드세요.
-      every: 매
       never_skip: 화면 건너뛰지 않기
-      smart_playlist: 스마트 플레이리스트
-      smart_playlist_hint: 내용이 한동안 바뀌지 않은 화면을 자동으로 건너뛰어요.
       skip_after:
         one: 1일 후 오래된 화면 건너뛰기
         other: "%{count}일 후 오래된 화면 건너뛰기"
@@ -747,9 +685,6 @@ ko:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: 이 플러그인의 새로고침 주기는 설정할 수 없어요.
         external: 이 플러그인은 실시간으로 데이터를 가져오므로 새로고침 주기 설정이 적용되지 않아요.
@@ -766,7 +701,6 @@ ko:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: 플레이리스트 업데이트 실패
       success: 플레이리스트를 업데이트했어요
     destroy:
       error: 플레이리스트 항목 삭제 오류
@@ -779,8 +713,6 @@ ko:
       success: 플레이리스트 순서를 업데이트했어요
     set_preferences:
       success: 스마트 플레이리스트 설정을 업데이트했어요
-    update:
-      success: 플레이리스트 순서를 업데이트했어요
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -811,23 +743,10 @@ ko:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -835,8 +754,6 @@ ko:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -847,9 +764,6 @@ ko:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -865,7 +779,6 @@ ko:
     index:
       title: 플러그인
       tagline: TRMNL에 무엇을 올릴까요?
-      available: 사용 가능
       connected: 연결됨
       supported_by_this_device: Supported by this device
       recipes: 레시피
@@ -877,7 +790,6 @@ ko:
         title: 내 플러그인
         tagline: 공개 마켓플레이스에 플러그인을 개발하세요
       card:
-        connections: 연결 수
         install: 설치
         review_are_you_sure: 정말요? TRMNL 팀이 테스트한 후 질문이 있으면 이메일로 연락드려요.
         submit_for_review: 검토 요청
@@ -907,16 +819,11 @@ ko:
     edit:
       title: 플러그인 편집
       tagline: 플러그인 정보를 업데이트하세요.
-      name: 이름
-      description: 설명
   plugin_recipes:
     connected: 레시피 연결됨
     connections:
       one: 연결
       other: 연결
-    forks:
-      one: Fork
-      other: Forks
     forked: Recipe forked
     new:
       error: 레시피를 찾을 수 없어요
@@ -924,18 +831,14 @@ ko:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: 활성
     copy_are_you_sure: 이 설정을 복사할까요?
     delete_are_you_sure: 이 설정을 삭제할까요?
     delete: 플러그인 설정을 완전히 삭제해요. 기기에서 플러그인을 숨기고 싶다면 플레이리스트에서 삭제하세요.
-    inactive: 비활성
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: 플러그인 설정이 없어요.
     not_supported: 현재 기기에서 지원하지 않아요
     refreshing_now_please_wait: 새로고침 중이에요. 몇 초 후에 페이지를 다시 불러오세요.
     reset_credentials: "%{plugin_name} 계정을 초기화했어요"
     form:
-      active_hint: 기기에서 이 플러그인 인스턴스를 숨기거나 표시하기
       advanced_settings: 고급 설정
       back_to_playlist: 플레이리스트로 돌아가기
       back_to_plugin: "%{plugin}으로 돌아가기"
@@ -957,15 +860,7 @@ ko:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: 이 플러그인에 대해 설명서에서 알아보세요
-      learn_more_fork: 이 플러그인은 레시피에서 포크됐어요.
-      learn_more_fork_original: 원본 보기
-      learn_more_native_long: 이 플러그인은 TRMNL이 개발하고 관리해요.
-      learn_more_native_short: TRMNL이 관리하는 플러그인이에요.
       learn_more_recipe_author: 도움이 필요하면 Discord에서 %{recipe_author}에게 연락하세요.
-      learn_more_recipe_long: 이 플러그인은 커뮤니티 레시피이며 TRMNL이 관리하지 않아요.
-      learn_more_recipe_short: '참고: 이 플러그인은 레시피예요.'
-      learn_more_third_party_long: 이 플러그인은 서드파티가 만들었으며 TRMNL이 관리하지 않아요.
-      learn_more_third_party_short: '참고: 이 플러그인은 서드파티 제공이에요.'
       linked_account: 연결된 계정
       linked_account_success: "%{plugin_name}에 연결했어요"
       link_oauth: 계정 연결
@@ -987,7 +882,6 @@ ko:
       recipe_cta_body_published: 변경사항이 기존 설치와 향후 설치/포크에 반영돼요.
       recipe_cta_body_in_review: 이 플러그인을 팀에 제출했어요. 잠시 기다려주세요.
       recipe_cta_body_not_published: 다른 사용자가 설치할 수 있도록 플러그인을 제출하세요. __자세히 알아보기__.
-      recipe_cta_confirm: 정말요? 팀이 검토한 후 며칠 내로 연락드려요. 계속 수정할 수 있어요.
       recipe_mirrored: 이 화면은 레시피에서 미러링됐어요.
       recipe_visibility_title: 어떻게 공개할까요?
       recipe_visibility_edit_title: 제출 수정
@@ -998,8 +892,6 @@ ko:
       recipe_visibility_unlisted: 비공개 링크
       recipe_visibility_unlisted_hint: 링크가 있는 사람만 설치할 수 있어요.
       refresh_rate: 새로고침 주기
-      refresh_rate_hint: 이 플러그인 인스턴스가 새 데이터를 가져오는 주기를 설정해요
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: "%{refresh_rate} 주기로 동기화 (변경 불가)"
       refreshed: 새로고침됨
       remove_plugin: 플러그인 삭제
@@ -1056,10 +948,8 @@ ko:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: 커스텀 스케줄 추가
       append: 그리고…
       no_schedule: 이 화면은 항상 표시돼요.
-      some_schedule: 이 시간에만 표시…
       to: to
       copy_prompt: 스케줄 복사…
       no_days_error: Please select at least one day.
@@ -1085,11 +975,6 @@ ko:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1618,7 +1503,6 @@ ko:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -12,7 +12,6 @@ lt:
   back: Atgal
   back_to_all_blog_posts: Atgal į visus įrašus
   blog: Tinklaraštis
-  brand: Prekių ženklas
   buy_now: Pirkti dabar
   cancel: Atšaukti
   change_password: Pakeisti slaptažodį
@@ -26,15 +25,11 @@ lt:
   copy: Kopijuoti
   copied_to_clipboard: Nukopijuota!
   copy_to_clipboard: Kopijuoti į iškarpinę
-  created: Sukurta
   create_an_account: Sukurti paskyrą
   current_device: Dabartinis įrenginys
-  days: dienos
   delete: Ištrinti
   developers: Kūrėjams
   developer_edition_required: Norint įjungti šią funkciją, reikalinga kūrėjo versija.
-  device_id: Įrenginio ID
-  device: Įrenginys
   discard: Discard
   edit: Redaguoti
   email_address: El. pašto adresas
@@ -45,7 +40,6 @@ lt:
   forgot_password_title: Ir vėl viskas iš naujo
   friendly_id: Atpažįstamas ID (Friendly ID)
   get_started: Pradedėkime!
-  hidden: paslėptas
   identify: Identifikuoti
   import: Importuoti
   import_new: Importuoti naują
@@ -59,32 +53,23 @@ lt:
   log_out: Atsijungti
   manage: Tvarkyti
   minimum_characters: simbolių minimumas
-  mins: min.
-  my_playlist: Mano grojaraštis
   new_password: Naujas slaptažodis
   password: Slaptažodis
-  please_wait: Prašome palaukti...
   plugin_not_found: Įskiepis nerastas
   preview: Peržiūra
-  privacy: Privatumas
-  refresh_rate: Atnaujinimo dažnis
   refresh_rates_hint: Sužinokite, kaip veikia atnaujinimo dažniai, __čia__.
   reset_password: Atstatyti mano slaptažodį
   reset_to_defaults: Atstatyti numatytuosius nustatymus
   required: Privaloma
   save: Išsaugoti
-  shown: rodomas
   section: Sekcija
   settings: Nustatymai
   sign_in: Prisijungti
   sign_up: Užsiregistruoti
   something_went_wrong: Kažkas nepavyko
   status: Būsena
-  subscribe: Prenumeruoti
   help_center: Pagalba
-  terms: Sąlygos
   unsaved_changes: You have unsaved changes
-  update: Atnaujinti
   view: Peržiūrėti
   collaboration_request: Norite bendradarbiauti?
   collaboration_request_hint: Partnerystės, grupiniai pardavimai, specialūs projektai – jūsų pasirinkimas.
@@ -153,9 +138,6 @@ lt:
       refer_and_earn_hint: Padovanokite TRMNL su asmeniniu kuponu. Uždirbkite už kiekvieną panaudojimą, mokama kas mėnesį.
       refer_and_earn_redemptions: Panaudojimai
       refer_and_earn_request_code: Užklausti kodą
-      device_invoice: Įrenginio sąskaita-faktūra
-      device_invoice_label: Atsisiųskite komercinius dokumentus savo buhalteriui arba (keistai) PDF kolekcijai.
-      device_invoice_hint: Ją rasite siuntos sekimo puslapyje arba pranešime el. paštu apie išsiuntimą.
       email_address_hint: Naudojama prisijungimui prie TRMNL ir sistemos pranešimams gauti.
       first_name_hint: Mes naudojame jūsų vardą, kad TRMNL sąsaja būtų jaukesnė.
       last_name_hint: Mes naudojame jūsų pavardę, kad TRMNL sąsaja būtų jaukesnė.
@@ -234,13 +216,7 @@ lt:
   dashboard:
     index:
       title: Skydelis
-      last_7_days: Paskutinės 7 dienos
-      last_30_days: Paskutinės 30 dienų
-      last_90_days: Paskutinės 90 dienų
-      today: Šiandien
-      yesterday: Vakar
     health:
-      bad: Įskiepiai patiria problemų
       good: Įskiepiai veikia puikiai
       next_steps: Mes jus informuosime, jei kas nors pasikeis
     news:
@@ -257,14 +233,9 @@ lt:
       new_and_popular: Nauji ir populiarūs
     shop:
       title: Parduotuvė
-      need_another: Reikia dar vieno TRMNL?
     time_saved:
       title: Sutaupytas laikas
-      cta: Skaityti apie
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Labas rytas
@@ -277,7 +248,6 @@ lt:
     edit:
       accepts_beta_firmware: Ankstyvoji programinės įrangos versija
       accepts_beta_firmware_hint: Įjunkite, kad gautumėte naujausius įrenginio programinės įrangos patobulinimus anksčiau už kitus.
-      back_to_devices: Atgal į įrenginius
       battery_and_sleep: Baterija ir miegas
       battery_consumption: Baterijos suvartojimas
       battery_consumption_hint: Taupykite energiją ir mėgaukitės ilgesniu baterijos veikimo laiku įjungdami miego režimą.
@@ -299,7 +269,6 @@ lt:
       device_model_switch_warning: Tai pavojingas veiksmas, sužinokite daugiau __čia__.
       device_info: Įrenginio informacija
       current_firmware: Dabartinė programinė įranga
-      last_ping: Paskutinis signalas (ping)
       unknown: Nežinoma
       never: Niekada
       display_calibration: Ekrano kalibravimas
@@ -345,7 +314,6 @@ lt:
       ota_byod_not_supported: OTA nepalaikoma BYOD įrenginiuose. Įrašykite suderinamą versiją tiesiogiai iš trmnl.com/flash
       maximum_compatibility: Įjungti maksimalų suderinamumą
       maximum_compatibility_hint: Išsprendžia ekrano problemas, kurias sukelia tam tikros ePaper tvarkyklės. Išjungia greitąjį atnaujinimą. Reikalinga programinė įranga 1.6.0+.
-      color_and_rotation: Spalvų ir ratavimas
       image_rotation: Image Rotation
       screen_rotation: Ekranų ratavimas
       screen_rotation_not_supported: Ekranų ratavimas šiuo metu nepalaikomas jūsų įrenginyje.
@@ -367,9 +335,7 @@ lt:
       tidbyt_credentials: Tidbyt kredencialai
       tidbyt_credentials_hint: Įveskite savo Tidbyt įrenginio API kredencialus iš Tidbyt programėlės (skiltyje Settings → Developer → Get API Key).
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API kredencialai negalioja. Patikrinkite ir bandykite dar kartą.
       tidbyt_device_id: Įrenginio ID
-      tidbyt_device_api_key: API raktas
       unlink: Atjungti
       unlink_confirm: Ar esate tikri? Tęskite tik tuo atveju, jei atiduodate šį įrenginį kitam asmeniui arba pereinate prie BYOS. Atjungimas ištrina visus įskiepių nustatymus ir grojaraščio elementus. Jei sprendžiate problemas, susisiekite su pagalba adresu help.trmnl.com.
       unlink_device: Atjungti įrenginį
@@ -377,7 +343,6 @@ lt:
       unlink_device_learn_more: Sekite pilną gidą __čia__.
       visibility: Matomumas
       visibility_hint: Padarykite savo TRMNL įrenginį atspindimą pakeisdami žemiau esančius nustatymus.
-      your_device: Jūsų TRMNL
       upgrade_og:
         title: Galimas atnaujinimas į 2-bitų ekraną
         sub_title: Jūsų įrenginį galima atnaujinti, kad jis palaikytų patobulintą pilkų atspalvių ekraną su 4 spalvų lygiais vietoj 2.
@@ -414,9 +379,6 @@ lt:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ lt:
     index:
       title: Įrenginiai
       tagline: Jūsų TRMNL įrenginiai
-      add_device_modal_title: Pridėti naują įrenginį
       add_first_device: Pradėkite pridėdami savo pirmąjį įrenginį!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -516,9 +477,6 @@ lt:
     dissociate:
       error: Klaida atjungiant įrenginį
       success: Įrenginys sėkmingai atjungtas
-    external_credentials:
-      error: Neteisingi įrenginio kredencialai
-      success: Įrenginio kredencialai sėkmingai atnaujinti
     identify:
       error: Klaida atnaujinant įrenginį
       success: Užklaustas įrenginio identifikavimas
@@ -557,16 +515,11 @@ lt:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Per daug bandymų, palaukite ir bandykite dar kartą
-    invoice_not_found: Sąskaita-faktūra nerasta
   logs:
     index:
       title: Žurnalai
       all: Visi
-      bulk_destroy: Masinis trynimas
       dump: Message
-      id: ID
       private_plugins: Privatūs įskiepiai
       source: Šaltinis
       time: Time (UTC)
@@ -601,9 +554,6 @@ lt:
       live_preview: Tiesioginė peržiūra
       no_changes_to_save: Nėra pakeitimų, kuriuos reikėtų išsaugoti
       pop_out_preview: Iškelti peržiūrą į atskirą langą
-      quickstart_examples: Greito starto pavyzdžiai
-      quickstart_example_applied: Pritaikyta!
-      quickstart_use_this_example: Naudoti šį pavyzdį
       revert: Sugrąžinti
       revert_confirm: Ar tikrai norite sugrąžinti? Visi neišsaugoti pakeitimai bus prarasti.
       save_changes: Išsaugoti pakeitimus (⌘﹢S)
@@ -667,9 +617,6 @@ lt:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA išjungta
@@ -695,21 +642,12 @@ lt:
   playlist_items:
     index:
       title: Grojaraštis
-      tagline: Pasirinkite, kas rodoma
-      add_a_group: Pridėti grupę
-      add_a_plugin: Pridėti įskiepį
       add_first_device_cta: Pradėkite __pridėdami__ savo pirmąjį TRMNL įrenginį!
       add_to_playlist: Pridėti į grojaraštį
-      create_first_playlist_cta: Sukurkite savo grojaraštį __prijungę__ savo pirmąjį įskiepį!
       custom: Pasirinktinis
       device_default: Įrenginio numatytasis
-      display_period_from: Rodyti nuo
-      display_period_to: iki
       display_period_validation: Pradžios laikas turi būti ankstesnis už pabaigos laiką. Sukurkite kitą grupę, kad apimtumėte nakties valandas.
-      every: Kas
       never_skip: Niekada nepraleisti ekranų
-      smart_playlist: Išmanusis grojaraštis
-      smart_playlist_hint: Automatiškai praleisti ekranus, kurių turinys kurį laiką nesikeitė.
       skip_after:
         one: Praleisti pasenusius ekranus po 1 dienos
         other: Praleisti pasenusius ekranus po %{count} dienų
@@ -747,9 +685,6 @@ lt:
       duplicate: Dubliuoti
       duplicate_confirm: Tai sukurs šio elemento kopiją ir pridės ją prie jūsų grojaraščio apačios. Tęsti?
       presentation: Presentation
-      color_palette: Spalvų paletė
-      device_default: Įrenginio numatytasis (%{name})
-      palette_unavailable: Galima tik įrenginiams su keliomis spalvų paletėmis
       refresh_rate_disabled:
         default: Šio įskiepio atnaujinimo dažnio negalima konfigūruoti.
         external: Šis įskiepis nuskaito duomenis realiuoju laiku, todėl atnaujinimo dažnio nustatymai netaikomi.
@@ -766,7 +701,6 @@ lt:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Nepavyko atnaujinti grojaraščio
       success: Grojaraštis atnaujintas
     destroy:
       error: Klaida šalinant elementą iš grojaraščio
@@ -779,8 +713,6 @@ lt:
       success: Grojaraščio tvarka atnaujinta
     set_preferences:
       success: Išmaniojo grojaraščio nustatymai atnaujinti
-    update:
-      success: Grojaraščio tvarka atnaujinta
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -811,23 +743,10 @@ lt:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -835,8 +754,6 @@ lt:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -847,9 +764,6 @@ lt:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -865,7 +779,6 @@ lt:
     index:
       title: Įskiepiai
       tagline: Ką įkelsite į savo TRMNL?
-      available: Prieinami
       connected: Prijungti
       supported_by_this_device: Supported by this device
       recipes: Receptai
@@ -877,7 +790,6 @@ lt:
         title: Mano įskiepiai
         tagline: Kurkite įskiepius viešajai rinkai
       card:
-        connections: prisijungimai
         install: Įdiegti
         review_are_you_sure: Ar esate tikri? TRMNL komanda jį išbandys ir el. paštu atsiųs jums visus klausimus.
         submit_for_review: Pateikti peržiūrai
@@ -907,16 +819,11 @@ lt:
     edit:
       title: Redaguoti įskiepį
       tagline: Atnaujinkite savo įskiepio informaciją.
-      name: Pavadinimas
-      description: Aprašymas
   plugin_recipes:
     connected: Receptas prijungtas
     connections:
       one: Prisijungimas
       other: Prisijungimai
-    forks:
-      one: Atšaka (Fork)
-      other: Atšakos (Forks)
     forked: Receptas atšakotas
     new:
       error: Receptas nerastas
@@ -924,18 +831,14 @@ lt:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Aktyvus
     copy_are_you_sure: Ar tikrai norite nukopijuoti šį nustatymą?
     delete_are_you_sure: Ar tikrai norite ištrinti šį nustatymą?
     delete: Tai visiškai pašalins įskiepio nustatymus. Norėdami tiesiog paslėpti šį įskiepį savo įrenginyje, ištrinkite jį iš savo grojaraščio.
-    inactive: Neaktyvus
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: Įskiepio nustatymų nerasta.
     not_supported: Nepalaikoma dabartiniame įrenginyje
     refreshing_now_please_wait: Dabar atnaujinama, perkraukite šį puslapį po kelių sekundžių.
     reset_credentials: "%{plugin_name} paskyra sėkmingai atstatyta"
     form:
-      active_hint: Rodyti arba paslėpti šią įskiepio instanciją savo įrenginyje
       advanced_settings: Išplėstiniai nustatymai
       back_to_playlist: Atgal į grojaraštį
       back_to_plugin: Atgal į %{plugin}
@@ -957,15 +860,7 @@ lt:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Sužinokite apie šį įskiepį mūsų žinių bazėje
-      learn_more_fork: Šis įskiepis buvo atšakotas iš recepto.
-      learn_more_fork_original: Žiūrėti originalą
-      learn_more_native_long: Šis įskiepis yra vietinis ir jį prižiūri TRMNL.
-      learn_more_native_short: Šį įskiepį prižiūri TRMNL.
       learn_more_recipe_author: Reikia pagalbos? Susisiekite su %{recipe_author} per Discord.
-      learn_more_recipe_long: Šis įskiepis yra bendruomenės receptas ir jo neprižiūri TRMNL.
-      learn_more_recipe_short: 'Pastaba: šis įskiepis yra receptas.'
-      learn_more_third_party_long: Šis įskiepis yra trečiosios šalies ir jo neprižiūri TRMNL.
-      learn_more_third_party_short: 'Pastaba: šis įskiepis yra sukurtas trečiosios šalies.'
       linked_account: Susieta paskyra
       linked_account_success: Sėkmingai susieta su %{plugin_name}
       link_oauth: Susieti paskyrą
@@ -987,7 +882,6 @@ lt:
       recipe_cta_body_published: Pakeitimai atsispindės esamuose diegimuose ir būsimuose diegimuose / atšakose.
       recipe_cta_body_in_review: Šis įskiepis buvo pateiktas mūsų komandai. Palaukite.
       recipe_cta_body_not_published: Pateikite šį įskiepį, kad kiti galėtų jį įsidiegti. __Sužinokite daugiau__.
-      recipe_cta_confirm: Ar esate tikri? Mūsų komanda peržiūrės ir susisieks su jumis per porą dienų. Galite toliau daryti pakeitimus.
       recipe_mirrored: Šis ekranas yra atspindėtas iš recepto.
       recipe_visibility_title: Kaip norėtumėte paskelbti?
       recipe_visibility_edit_title: Redaguoti pateikimą
@@ -998,8 +892,6 @@ lt:
       recipe_visibility_unlisted: Neįtrauktas į sąrašą
       recipe_visibility_unlisted_hint: Įsidiegti gali visi, kas turi nuorodą.
       refresh_rate: Atnaujinimo dažnis
-      refresh_rate_hint: Nustatykite, kaip dažnai ši įskiepio instancija nuskaito šviežius duomenis
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Sinchronizuojama %{refresh_rate} (nekonfigūruojama)
       refreshed: Atnaujinta
       remove_plugin: Pašalinti įskiepį
@@ -1056,10 +948,8 @@ lt:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Pridėti pasirinktinį tvarkaraštį
       append: Ir šiuo metu…
       no_schedule: Šis ekranas bus rodomas visą laiką.
-      some_schedule: Rodyti šį ekraną tik šiuo metu…
       to: iki
       copy_prompt: Kopijuoti tvarkaraštį iš…
       no_days_error: Please select at least one day.
@@ -1085,11 +975,6 @@ lt:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1618,7 +1503,6 @@ lt:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -12,7 +12,6 @@ nl:
   back: Terug
   back_to_all_blog_posts: Terug naar alle berichten
   blog: Blog
-  brand: Brand
   buy_now: Nu kopen
   cancel: Annuleren
   change_password: Wachtwoord wijzigen
@@ -26,15 +25,11 @@ nl:
   copy: Kopiëren
   copied_to_clipboard: Gekopieerd!
   copy_to_clipboard: Kopiëren naar klembord
-  created: Aangemaakt
   create_an_account: Maak een account
   current_device: Huidig apparaat
-  days: dagen
   delete: Verwijder
   developers: Developers
   developer_edition_required: Developer-editie is vereist om deze functie in the schakelen.
-  device_id: Apparaat ID
-  device: Apparaat
   discard: Discard
   edit: Bewerken
   email_address: Emailadres
@@ -45,7 +40,6 @@ nl:
   forgot_password_title: Hier gaan we weer
   friendly_id: Friendly ID
   get_started: Laten we beginnen!
-  hidden: hidden
   identify: Identificeren
   import: Import
   import_new: Import new
@@ -59,32 +53,23 @@ nl:
   log_out: Uitloggen
   manage: Manage
   minimum_characters: karakters minimaal
-  mins: min.
-  my_playlist: Mijn afspeellijst
   new_password: Nieuw wachtwoord
   password: Wachtwoord
-  please_wait: Even geduld...
   plugin_not_found: Plugin niet gevonden
   preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
   refresh_rates_hint: Leer __hier__ hoe verversingssnelheden werken
   reset_password: Vraag nieuw wachtwoord op
   reset_to_defaults: Reset to defaults
   required: Required
   save: Opslaan
-  shown: shown
   section: Sectie
   settings: Settings
   sign_in: Inloggen
   sign_up: Registreren
   something_went_wrong: Er is iets misgegaan
   status: Status
-  subscribe: Subscribe
   help_center: Support
-  terms: Terms
   unsaved_changes: You have unsaved changes
-  update: Bijwerken
   view: Bekijk
   collaboration_request: Wanna collaborate?
   collaboration_request_hint: Partnerships, group sales, special projects, your call.
@@ -153,9 +138,6 @@ nl:
       refer_and_earn_hint: Deel TRMNL via een gepersonaliseerde coupon. Verdien per gebruik, maandelijks uitbetaald.
       refer_and_earn_redemptions: Aantal keer gebruikt
       refer_and_earn_request_code: Vraag een code aan
-      device_invoice: Apparaatfactuur
-      device_invoice_label: Download commerciële documenten voor je accountant of jouw PDF-verzameling.
-      device_invoice_hint: Vind dit op je track & trace pagina of als bijlage bij de verzendbevestiging per e-mail.
       email_address_hint: Gebruikt om in te loggen bij TRMNL en systeemberichten te ontvangen.
       first_name_hint: We gebruiken jouw naam om de TRMNL interface persoonlijker te maken.
       last_name_hint: We gebruiken jouw naam om de TRMNL interface persoonlijker te maken.
@@ -234,13 +216,7 @@ nl:
   dashboard:
     index:
       title: Dashboard
-      last_7_days: Laatste 7 dagen
-      last_30_days: Laatste 30 dagen
-      last_90_days: Laatste 90 dagen
-      today: Vandaag
-      yesterday: Gisteren
     health:
-      bad: Plugins hebben wat problemen
       good: Plugins zien er goed uit
       next_steps: We informeren je als er iets verandert
     news:
@@ -257,14 +233,9 @@ nl:
       new_and_popular: Nieuw en populair
     shop:
       title: Winkel
-      need_another: Need another TRMNL?
     time_saved:
       title: Tijd bespaard
-      cta: Lees meer
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Goedemorgen
@@ -277,7 +248,6 @@ nl:
     edit:
       accepts_beta_firmware: Beta firmware-release
       accepts_beta_firmware_hint: Schakel in om de nieuwste beta firmwareverbeteringen voor je apparaat te ontvangen.
-      back_to_devices: Terug naar apparaten
       battery_and_sleep: Battery & Sleep
       battery_consumption: Batterijgebruik
       battery_consumption_hint: Bespaar energie en geniet van een langere batterijduur door slaapmodus te activeren.
@@ -299,7 +269,6 @@ nl:
       device_model_switch_warning: Dit is een gevaarlijke actie, lees __hier__ meer
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -345,7 +314,6 @@ nl:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Activeer Maximale Compatibiliteit
       maximum_compatibility_hint: Los scherm issues op met bepaalde ePaper driver chips. Zet snelle verversing uit. Firmware 1.6.0+ benodigd.
-      color_and_rotation: Kleur en rotatie
       image_rotation: Image Rotation
       screen_rotation: Schermrotatie
       screen_rotation_not_supported: Schermrotatie is momenteel niet ondersteund op je apparaat.
@@ -367,9 +335,7 @@ nl:
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
       unlink: Ontkoppelen
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Apparaat ontkoppelen
@@ -377,7 +343,6 @@ nl:
       unlink_device_learn_more: Volg __hier__ de volledige handleiding.
       visibility: Vindbaarheid
       visibility_hint: Maak jouw TRMNL apparaat spiegelbaar door onderstaande instelling aan te passen.
-      your_device: Jouw TRMNL
       upgrade_og:
         title: Upgrade naar 2-bit scherm beschikbaar
         sub_title: Jouw device kan geupgrade worden om uitgebreide grijswaarden te ondersteunen, met 4 kleurniveau's ipv 2.
@@ -414,9 +379,6 @@ nl:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ nl:
     index:
       title: Apparaten
       tagline: Jouw TRMNL apparaten
-      add_device_modal_title: Nieuw apparaat toevoegen
       add_first_device: Begin door jouw eerste apparaat toe te voegen!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -516,9 +477,6 @@ nl:
     dissociate:
       error: Fout bij ontkoppelen apparaat
       success: Apparaat succesvol ontkoppeld
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: Fout bij updaten apparaat
       success: Apparaatidentificatie aangevraagd
@@ -557,16 +515,11 @@ nl:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Te vaak geprobeerd. Wacht even en probeer het laten nog eens
-    invoice_not_found: Factuur niet gevonden
   logs:
     index:
       title: Logboeken
       all: Alles
-      bulk_destroy: Bulk Destroy
       dump: Message
-      id: ID
       private_plugins: Privé-plugins
       source: Bron
       time: Time (UTC)
@@ -601,9 +554,6 @@ nl:
       live_preview: Live voorbeeld
       no_changes_to_save: Geen wijzigingen om op te slaan
       pop_out_preview: Pop Out Preview
-      quickstart_examples: Snelstartvoorbeelden
-      quickstart_example_applied: Toegepast!
-      quickstart_use_this_example: Gebruik dit voorbeeld
       revert: Terugzetten
       revert_confirm: Weet je zeker dat je wilt terugzetten? All niet-opgeslagen wijzigingen gaan verloren.
       save_changes: Wijzigingen opslaan (⌘﹢S)
@@ -667,9 +617,6 @@ nl:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA uitschaekeld
@@ -695,21 +642,12 @@ nl:
   playlist_items:
     index:
       title: Afspeellijst
-      tagline: Kies wat wordt getoond op
-      add_a_group: Een groep toevoegen
-      add_a_plugin: Een plugin toevoegen
       add_first_device_cta: Begin door jouw eerste TRMNL apparaat __toe te voegen__!
       add_to_playlist: Toevoegen aan afspeellijst
-      create_first_playlist_cta: Maak jouw afspeellijst nadat je jouw eerst plugin __verbindt__!
       custom: Custom
       device_default: Device standaard
-      display_period_from: Weergeven van
-      display_period_to: tot
       display_period_validation: Begintijd moet voor de eindtijd zijn. Maak een nieuwe groep om nachtelijke uren in te stellen.
-      every: Elke
       never_skip: Sla nooit scherm over
-      smart_playlist: Slimme Afspeellijst
-      smart_playlist_hint: Sla schermen automatisch over als de inhoud niet gewijzigd is.
       skip_after:
         one: Sla niet bijgewerkte schermen over na 1 dag
         other: Sla niet bijgewerkte schermen over na %{count} dagen
@@ -747,9 +685,6 @@ nl:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -766,7 +701,6 @@ nl:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Bijwerken van afspeellijst is mislukt
       success: Afspeellijst is bijgewerkt
     destroy:
       error: Fout bij het verwijderen van afspeellijst
@@ -779,8 +713,6 @@ nl:
       success: Playlist order updated
     set_preferences:
       success: Smart playlist preference updated
-    update:
-      success: Volgorde afspeellijst bijgewerkt
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -811,23 +743,10 @@ nl:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -835,8 +754,6 @@ nl:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -847,9 +764,6 @@ nl:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -865,7 +779,6 @@ nl:
     index:
       title: Plugins
       tagline: Wat ga jij op jouw TRMNL zetten?
-      available: Beschikbaar
       connected: Verbonden
       supported_by_this_device: Supported by this device
       recipes: Recepten
@@ -877,7 +790,6 @@ nl:
         title: Mijn plugins
         tagline: Ontwikkel plugins voor de openbare marktplaats
       card:
-        connections: verbindingen
         install: Installeren
         review_are_you_sure: Weet je het zeker? Het TRMNL-team gaat je plugin testen en kan eventueel vragen per e-mail sturen.
         submit_for_review: Indienen ter beoordeling
@@ -907,16 +819,11 @@ nl:
     edit:
       title: Plugin bewerken
       tagline: Werk de details van je plugin bij.
-      name: Naam
-      description: Beschrijving
   plugin_recipes:
     connected: Recept verbonden
     connections:
       one: Connection
       other: Connections
-    forks:
-      one: Fork
-      other: Forks
     forked: Recipe forked
     new:
       error: Recept niet gevonden
@@ -924,18 +831,14 @@ nl:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Actief
     copy_are_you_sure: Weet je zeker dat je deze instelling wilt kopiëren?
     delete_are_you_sure: Weet je zeker dat je deze instelling wilt verwijderen?
     delete: Hiermee verwijder je de instellingen van de plugin volledig. Om deze plugin simpelweg te verbergen verwijder je deze uit jouw afspeellijst.
-    inactive: Inactief
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: Geen plugininstellingen gevonden.
     not_supported: Not supported on current device
     refreshing_now_please_wait: Plugin wordt ververst, herlaad de pagina over een paar seconden.
     reset_credentials: "%{plugin_name} account succesvol hersteld"
     form:
-      active_hint: Toon of verberg deze plugin op je apparaat
       advanced_settings: Geavanceerde Instellingen
       back_to_playlist: Back to Playlist
       back_to_plugin: Terug naar %{plugin}
@@ -957,15 +860,7 @@ nl:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Kom meer te weten over deze plugin in onze kennisbank
-      learn_more_fork: Deze plugin is een fork van een recept.
-      learn_more_fork_original: Bekijk het origineel
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
       learn_more_recipe_author: Hulp nodig? Neem contact op met %{recipe_author} via Discord.
-      learn_more_recipe_long: Deze plugin is een recept uit de community, en wordt niet onderhouden door TRMNL.
-      learn_more_recipe_short: 'Noot: deze plugin is een recept'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       linked_account: Gekoppeld account
       linked_account_success: Succesvol gekoppeld met %{plugin_name}
       link_oauth: Account koppelen
@@ -987,7 +882,6 @@ nl:
       recipe_cta_body_published: Veranderingen worden doorgevoerd bij bestaande installaties en toekomstige installaties en forks.
       recipe_cta_body_in_review: De plugin is ingediend bij het team. Nog even geduld.
       recipe_cta_body_not_published: Verstuur de plugin zodat anderen deze ook kunnen gebruiken. __Lees hier meer over__.
-      recipe_cta_confirm: Weet je het zeker? Ons team zal je plugin reviewen en bij je terugkomen met mogelijke vragen. Je kan ondertussen wijzigingen blijven doorvoeren.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: How would you like to publish?
       recipe_visibility_edit_title: Edit Submission
@@ -998,8 +892,6 @@ nl:
       recipe_visibility_unlisted: Unlisted
       recipe_visibility_unlisted_hint: Anyone with the link can install.
       refresh_rate: Verversingssnelheid
-      refresh_rate_hint: Bepaal hoe vaak deze plugin instantie verse data ophaalt
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
       refreshed: Ververst
       remove_plugin: Plugin verwijderen
@@ -1056,10 +948,8 @@ nl:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Voeg een op-maat schema toe
       append: Tijdens…
       no_schedule: Dit scherm wordt altijd getoond
-      some_schedule: Toon enkel tijdens…
       to: naar
       copy_prompt: Kopieër schema van…
       no_days_error: Please select at least one day.
@@ -1085,11 +975,6 @@ nl:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1618,7 +1503,6 @@ nl:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -12,7 +12,6 @@
   back: Tilbake
   back_to_all_blog_posts: Tilbake til alle innlegg
   blog: Blogg
-  brand: Brand
   buy_now: Kjøp nå
   cancel: Avbryt
   change_password: Endre passord
@@ -26,15 +25,11 @@
   copy: Kopier
   copied_to_clipboard: Kopiert!
   copy_to_clipboard: Kopier til utklippstavle
-  created: Opprettet
   create_an_account: Lag en konto
   current_device: Nåværende enhet
-  days: dager
   delete: Slett
   developers: Developers
   developer_edition_required: Utviklerutgaven kreves for å aktivere denne funksjonen.
-  device_id: Enhets-ID
-  device: Enhet
   discard: Discard
   edit: Innstillinger
   email_address: E-postadresse
@@ -45,7 +40,6 @@
   forgot_password_title: Her går vi igjen
   friendly_id: Friendly ID
   get_started: La oss komme i gang!
-  hidden: hidden
   identify: Identifiser
   import: Importer
   import_new: Importer ny
@@ -59,32 +53,23 @@
   log_out: Logg ut
   manage: Manage
   minimum_characters: minimum antall tegn
-  mins: min
-  my_playlist: Min spilleliste
   new_password: Nytt passord
   password: Passord
-  please_wait: Vennligst vent...
   plugin_not_found: Plugin ikke funnet
   preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
   refresh_rates_hint: Lær hvordan oppdateringsfrekvenser fungerer __her__.
   reset_password: Tilbakestill passordet mitt
   reset_to_defaults: Reset to defaults
   required: Required
   save: Lagre
-  shown: shown
   section: Seksjon
   settings: Settings
   sign_in: Logg inn
   sign_up: Registrer deg
   something_went_wrong: Noe gikk galt
   status: Status
-  subscribe: Subscribe
   help_center: Support
-  terms: Terms
   unsaved_changes: You have unsaved changes
-  update: Oppdater
   view: Vis
   collaboration_request: Wanna collaborate?
   collaboration_request_hint: Partnerships, group sales, special projects, your call.
@@ -153,9 +138,6 @@
       refer_and_earn_hint: Gi gaven av TRMNL med en personlig kupong. Tjen per bruk, betalt månedlig.
       refer_and_earn_redemptions: Innbyttinger
       refer_and_earn_request_code: Be om en kode
-      device_invoice: Enhetsfaktura
-      device_invoice_label: Last ned kommersielle dokumenter for regnskapsføreren din eller til PDF-samlingen (merkelig).
-      device_invoice_hint: Finnes på sporingssiden for pakken din eller i e-posten for forsendelsesvarsel.
       email_address_hint: Brukes for å logge inn på TRMNL og motta systemmeldinger.
       first_name_hint: Vi bruker navnet ditt for å gjøre TRMNL-grensesnittet mer personlig.
       last_name_hint: Vi bruker navnet ditt for å gjøre TRMNL-grensesnittet mer personlig.
@@ -234,13 +216,7 @@
   dashboard:
     index:
       title: Oversikt
-      last_7_days: Siste 7 dager
-      last_30_days: Siste 30 dager
-      last_90_days: Siste 90 dager
-      today: I dag
-      yesterday: I går
     health:
-      bad: Plugins har problemer
       good: Plugins fungerer bra
       next_steps: Vi informerer deg hvis noe endres
     news:
@@ -257,14 +233,9 @@
       new_and_popular: Nye og populære
     shop:
       title: Butikk
-      need_another: Need another TRMNL?
     time_saved:
       title: Tid spart
-      cta: Les om
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: God morgen
@@ -277,7 +248,6 @@
     edit:
       accepts_beta_firmware: Tidlig utgivelse av fastvare
       accepts_beta_firmware_hint: Slå på for å få de nyeste fastvareoppdateringene før andre brukere.
-      back_to_devices: Tilbake til enheter
       battery_and_sleep: Battery & Sleep
       battery_consumption: Batteriforbruk
       battery_consumption_hint: Spar strøm og få lengre batterilevetid ved å aktivere dvalemodus.
@@ -299,7 +269,6 @@
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -345,7 +314,6 @@
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
-      color_and_rotation: Farge og rotasjon
       image_rotation: Image Rotation
       screen_rotation: Skjermrotasjon
       screen_rotation_not_supported: Skjermrotasjon er ikke understøttet på din enhet.
@@ -367,9 +335,7 @@
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
       unlink: Koble fra
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Koble fra enhet
@@ -377,7 +343,6 @@
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Synlighet
       visibility_hint: Gjør TRMNL-enheten din speilbar ved å endre innstillingene nedenfor.
-      your_device: Din TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -414,9 +379,6 @@
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@
     index:
       title: Enheter
       tagline: Dine TRMNL-enheter
-      add_device_modal_title: Legg til en ny enhet
       add_first_device: Start med å legge til din første enhet!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -516,9 +477,6 @@
     dissociate:
       error: Feil ved frakobling av enhet
       success: Enheten ble frakoblet
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: Feil ved oppdatering av enhet
       success: Forespørsel om enhetsidentifikasjon sendt
@@ -557,16 +515,11 @@
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: For mange forsøk, vennligst vent og prøv igjen
-    invoice_not_found: Faktura ikke funnet
   logs:
     index:
       title: Logger
       all: Alle
-      bulk_destroy: Bulk Destroy
       dump: Message
-      id: ID
       private_plugins: Private plugins
       source: Kilde
       time: Time (UTC)
@@ -601,9 +554,6 @@
       live_preview: Direkte forhåndsvisning
       no_changes_to_save: Ingen endringer å lagre
       pop_out_preview: Pop Out Preview
-      quickstart_examples: Raskstartseksempler
-      quickstart_example_applied: Anvendt!
-      quickstart_use_this_example: Bruk dette eksempelet
       revert: Angre
       revert_confirm: Er du sikker på at du vil angre? Alle uspurte endringer vil gå tapt.
       save_changes: Lagre endringer (⌘﹢S)
@@ -667,9 +617,6 @@
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA deaktivert
@@ -695,21 +642,12 @@
   playlist_items:
     index:
       title: Spilleliste
-      tagline: Velg hva som vises på
-      add_a_group: Legg til en gruppe
-      add_a_plugin: Legg til en plugin
       add_first_device_cta: Start med å __legge til__ din første TRMNL-enhet!
       add_to_playlist: Legg til i spilleliste
-      create_first_playlist_cta: Lag spillelisten din etter å ha __koblet til__ din første plugin!
       custom: Custom
       device_default: Device default
-      display_period_from: Vis fra
-      display_period_to: til
       display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
       never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
       skip_after:
         one: Skip stale screens after 1 day
         other: Skip stale screens after %{count} days
@@ -747,9 +685,6 @@
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -766,7 +701,6 @@
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Kunne ikke oppdatere spillelisten
       success: Spilleliste oppdatert
     destroy:
       error: Feil ved fjerning av element fra spilleliste
@@ -779,8 +713,6 @@
       success: Playlist order updated
     set_preferences:
       success: Smart playlist preference updated
-    update:
-      success: Rekkefølgen i spillelisten er oppdatert
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -811,23 +743,10 @@
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -835,8 +754,6 @@
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -847,9 +764,6 @@
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -865,7 +779,6 @@
     index:
       title: Plugins
       tagline: Hva vil du vise på din TRMNL?
-      available: Tilgjengelig
       connected: Tilkoblet
       supported_by_this_device: Supported by this device
       recipes: Oppskrifter
@@ -877,7 +790,6 @@
         title: Mine plugins
         tagline: Utvikle plugins for det offentlige markedet
       card:
-        connections: tilkoblinger
         install: Installer
         review_are_you_sure: Er du sikker? TRMNL-teamet vil teste den og sende deg e-post med spørsmål.
         submit_for_review: Send inn for vurdering
@@ -907,16 +819,11 @@
     edit:
       title: Rediger plugin
       tagline: Oppdater detaljene for din plugin.
-      name: Navn
-      description: Beskrivelse
   plugin_recipes:
     connected: Recipe connected
     connections:
       one: Connection
       other: Connections
-    forks:
-      one: Fork
-      other: Forks
     forked: Recipe forked
     new:
       error: Oppskrift ikke funnet
@@ -924,18 +831,14 @@
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Aktiv
     copy_are_you_sure: Er du sikker på at du vil kopiere denne innstillingen?
     delete_are_you_sure: Er du sikker på at du vil slette denne innstillingen?
     delete: Dette vil fullstendig fjerne plugin-innstillingene. For kun å skjule pluginen fra enheten din, fjern den fra spillelisten i stedet.
-    inactive: Inaktiv
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: Ingen plugin-innstillinger funnet.
     not_supported: Not supported on current device
     refreshing_now_please_wait: Oppdaterer nå, last siden på nytt om noen sekunder.
     reset_credentials: "%{plugin_name} konto ble tilbakestilt"
     form:
-      active_hint: Vis eller skjul denne plugin-instansen på enheten din
       advanced_settings: Advanced Settings
       back_to_playlist: Back to Playlist
       back_to_plugin: Tilbake til %{plugin}
@@ -957,15 +860,7 @@
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Les om denne pluginen i vår kunnskapsbase
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
       learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       linked_account: Koblet konto
       linked_account_success: Koblet til %{plugin_name} med hell
       link_oauth: Koble konto
@@ -987,7 +882,6 @@
       recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
       recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
       recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: How would you like to publish?
       recipe_visibility_edit_title: Edit Submission
@@ -998,8 +892,6 @@
       recipe_visibility_unlisted: Unlisted
       recipe_visibility_unlisted_hint: Anyone with the link can install.
       refresh_rate: Oppdateringsfrekvens
-      refresh_rate_hint: Definer hvor ofte denne plugin-instansen henter nye data
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
       refreshed: Oppdatert
       remove_plugin: Fjern plugin
@@ -1056,10 +948,8 @@
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Add a custom schedule
       append: And during…
       no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
       to: to
       copy_prompt: Copy schedule from…
       no_days_error: Please select at least one day.
@@ -1085,11 +975,6 @@
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1618,7 +1503,6 @@
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -12,7 +12,6 @@ pl:
   back: Wstecz
   back_to_all_blog_posts: Powrót do wszystkich postów
   blog: Blog
-  brand: Marka
   buy_now: Kup teraz
   cancel: Anuluj
   change_password: Zmień hasło
@@ -26,15 +25,11 @@ pl:
   copy: Kopiuj
   copied_to_clipboard: Skopiowano!
   copy_to_clipboard: Skopiuj do schowka
-  created: Utworzono
   create_an_account: Utwórz konto
   current_device: Obecne urządzenie
-  days: dni
   delete: Usuń
   developers: Deweloperzy
   developer_edition_required: Aby aktywować tę funkcję, wymagane jest posiadanie edycji deweloperskiej.
-  device_id: ID urządzenia
-  device: Urządzenie
   discard: Odrzuć
   edit: Edytuj
   email_address: Adres e-mail
@@ -45,7 +40,6 @@ pl:
   forgot_password_title: Utwórz nowe hasło
   friendly_id: Przyjazne ID
   get_started: No to zaczynamy!
-  hidden: ukryty
   identify: Identyfikuj
   import: Importuj
   import_new: Importuj nowe
@@ -59,32 +53,23 @@ pl:
   log_out: Wyloguj
   manage: Zarządzaj
   minimum_characters: znaków minimum
-  mins: min.
-  my_playlist: Moja playlista
   new_password: Nowe hasło
   password: Hasło
-  please_wait: Proszę czekać...
   plugin_not_found: Nie znaleziono pluginu
   preview: Podgląd
-  privacy: Prywatność
-  refresh_rate: Refresh rate
   refresh_rates_hint: __Tutaj__ dowiesz się więcej o częstotliwościach odświeżania.
   reset_password: Zresetuj hasło
   reset_to_defaults: Przywróć ustawienia fabryczne
   required: Wymagany
   save: Zapisz
-  shown: wyświetlany
   section: Sekcja
   settings: Ustawienia
   sign_in: Zaloguj się
   sign_up: Zarejestruj się
   something_went_wrong: Ups, coś poszło nie tak
   status: Status
-  subscribe: Subskrybuj
   help_center: Wsparcie techniczne
-  terms: Warunki
   unsaved_changes: Masz niezapisane zmiany
-  update: Aktualizacja
   view: Widok
   collaboration_request: Chcesz nawiązać współpracę?
   collaboration_request_hint: Partnerstwo, sprzedaż grupowa, projekty specjalne, Twój wybór.
@@ -175,9 +160,6 @@ pl:
       refer_and_earn_hint: Udostępnij spersonalizowany kod polecający. Zarabiaj przy każdym użyciu (rozliczenie miesięczne).
       refer_and_earn_redemptions: Realizacje
       refer_and_earn_request_code: Zawnioskuj o kod
-      device_invoice: Faktura za urządzenie
-      device_invoice_label: Pobierz dokumenty dla księgowości lub (dziwny) zbiór PDF-ów.
-      device_invoice_hint: Znajdziesz tę informację na stronie śledzenia paczki lub w e-mailu z powiadomieniem o wysyłce.
       email_address_hint: Używany do logowania do TRMNL i odbioru wiadomości systemowych.
       first_name_hint: Używamy Twojego imienia, aby uczynić korzystanie z TRMNL przyjemniejszym.
       last_name_hint: Używamy Twojego nazwiska, aby uczynić korzystanie z TRMNL przyjemniejszym.
@@ -256,13 +238,7 @@ pl:
   dashboard:
     index:
       title: Pulpit
-      last_7_days: Ostatnie 7 dni
-      last_30_days: Ostatnie 30 dni
-      last_90_days: Ostatnie 90 dni
-      today: Dziś
-      yesterday: Wczoraj
     health:
-      bad: Występują problemy z pluginami
       good: Pluginy działają poprawnie
       next_steps: Poinformujemy Cię, jeśli cokolwiek się zmieni
     news:
@@ -279,14 +255,9 @@ pl:
       new_and_popular: Nowe i popularne
     shop:
       title: Sklep
-      need_another: Potrzebujesz kolejnego TRMNL?
     time_saved:
       title: Zaoszczędzony czas
-      cta: Dowiedz się więcej
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Dzień dobry
@@ -299,7 +270,6 @@ pl:
     edit:
       accepts_beta_firmware: Firmware - wczesny dostęp
       accepts_beta_firmware_hint: Włącz, aby uzyskać najnowsze oprogramowanie układowe przed innymi użytkownikami.
-      back_to_devices: Wróć do przeglądu urządzeń
       battery_and_sleep: Bateria i tryb uśpienia
       battery_consumption: Zużycie baterii
       battery_consumption_hint: Oszczędzaj energię i ciesz się dłuższym działaniem dzięki Trybowi Uśpienia.
@@ -321,7 +291,6 @@ pl:
       device_model_switch_warning: Zmiana jest obarczona ryzykiem. Przeczytaj więcej __tutaj__
       device_info: Informacje o urządzeniu
       current_firmware: Obecny firmware
-      last_ping: Ostatni ping
       unknown: Nieznane
       never: Nigdy
       display_calibration: Kalibracja wyświetlacza
@@ -367,7 +336,6 @@ pl:
       ota_byod_not_supported: Aktualizacje OTA nie są wspierane na urządzeniach firm trzecich (BYOD). Wgraj kompatybilne oprogramowanie ze strony trmnl.com/flash
       maximum_compatibility: Włącz maksymalną kompatybilność
       maximum_compatibility_hint: Rozwiązuje problemy z wyświetlaniem na niektórych wyświetlaczach ePaper. Wyłącza szybkie odświeżanie. Wymaga oprogramowania 1.6.0 lub nowszego.
-      color_and_rotation: Kolor i obrót
       image_rotation: Image Rotation
       screen_rotation: Obrót ekranu
       screen_rotation_not_supported: Obrót ekranu nie jest obecnie obsługiwany na Twoim urządzeniu.
@@ -389,9 +357,7 @@ pl:
       tidbyt_credentials: Poświadczenia Tidbyt
       tidbyt_credentials_hint: Wprowadź poświadczenia API swojego urządzenia Tidbyt. Znajdziesz je w aplikacji Tidbyt w menu Settings → Developer → Get API Key
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Niepoprawne poświadczenia Tidbyt API. Sprawdź ich poprawność i spróbuj ponownie.
       tidbyt_device_id: ID urządzenia
-      tidbyt_device_api_key: Klucz API
       unlink: Odłącz
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Odłącz urządzenie
@@ -399,7 +365,6 @@ pl:
       unlink_device_learn_more: Szczegółowe informacje znajdziesz __tutaj__.
       visibility: Widoczność
       visibility_hint: Przełączenie w tryb udostępniania umożliwi ustawienie urządzenia jako źródła kopii lustrzanej (mirror).
-      your_device: Twój TRMNL
       upgrade_og:
         title: Aktualizacja do 2-bitowego wyświetlacza dostępna
         sub_title: Twoje urządzenie może być zaktualizowane, aby być w stanie wyświetlać 4 odcienie szarości zamiast standardowych 2.
@@ -436,9 +401,6 @@ pl:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -512,7 +474,6 @@ pl:
     index:
       title: Urządzenia
       tagline: Twoje urządzenia TRMNL
-      add_device_modal_title: Dodaj nowe urządzenie
       add_first_device: Zacznij, dodając swoje pierwsze urządzenie!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -538,9 +499,6 @@ pl:
     dissociate:
       error: Błąd przy odłączaniu urządzenia
       success: Pomyślnie odłączono urządzenie
-    external_credentials:
-      error: Niepoprawne poświadczenia urządzenia
-      success: Poświadczenia urządzenia zostały pomyślnie zaktualizowane
     identify:
       error: Błąd podczas aktualizacji urządzenia
       success: Wysłano żądanie identyfikacji urządzenia
@@ -579,16 +537,11 @@ pl:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Zbyt wiele prób, odczekaj chwilę i spróbuj ponownie
-    invoice_not_found: Nie odnaleziono faktury
   logs:
     index:
       title: Logi
       all: Wszystkie
-      bulk_destroy: Usuń wszystko
       dump: Message
-      id: ID
       private_plugins: Prywatne pluginy
       source: Źródło
       time: Time (UTC)
@@ -623,9 +576,6 @@ pl:
       live_preview: Podgląd na żywo
       no_changes_to_save: Brak zmian do zapisania
       pop_out_preview: Podgląd w nowym oknie
-      quickstart_examples: Gotowe przykłady na start
-      quickstart_example_applied: Zastosowano!
-      quickstart_use_this_example: Użyj tego przykładu
       revert: Cofnij
       revert_confirm: Na pewno chcesz cofnąć? Wszystkie niezapisane zmiany zostaną utracone.
       save_changes: Zapisz zmiany (⌘﹢S / Ctrl + S)
@@ -689,9 +639,6 @@ pl:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: Uwierzytelnianie dwuskładnikowe (2FA) wyłączone
@@ -717,21 +664,12 @@ pl:
   playlist_items:
     index:
       title: Playlista
-      tagline: 'Wybierz, co ma się wyświetlać na:'
-      add_a_group: Dodaj grupę
-      add_a_plugin: Dodaj plugin
       add_first_device_cta: Zacznij od __dodania__ Twojego pierwszego TRMNL!
       add_to_playlist: Dodaj do playlisty
-      create_first_playlist_cta: Stwórz playlistę po __dodaniu__ swojego pierwszego pluginu!
       custom: Niestandardowe
       device_default: Domyślne dla urządzenia
-      display_period_from: Wyświetlaj od
-      display_period_to: do
       display_period_validation: Godzina startu nie może być późniejsza niż godzina zakończenia. Utwórz kolejną grupę, aby objąć godziny nocne.
-      every: Każdy
       never_skip: Nigdy nie pomijaj żadnych ekranów
-      smart_playlist: Inteligentna playlista
-      smart_playlist_hint: Automatycznie pomiń ekrany, na których treści się nie zmieniły przez dłuższy czas.
       skip_after:
         one: Pomiń nieaktualne ekrany po 1 dniu
         other: Pomiń nieaktualne ekrany po %{count} dniach
@@ -769,9 +707,6 @@ pl:
       duplicate: Duplikuj
       duplicate_confirm: Funkcja ta zduplikuje obiekt i umieści go na końcu playlisty. Kontynować?
       presentation: Presentation
-      color_palette: Paleta kolorów
-      device_default: Domyślne dla urządzenia (%{name})
-      palette_unavailable: Dostępne tylko dla urządzeń obsługujących palety kolorów
       refresh_rate_disabled:
         default: Częstotliwość odświeżania tego pluginu nie może być skonfigurowana.
         external: Ten plugin pobiera dane na bieżąco, więc częstotliwość odświeżania nie ma tu zastosowania.
@@ -788,7 +723,6 @@ pl:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Aktualizacja playlisty nie powiodła się
       success: Playlista zaktualizowana
     destroy:
       error: Usunięcie elementu z playlisty nie powiodło się
@@ -801,8 +735,6 @@ pl:
       success: Kolejność playlisty została zaktualizowana
     set_preferences:
       success: Ustawienia inteligentnej listy odtwarzania zaktualizowane
-    update:
-      success: Zaktualizowano kolejność odtwarzania
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -833,23 +765,10 @@ pl:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -857,8 +776,6 @@ pl:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -869,9 +786,6 @@ pl:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -887,7 +801,6 @@ pl:
     index:
       title: Pluginy
       tagline: Co umieścisz na swoim TRMNL?
-      available: Dostępne
       connected: Połączone
       supported_by_this_device: Supported by this device
       recipes: Receptury
@@ -899,7 +812,6 @@ pl:
         title: Moje pluginy
         tagline: Twórz pluginy i udostępniaj je w publicznym katalogu
       card:
-        connections: połączenia
         install: Instaluj
         review_are_you_sure: Na pewno? Zespół TRMNL przetestuje plugin i w razie potrzeby skontaktuje się z Tobą przez e-mail.
         submit_for_review: Prześlij do weryfikacji
@@ -929,16 +841,11 @@ pl:
     edit:
       title: Edytuj plugin
       tagline: Zaktualizuj szczegóły swojego pluginu.
-      name: Nazwa
-      description: Opis
   plugin_recipes:
     connected: Receptura połączona
     connections:
       one: Połączenie
       other: Połączenia
-    forks:
-      one: Fork
-      other: Forki
     forked: Receptura sforkowana
     new:
       error: Nie znaleziono receptury
@@ -946,18 +853,14 @@ pl:
       more_by_author: Więcej od tego Autora
       view_all: Pokaż wszystko
   plugin_settings:
-    active: Aktywny
     copy_are_you_sure: Czy na pewno chcesz skopiować to ustawienie?
     delete_are_you_sure: Czy na pewno chcesz usunąć to ustawienie?
     delete: To całkowicie usunie ustawienia pluginu. Jeśli nie chcesz, by plugin był wyświetlany na urządzeniu, po prostu usuń go z playlisty.
-    inactive: Nieaktywny
     no_matches_found: Nie znaleziono pluginów pasujących do kryteriów.
-    no_plugin_settings_found: Nie znaleziono ustawień pluginu.
     not_supported: Niewspierany na tym urządzeniu
     refreshing_now_please_wait: Odświeżanie w toku, przeładuj tę stronę za kilka sekund.
     reset_credentials: Pomyślnie zresetowano konto %{plugin_name}
     form:
-      active_hint: Pokazuje lub ukrywa instancję tego pluginu na Twoim urządzeniu
       advanced_settings: Zaawansowane
       back_to_playlist: Wróć do Playlist
       back_to_plugin: Wróć do %{plugin}
@@ -979,15 +882,7 @@ pl:
       health_notifications_hint: Otrzymaj e-maila, jeśli stan tego pluginu wskaże problem (zdegradowany / błąd). Otrzymasz najwyżej jeden e-mail na zmianę stanu na incydent. Alerty uzbrajają się ponownie po powrocie pluginu do stanu "zdrowy".
       health_notifications_checkbox: Wyślij mi e-mail, jeśli plugin będzie miał problem z działaniem
       learn_more: Dowiedz się więcej o tym pluginie z naszej bazy wiedzy
-      learn_more_fork: Ten plugin jest forkiem Receptury.
-      learn_more_fork_original: Zobacz oryginał
-      learn_more_native_long: To jest natywny plugin, wspierany przez TRMNL.
-      learn_more_native_short: Ten plugin jest wspierany przez TRMNL.
       learn_more_recipe_author: Potrzebujesz pomocy? Skontaktuj się z %{recipe_author} na Discordzie.
-      learn_more_recipe_long: Ten plugin jest Recepturą społecznościową i nie jest utrzymywany przez TRMNL.
-      learn_more_recipe_short: 'Uwaga: ten plugin jest Recepturą.'
-      learn_more_third_party_long: Wtyczka została stworzona przez osoby trzecie i nie jest wspierana przez TRMNL.
-      learn_more_third_party_short: 'Uwaga: wtyczka stworzona przez osoby trzecie.'
       linked_account: Konto połączone
       linked_account_success: Pomyślnie połączono z %{plugin_name}
       link_oauth: Połącz konto
@@ -1009,7 +904,6 @@ pl:
       recipe_cta_body_published: Zmiany będą miały wpływ na obecne i przyszłe instalacje/forki.
       recipe_cta_body_in_review: Plugin został zgłoszony do przetestowania przez nasz zespół. Prosimy o cierpliwość.
       recipe_cta_body_not_published: Opublikuj ten plugin, aby inni mogli go zainstalować. __Dowiedz się więcej__.
-      recipe_cta_confirm: Na pewno? Zespół TRMNL przetestuje plugin i odezwie się w ciągu kilku dni. Możesz nadal nanosić zmiany.
       recipe_mirrored: Ten ekran jest kopią lustrzaną z receptury.
       recipe_visibility_title: Wybierz sposób publikacji
       recipe_visibility_edit_title: Edytuj zgłoszenie
@@ -1020,8 +914,6 @@ pl:
       recipe_visibility_unlisted: Ukryty
       recipe_visibility_unlisted_hint: Tylko osoby posiadające link mogą zainstalować.
       refresh_rate: Częstotliwość odświeżania
-      refresh_rate_hint: Określ, jak często ta instancja pluginu ma pobierać świeże dane.
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Odświeżanie %{refresh_rate} (niekonfigurowalne)
       refreshed: Odświeżony
       remove_plugin: Usuń plugin
@@ -1078,10 +970,8 @@ pl:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Dodaj własny harmonogram
       append: Oraz…
       no_schedule: Ten ekran będzie wyświetlany przez cały czas.
-      some_schedule: Określ, kiedy ten ekran ma być wyświetlany
       to: do
       copy_prompt: Kopiuj harmonogram z…
       no_days_error: Wybierz proszę minimum jeden dzień.
@@ -1107,11 +997,6 @@ pl:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1640,7 +1525,6 @@ pl:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -12,7 +12,6 @@ pt-BR:
   back: Voltar
   back_to_all_blog_posts: Voltar
   blog: Blog
-  brand: Marca
   buy_now: Comprar Agora
   cancel: Cancelar
   change_password: Mudar Senha
@@ -26,15 +25,11 @@ pt-BR:
   copy: Copiar
   copied_to_clipboard: Copiado!
   copy_to_clipboard: Copiar para área de transferência
-  created: Criado
   create_an_account: Criar uma conta
   current_device: Dispositivo atual
-  days: dias
   delete: Deletar
   developers: Desenvolvedores
   developer_edition_required: Você precisa da Edição de Desenvolvedor para ativar essa função.
-  device_id: ID do Dispositivo
-  device: Dispositivo
   discard: Discard
   edit: Configurações
   email_address: E-mail
@@ -45,7 +40,6 @@ pt-BR:
   forgot_password_title: Lá vamos nós de novo
   friendly_id: Friendly ID
   get_started: Vamos começar!
-  hidden: hidden
   identify: Identificar
   import: Importar
   import_new: Importar novo
@@ -59,32 +53,23 @@ pt-BR:
   log_out: Sair
   manage: Gerenciar
   minimum_characters: caracteres pelo menos
-  mins: mins
-  my_playlist: Minha Playlist
   new_password: Nova senha
   password: Senha
-  please_wait: Aguarde...
   plugin_not_found: Plugin não encontrado
   preview: Preview
-  privacy: Privacidade
-  refresh_rate: Refresh rate
   refresh_rates_hint: Saiba mais sobre taxas de atualização __aqui__.
   reset_password: Redefinir minha senha
   reset_to_defaults: Reset to defaults
   required: Required
   save: Salvar
-  shown: shown
   section: Seção
   settings: Configurações
   sign_in: Entrar
   sign_up: Cadastrar
   something_went_wrong: Algo deu errado
   status: Status
-  subscribe: Assine
   help_center: Suporte
-  terms: Termos
   unsaved_changes: You have unsaved changes
-  update: Atualizar
   view: Visualizar
   collaboration_request: Quer colaborar?
   collaboration_request_hint: Parcerias, vendas para empresas, projetos especiais, o que você quiser.
@@ -153,9 +138,6 @@ pt-BR:
       refer_and_earn_hint: Presenteie um TRMNL com um cupom personalizado. Receba por uso, pago mensalmente.
       refer_and_earn_redemptions: Resgates
       refer_and_earn_request_code: Pedir um Código
-      device_invoice: Fatura do Dispositivo
-      device_invoice_label: Obtenha documentos comerciais para seu contador ou sua coleção de PDFs.
-      device_invoice_hint: Encontre o código na página de rastreamento do pedido ou no e-mail de notificação de pedido.
       email_address_hint: Usado para entrar no TRMNL e receber mensagens do sistema.
       first_name_hint: Nós usamos o seu nome para tornar a interface do TRMNL mais confortável.
       last_name_hint: Nós usamos o seu nome para tornar a interface do TRMNL mais confortável.
@@ -234,13 +216,7 @@ pt-BR:
   dashboard:
     index:
       title: Dashboard
-      last_7_days: Últimos 7 dias
-      last_30_days: Últimos 30 dias
-      last_90_days: Últimos 90 dias
-      today: Hoje
-      yesterday: Ontem
     health:
-      bad: Plugins com problemas
       good: Plugins funcionando
       next_steps: Vamos lhe informar se algo mudar
     news:
@@ -257,14 +233,9 @@ pt-BR:
       new_and_popular: Novos e Populares
     shop:
       title: Loja
-      need_another: Precisa de outro TRMNL?
     time_saved:
       title: Tempo economizado
-      cta: Ler sobre
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Bom dia
@@ -277,7 +248,6 @@ pt-BR:
     edit:
       accepts_beta_firmware: Versões Antecipadas de Firmware
       accepts_beta_firmware_hint: Ative para obter as últimas versões do firmware de dispositivo antes dos outros usuários.
-      back_to_devices: Voltar para Dispositivos
       battery_and_sleep: Battery & Sleep
       battery_consumption: Consumo da Bateria
       battery_consumption_hint: Economize energia desfrute de mais bateria ativando o Modo de Suspensão.
@@ -299,7 +269,6 @@ pt-BR:
       device_model_switch_warning: Essa é uma operação perigosa, saiba mais __aqui__
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -345,7 +314,6 @@ pt-BR:
       ota_byod_not_supported: OTA não é suportado em dispositivos BYOD. Instale uma versão compatível diretamente de trmnl.com/flash
       maximum_compatibility: Habilitar Compatibilidade Máxima
       maximum_compatibility_hint: Resolve problemas de exibição causados por determinados chips ePaper. Desabilida a atualização rápida. Requer o firmware 1.6.0+.
-      color_and_rotation: Color & Rotation
       image_rotation: Image Rotation
       screen_rotation: Screen Rotation
       screen_rotation_not_supported: A rotação da tela não é suportada no seu dispositivo.
@@ -367,9 +335,7 @@ pt-BR:
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
       unlink: Desconectar
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Desconectar Dispositivo
@@ -377,7 +343,6 @@ pt-BR:
       unlink_device_learn_more: Siga o guia completo __aqui__.
       visibility: Visibilidade
       visibility_hint: Torne seu TRMNL espelhável mudando a configuração abaixo.
-      your_device: Seu TRMNL
       upgrade_og:
         title: Atualização para Display de 2 bits Disponível
         sub_title: Seu dispositivo pode ser atualizado para suportar imagens com 4 tons de cinza ao invés de apenas 2.
@@ -414,9 +379,6 @@ pt-BR:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ pt-BR:
     index:
       title: Dispositivos
       tagline: Seus dispositivos TRMNL
-      add_device_modal_title: Adicionar novo dispositivo
       add_first_device: Comece adicionando seu primeiro dispositivo!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -516,9 +477,6 @@ pt-BR:
     dissociate:
       error: Erro ao desconectar dispositivo
       success: Dispositivo desconectado com sucesso
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: Erro ao atualizar dispositivo
       success: Identificação do dispositivo solicitada
@@ -557,16 +515,11 @@ pt-BR:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Muitas tentativas, por favor espere e tente novamente
-    invoice_not_found: Fatura não encontrada
   logs:
     index:
       title: Logs
       all: Todos
-      bulk_destroy: Remover em Massa
       dump: Message
-      id: ID
       private_plugins: Plugins Privados
       source: Fonte
       time: Time (UTC)
@@ -601,9 +554,6 @@ pt-BR:
       live_preview: Pré-visualização
       no_changes_to_save: Não há alterações para salvar
       pop_out_preview: Destacar Pré-visualização
-      quickstart_examples: Exemplos Rápidos
-      quickstart_example_applied: Aplicado!
-      quickstart_use_this_example: Usar este exemplo
       revert: Reverter
       revert_confirm: Tem certeza que deseja reverter? Todas as mudanças não salvas serão perdidas.
       save_changes: Salvar (⌘﹢S)
@@ -667,9 +617,6 @@ pt-BR:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA Desativado
@@ -695,21 +642,12 @@ pt-BR:
   playlist_items:
     index:
       title: Playlist
-      tagline: Escolha o que é exibido no
-      add_a_group: Adicionar um Grupo
-      add_a_plugin: Adicionar um Plugin
       add_first_device_cta: Comece __adicionando__ seu primeiro TRMNL!
       add_to_playlist: Adicionar na Playlist
-      create_first_playlist_cta: Cria sua playlist após __conectar__ seu primeiro plugin!
       custom: Customizado
       device_default: Padrão do Dispositivo
-      display_period_from: Exibir de
-      display_period_to: até
       display_period_validation: Hora de início deve ser anterior a hora de fim. Crie um novo grupo para abrenger o período noturno.
-      every: Cada
       never_skip: Nunca esconda telas
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Esconda telas cujo conteúdo não foi alterado durante algum tempo.
       skip_after:
         one: Esconda telas após 1 dia
         other: Esconda telas após %{count} dias
@@ -747,9 +685,6 @@ pt-BR:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -766,7 +701,6 @@ pt-BR:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Falha ao atualizar a playlist
       success: Playlist atualizada
     destroy:
       error: Erro ao remover item da playlist
@@ -779,8 +713,6 @@ pt-BR:
       success: Ordem da Playlist atualizada
     set_preferences:
       success: Preferência por Smart playlist atualizada
-    update:
-      success: Ordem da Playlist atualizada
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -811,23 +743,10 @@ pt-BR:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -835,8 +754,6 @@ pt-BR:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -847,9 +764,6 @@ pt-BR:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -865,7 +779,6 @@ pt-BR:
     index:
       title: Plugins
       tagline: O que você vai colocar no seu TRMNL?
-      available: Disponíveis
       connected: Conectados
       supported_by_this_device: Supported by this device
       recipes: Receitas
@@ -877,7 +790,6 @@ pt-BR:
         title: Meus Plugins
         tagline: Desenvolva Plugins para o marketplace público
       card:
-        connections: conexões
         install: Instalar
         review_are_you_sure: Tem certeza? A equipe do TRMNL irá testar e te enviar quaisquer perguntas por e-mail.
         submit_for_review: Enviar para Avaliação
@@ -907,16 +819,11 @@ pt-BR:
     edit:
       title: Alterar Plugin
       tagline: Atualize os detalhes do seu plugin.
-      name: Nome
-      description: Descrição
   plugin_recipes:
     connected: Receita instalada
     connections:
       one: Conexão
       other: Conexões
-    forks:
-      one: Derivação
-      other: Derivações
     forked: Recipe forked
     new:
       error: Receita não encontrada
@@ -924,18 +831,14 @@ pt-BR:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Ativo
     copy_are_you_sure: Tem certeza que deseja copiar esta configuração?
     delete_are_you_sure: Tem certeza que deseja deletar essa configuração?
     delete: Isso irá remover completamente as condfigurações do plugin. Para esconder o plugin do dispositivo, simplesmente remova-o da Playlist.
-    inactive: Inativo
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: Nenhuma configuração encontrada.
     not_supported: Não suportado no dispositivo atual
     refreshing_now_please_wait: Atualizando agora, reabra essa página em alguns segundos.
     reset_credentials: Conta %{plugin_name} resetada com sucesso
     form:
-      active_hint: Exibir ou esconder este plugin no seu dispositivo
       advanced_settings: Configurações Avançadas
       back_to_playlist: Back to Playlist
       back_to_plugin: Voltar para %{plugin}
@@ -957,15 +860,7 @@ pt-BR:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Saiba mais sobre esse plugin em nossa base de conhecimento
-      learn_more_fork: Esse plugin foi derivado de uma Receita.
-      learn_more_fork_original: Ver Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
       learn_more_recipe_author: Precisa de ajuda? Fale com %{recipe_author} no Discord.
-      learn_more_recipe_long: Esse plugin é uma Receita da comunidade e não é mantido pelo TRMNL.
-      learn_more_recipe_short: 'Nota: esse plugin é uma Receita.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       linked_account: Conta Vinculada
       linked_account_success: Conta vinculada com sucesso com %{plugin_name}
       link_oauth: Vincular Conta
@@ -987,7 +882,6 @@ pt-BR:
       recipe_cta_body_published: Mudanças serão refletidas em instalações atuais e futuras instalações/forks..
       recipe_cta_body_in_review: Esse plugin foi submetido para nosso time. Aguarde.
       recipe_cta_body_not_published: Submeta esse plugin para que outros possam instalá-lo. __Saiba mais__.
-      recipe_cta_confirm: Tem certeza? Nosso time irá revisar e te retornar em alguns dias. Você pode continuar efetuando mudanças.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: Como você gostaria de publicar?
       recipe_visibility_edit_title: Alterar Submissão
@@ -998,8 +892,6 @@ pt-BR:
       recipe_visibility_unlisted: Não Listado
       recipe_visibility_unlisted_hint: Apenas quem possuir o link pode instalar.
       refresh_rate: Taxa de atualização
-      refresh_rate_hint: Defina com que frequência esse plugin obtém novos dados
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Atualiza %{refresh_rate} (não configurável)
       refreshed: Atualizado
       remove_plugin: Remover plugin
@@ -1056,10 +948,8 @@ pt-BR:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Adicione uma agenda customizada
       append: E durante…
       no_schedule: Essa tela será exibida sempre.
-      some_schedule: Exiba essa tela apenas durante…
       to: para
       copy_prompt: Copiar agenda de…
       no_days_error: Please select at least one day.
@@ -1085,11 +975,6 @@ pt-BR:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1618,7 +1503,6 @@ pt-BR:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -12,7 +12,6 @@ raw:
   back: back
   back_to_all_blog_posts: back_to_all_blog_posts
   blog: blog
-  brand: brand
   buy_now: buy_now
   cancel: cancel
   change_password: change_password
@@ -26,15 +25,11 @@ raw:
   copy: copy
   copied_to_clipboard: copied_to_clipboard
   copy_to_clipboard: copy_to_clipboard
-  created: created
   create_an_account: create_an_account
   current_device: current_device
-  days: days
   delete: delete
   developers: developers
   developer_edition_required: developer_edition_required
-  device_id: device_id
-  device: device
   discard: discard
   edit: edit
   email_address: email_address
@@ -45,7 +40,6 @@ raw:
   forgot_password_title: forgot_password_title
   friendly_id: friendly_id
   get_started: get_started
-  hidden: hidden
   identify: identify
   import: import
   import_new: import_new
@@ -59,32 +53,23 @@ raw:
   log_out: log_out
   manage: manage
   minimum_characters: minimum_characters
-  mins: mins
-  my_playlist: my_playlist
   new_password: new_password
   password: password
-  please_wait: please_wait
   plugin_not_found: plugin_not_found
   preview: preview
-  privacy: privacy
-  refresh_rate: refresh_rate
   refresh_rates_hint: refresh_rates_hint __here__.
   reset_password: reset_password
   reset_to_defaults: reset_to_defaults
   required: required
   save: save
-  shown: shown
   section: section
   settings: settings
   sign_in: sign_in
   sign_up: sign_up
   something_went_wrong: something_went_wrong
   status: status
-  subscribe: subscribe
   help_center: support
-  terms: terms
   unsaved_changes: unsaved_changes
-  update: update
   view: view
   collaboration_request: collaboration_request
   collaboration_request_hint: collaboration_request_hint
@@ -153,9 +138,6 @@ raw:
       refer_and_earn_hint: account.index.refer_and_earn_hint
       refer_and_earn_redemptions: account.index.refer_and_earn_redemptions
       refer_and_earn_request_code: account.index.refer_and_earn_request_code
-      device_invoice: account.index.device_invoice
-      device_invoice_label: account.index.device_invoice_label
-      device_invoice_hint: account.index.device_invoice_hint
       email_address_hint: account.index.email_address_hint
       first_name_hint: account.index.first_name_hint
       last_name_hint: account.index.last_name_hint
@@ -234,13 +216,7 @@ raw:
   dashboard:
     index:
       title: dashboard.index.title
-      last_7_days: dashboard.index.last_7_days
-      last_30_days: dashboard.index.last_30_days
-      last_90_days: dashboard.index.last_90_days
-      today: dashboard.index.today
-      yesterday: dashboard.index.yesterday
     health:
-      bad: dashboard.health.bad
       good: dashboard.health.good
       next_steps: dashboard.health.next_steps
     news:
@@ -257,15 +233,10 @@ raw:
       new_and_popular: dashboard.plugins.new_and_popular
     shop:
       title: dashboard.shop.title
-      need_another: dashboard.shop.need_another
     time_saved:
       title: dashboard.time_saved.title
-      cta: dashboard.time_saved.cta
     discover_callout:
       manage_persona: dashboard.discover_callout.manage_persona
-      dismiss: dashboard.discover_callout.dismiss
-    saved_discovery_setup:
-      manage_persona: dashboard.saved_discovery_setup.manage_persona
     welcome_message:
       morning_salutation: dashboard.welcome_message.morning_salutation
       afternoon_salutation: dashboard.welcome_message.afternoon_salutation
@@ -277,7 +248,6 @@ raw:
     edit:
       accepts_beta_firmware: devices.edit.accepts_beta_firmware
       accepts_beta_firmware_hint: devices.edit.accepts_beta_firmware_hint
-      back_to_devices: devices.edit.back_to_devices
       battery_and_sleep: devices.edit.battery_and_sleep
       battery_consumption: devices.edit.battery_consumption
       battery_consumption_hint: devices.edit.battery_consumption_hint
@@ -299,7 +269,6 @@ raw:
       device_model_switch_warning: devices.edit.device_model_switch_warning
       device_info: devices.edit.device_info
       current_firmware: devices.edit.current_firmware
-      last_ping: devices.edit.last_ping
       unknown: devices.edit.unknown
       never: devices.edit.never
       display_calibration: devices.edit.display_calibration
@@ -345,7 +314,6 @@ raw:
       ota_byod_not_supported: devices.edit.ota_byod_not_supported
       maximum_compatibility: devices.edit.maximum_compatibility
       maximum_compatibility_hint: devices.edit.maximum_compatibility_hint
-      color_and_rotation: devices.edit.color_and_rotation
       image_rotation: devices.edit.image_rotation
       screen_rotation: devices.edit.screen_rotation
       screen_rotation_not_supported: devices.edit.screen_rotation_not_supported
@@ -367,9 +335,7 @@ raw:
       tidbyt_credentials: devices.edit.tidbyt_credentials
       tidbyt_credentials_hint: devices.edit.tidbyt_credentials_hint
       tidbyt_api_key: devices.edit.tidbyt_api_key
-      tidbyt_credentials_invalid: devices.edit.tidbyt_credentials_invalid
       tidbyt_device_id: devices.edit.tidbyt_device_id
-      tidbyt_device_api_key: devices.edit.tidbyt_device_api_key
       unlink: devices.edit.unlink
       unlink_confirm: devices.edit.unlink_confirm
       unlink_device: devices.edit.unlink_device
@@ -377,7 +343,6 @@ raw:
       unlink_device_learn_more: devices.edit.unlink_device_learn_more
       visibility: devices.edit.visibility
       visibility_hint: devices.edit.visibility_hint
-      your_device: devices.edit.your_device
       upgrade_og:
         title: devices.edit.upgrade_og.title
         sub_title: devices.edit.upgrade_og.sub_title
@@ -414,9 +379,6 @@ raw:
       waits_for_next_render_hint: devices.edit.waits_for_next_render_hint
       battery_advice:
         title: devices.edit.battery_advice.title
-        wakes_per_day:
-          one: devices.edit.battery_advice.wakes_per_day.one
-          other: devices.edit.battery_advice.wakes_per_day.other
         days_per_charge:
           one: devices.edit.battery_advice.days_per_charge.one
           other: devices.edit.battery_advice.days_per_charge.other
@@ -490,7 +452,6 @@ raw:
     index:
       title: devices.index.title
       tagline: devices.index.tagline
-      add_device_modal_title: devices.index.add_device_modal_title
       add_first_device: devices.index.add_first_device
       go_to_settings: devices.index.go_to_settings
       clear_playlist: devices.index.clear_playlist
@@ -516,9 +477,6 @@ raw:
     dissociate:
       error: devices.dissociate.error
       success: devices.dissociate.success
-    external_credentials:
-      error: devices.external_credentials.error
-      success: devices.external_credentials.success
     identify:
       error: devices.identify.error
       success: devices.identify.success
@@ -557,16 +515,11 @@ raw:
         title: discovery.dashboard_action.setup.title
         subtext: discovery.dashboard_action.setup.subtext
         primary_label: discovery.dashboard_action.setup.primary_label
-  invoices:
-    rate_limit: invoices.rate_limit
-    invoice_not_found: invoices.invoice_not_found
   logs:
     index:
       title: logs.index.title
       all: logs.index.all
-      bulk_destroy: logs.index.bulk_destroy
       dump: logs.index.dump
-      id: logs.index.id
       private_plugins: logs.index.private_plugins
       source: logs.index.source
       time: logs.index.time
@@ -601,9 +554,6 @@ raw:
       live_preview: markups.form.live_preview
       no_changes_to_save: markups.form.no_changes_to_save
       pop_out_preview: markups.form.pop_out_preview
-      quickstart_examples: markups.form.quickstart_examples
-      quickstart_example_applied: markups.form.quickstart_example_applied
-      quickstart_use_this_example: markups.form.quickstart_use_this_example
       revert: markups.form.revert
       revert_confirm: markups.form.revert_confirm
       save_changes: markups.form.save_changes
@@ -667,9 +617,6 @@ raw:
       workspace_ready: markups.visual_editor.workspace_ready
       zoom_in: markups.visual_editor.zoom_in
       zoom_out: markups.visual_editor.zoom_out
-  notices:
-    dismiss:
-      discover_callout: notices.dismiss.discover_callout
   mfa:
     disable_otp:
       success: mfa.disable_otp.success
@@ -695,21 +642,12 @@ raw:
   playlist_items:
     index:
       title: playlists.index.title
-      tagline: playlists.index.tagline
-      add_a_group: playlists.index.add_a_group
-      add_a_plugin: playlists.index.add_a_plugin
       add_first_device_cta: playlists.index.add_first_device_cta
       add_to_playlist: playlists.index.add_to_playlist
-      create_first_playlist_cta: playlists.index.create_first_playlist_cta
       custom: playlists.index.custom
       device_default: playlists.index.device_default
-      display_period_from: playlists.index.display_period_from
-      display_period_to: playlists.index.display_period_to
       display_period_validation: playlists.index.display_period_validation
-      every: playlists.index.every
       never_skip: playlist_items.index.never_skip
-      smart_playlist: playlist_items.index.smart_playlist
-      smart_playlist_hint: playlist_items.index.smart_playlist_hint
       skip_after:
         one: playlist_items.index.skip_after.one
         other: playlist_items.index.skip_after.other
@@ -747,9 +685,6 @@ raw:
       duplicate: playlist_items.playlist_item.duplicate
       duplicate_confirm: playlist_items.playlist_item.duplicate_confirm
       presentation: playlist_items.playlist_item.presentation
-      color_palette: playlist_items.playlist_item.color_palette
-      device_default: playlist_items.playlist_item.device_default
-      palette_unavailable: playlist_items.playlist_item.palette_unavailable
       refresh_rate_disabled:
         default: playlist_items.playlist_item.refresh_rate_disabled.default
         external: playlist_items.playlist_item.refresh_rate_disabled.external
@@ -766,7 +701,6 @@ raw:
       render_overdue: playlist_items.playlist_item.render_overdue
       no_next_render: playlist_items.playlist_item.no_next_render
     create:
-      error: playlists.create.error
       success: playlists.create.success
     destroy:
       error: playlists.destroy.error
@@ -779,8 +713,6 @@ raw:
       success: playlists.sort.success
     set_preferences:
       success: playlist_items.set_preferences.success
-    update:
-      success: playlists.update.success
     refresh:
       success: playlist_items.refresh.success
       placeholder: playlist_items.refresh.placeholder
@@ -811,23 +743,10 @@ raw:
         other: playlist_items.schedule.custom.other
       important_title: playlist_items.schedule.important_title
       important_description: playlist_items.schedule.important_description
-    column:
-      schedule: playlist_items.column.schedule
-      status: playlist_items.column.status
-    skip_reasons:
-      needs_configuration: playlist_items.skip_reasons.needs_configuration
-      hidden: playlist_items.skip_reasons.hidden
-      skipped: playlist_items.skip_reasons.skipped
-      schedule: playlist_items.skip_reasons.schedule
-      stale: playlist_items.skip_reasons.stale
     bulk_actions:
-      selected:
-        one: playlist_items.bulk_actions.selected.one
-        other: playlist_items.bulk_actions.selected.other
       hide: playlist_items.bulk_actions.hide
       show: playlist_items.bulk_actions.show
       delete: playlist_items.bulk_actions.delete
-      cancel: playlist_items.bulk_actions.cancel
       destroy_confirm: playlist_items.bulk_actions.destroy_confirm
       success:
         hide: playlist_items.bulk_actions.success.hide
@@ -835,8 +754,6 @@ raw:
         destroy: playlist_items.bulk_actions.success.destroy
       error: playlist_items.bulk_actions.error
     time_travel_modal:
-      title: playlist_items.time_travel_modal.title
-      apply: playlist_items.time_travel_modal.apply
       false: playlist_items.time_travel_modal.false
     smart_skip_modal:
       title: playlist_items.smart_skip_modal.title
@@ -847,9 +764,6 @@ raw:
       error: playlist_items.update_full_playlist_order.error
     day_ahead:
       title: playlist_items.day_ahead.title
-      window: playlist_items.day_ahead.window
-      open: playlist_items.day_ahead.open
-      toggle: playlist_items.day_ahead.toggle
       times:
         one: playlist_items.day_ahead.times.one
         other: playlist_items.day_ahead.times.other
@@ -865,7 +779,6 @@ raw:
     index:
       title: plugins.index.title
       tagline: plugins.index.tagline
-      available: plugins.index.available
       connected: plugins.index.connected
       supported_by_this_device: plugins.index.supported_by_this_device
       recipes: recipes
@@ -877,7 +790,6 @@ raw:
         title: plugins.my.title
         tagline: plugins.my.tagline
       card:
-        connections: plugins.my.connections
         install: plugins.my.install
         review_are_you_sure: plugins.my.review_are_you_sure
         submit_for_review: plugins.my.submit_for_review
@@ -907,16 +819,11 @@ raw:
     edit:
       title: plugins.edit.title
       tagline: plugins.edit.tagline
-      name: plugins.edit.name
-      description: plugins.edit.description
   plugin_recipes:
     connected: plugin_recipes.connected
     connections:
       one: plugin_recipes.connections.one
       other: plugin_recipes.connections.many
-    forks:
-      one: plugin_recipes.forks.one
-      other: plugin_recipes.forks.many
     forked: plugin_recipes.forked
     new:
       error: plugin_recipes.new.error
@@ -924,18 +831,14 @@ raw:
       more_by_author: plugin_recipes.show.more_by_author
       view_all: plugin_recipes.show.view_all
   plugin_settings:
-    active: plugin_settings.active
     copy_are_you_sure: plugin_settings.copy_are_you_sure
     delete_are_you_sure: plugin_settings.delete_are_you_sure
     delete: plugin_settings.delete
-    inactive: plugin_settings.inactive
     no_matches_found: plugin_settings.no_matches_found
-    no_plugin_settings_found: plugin_settings.no_plugin_settings_found
     not_supported: plugin_settings.not_supported
     refreshing_now_please_wait: plugin_settings.refreshing_now_please_wait
     reset_credentials: plugin_settings.reset_credentials
     form:
-      active_hint: plugin_settings.form.active_hint
       advanced_settings: plugin_settings.form.advanced_settings
       back_to_playlist: Back to Playlist
       back_to_plugin: plugin_settings.form.back_to_plugin
@@ -957,15 +860,7 @@ raw:
       health_notifications_hint: plugin_settings.form.health_notifications_hint
       health_notifications_checkbox: plugin_settings.form.health_notifications_checkbox
       learn_more: plugin_settings.form.learn_more
-      learn_more_fork: plugin_settings.form.learn_more_fork
-      learn_more_fork_original: plugin_settings.form.learn_more_fork_original
-      learn_more_native_long: plugin_settings.form.learn_more_native_long
-      learn_more_native_short: plugin_settings.form.learn_more_native_short
       learn_more_recipe_author: plugin_settings.form.learn_more_recipe_author
-      learn_more_recipe_long: plugin_settings.form.learn_more_recipe_long
-      learn_more_recipe_short: plugin_settings.form.learn_more_recipe_short
-      learn_more_third_party_long: plugin_settings.form.learn_more_third_party_long
-      learn_more_third_party_short: plugin_settings.form.learn_more_third_party_short
       linked_account: plugin_settings.form.linked_account
       linked_account_success: plugin_settings.form.linked_account_success
       link_oauth: plugin_settings.form.link_oauth
@@ -987,7 +882,6 @@ raw:
       recipe_cta_body_published: plugin_settings.form.recipe_cta_body_published
       recipe_cta_body_in_review: plugin_settings.form.recipe_cta_body_in_review
       recipe_cta_body_not_published: plugin_settings.form.recipe_cta_body_not_published
-      recipe_cta_confirm: plugin_settings.form.recipe_cta_confirm
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: plugin_settings.form.recipe_visibility_title
       recipe_visibility_edit_title: plugin_settings.form.recipe_visibility_edit_title
@@ -998,8 +892,6 @@ raw:
       recipe_visibility_unlisted: plugin_settings.form.recipe_visibility_unlisted
       recipe_visibility_unlisted_hint: plugin_settings.form.recipe_visibility_unlisted_hint
       refresh_rate: plugin_settings.form.refresh_rate
-      refresh_rate_hint: plugin_settings.form.refresh_rate_hint
-      refresh_rate_jit_hint: plugin_settings.form.refresh_rate_jit_hint
       refresh_rate_not_configurable: plugin_settings.form.refresh_rate_not_configurable
       refreshed: plugin_settings.form.refreshed
       remove_plugin: plugin_settings.form.remove_plugin
@@ -1056,10 +948,8 @@ raw:
       search_placeholder: recipes.index.search_placeholder
   schedules:
     form:
-      add: schedules.form.add
       append: schedules.form.append
       no_schedule: schedules.form.no_schedule
-      some_schedule: schedules.form.some_schedule
       to: schedules.form.to
       copy_prompt: schedules.form.copy_prompt
       no_days_error: schedules.form.no_days_error
@@ -1085,11 +975,6 @@ raw:
       day_events:
         one: activity_logs.index.day_events.one
         other: activity_logs.index.day_events.other
-      time: activity_logs.index.time
-      event: activity_logs.index.event
-      screen: activity_logs.index.screen
-      device: activity_logs.index.device
-      detail: activity_logs.index.detail
     link:
       title: activity_logs.link.title
       device_hint: activity_logs.link.device_hint
@@ -1616,7 +1501,6 @@ raw:
       add_to_playlist: mashups.mashup.add_to_playlist
     update:
       success: mashups.update.success
-      error: mashups.update.error
     render_section_error:
       error: mashups.render_section_error.error
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -12,7 +12,6 @@ ro:
   back: Înapoi
   back_to_all_blog_posts: Înapoi la toate postările
   blog: Blog
-  brand: Brand
   buy_now: Cumpără acum
   cancel: Anulează
   change_password: Schimbă parola
@@ -26,15 +25,11 @@ ro:
   copy: Copiază
   copied_to_clipboard: Copiat!
   copy_to_clipboard: Copiază în clipboard
-  created: Creat
   create_an_account: Creează un cont
   current_device: Dispozitivul curent
-  days: zile
   delete: Șterge
   developers: Dezvoltatori
   developer_edition_required: Ediția pentru dezvoltatori este necesară pentru a activa această funcție.
-  device_id: ID dispozitiv
-  device: Dispozitiv
   discard: Discard
   edit: Editează
   email_address: Adresă de email
@@ -45,7 +40,6 @@ ro:
   forgot_password_title: Hai să rezolvăm asta
   friendly_id: ID prietenos
   get_started: Să începem!
-  hidden: ascuns
   identify: Identifică
   import: Importă
   import_new: Importă nou
@@ -59,32 +53,23 @@ ro:
   log_out: Deconectare
   manage: Gestionează
   minimum_characters: caractere minimum
-  mins: min
-  my_playlist: Lista mea
   new_password: Parolă nouă
   password: Parolă
-  please_wait: Vă rugăm așteptați...
   plugin_not_found: Plugin negăsit
   preview: Previzualizare
-  privacy: Confidențialitate
-  refresh_rate: Rată de reîmprospătare
   refresh_rates_hint: Află cum funcționează ratele de reîmprospătare __aici__.
   reset_password: Resetează parola mea
   reset_to_defaults: Resetează la valori implicite
   required: Obligatoriu
   save: Salvează
-  shown: afișat
   section: Secțiune
   settings: Setări
   sign_in: Autentifică-te
   sign_up: Înregistrează-te
   something_went_wrong: Ceva a mers greșit
   status: Stare
-  subscribe: Abonează-te
   help_center: Asistență
-  terms: Termeni
   unsaved_changes: You have unsaved changes
-  update: Actualizează
   view: Vizualizează
   collaboration_request: Vrei să colaborezi?
   collaboration_request_hint: Parteneriate, vânzări de grup, proiecte speciale, la alegerea ta.
@@ -153,9 +138,6 @@ ro:
       refer_and_earn_hint: Oferă cadoul TRMNL cu un cupon personalizat. Câștigă per utilizare, plătit lunar.
       refer_and_earn_redemptions: Utilizări
       refer_and_earn_request_code: Solicită un cod
-      device_invoice: Factură dispozitiv
-      device_invoice_label: Descarcă documente comerciale pentru contabilul tău sau colecția ta (ciudată) de PDF-uri.
-      device_invoice_hint: Găsește-l pe pagina de urmărire a coletului sau în emailul de notificare al expedierii.
       email_address_hint: Folosit pentru autentificarea în TRMNL și primirea mesajelor de sistem.
       first_name_hint: Folosim numele tău pentru a face interfața TRMNL mai confortabilă.
       last_name_hint: Folosim numele tău pentru a face interfața TRMNL mai confortabilă.
@@ -234,13 +216,7 @@ ro:
   dashboard:
     index:
       title: Panou de control
-      last_7_days: Ultimele 7 zile
-      last_30_days: Ultimele 30 de zile
-      last_90_days: Ultimele 90 de zile
-      today: Astăzi
-      yesterday: Ieri
     health:
-      bad: Plugin-urile întâmpină probleme
       good: Plugin-urile funcționează corect
       next_steps: Te vom anunța dacă ceva se schimbă
     news:
@@ -257,14 +233,9 @@ ro:
       new_and_popular: Noi și populare
     shop:
       title: Magazin
-      need_another: Mai ai nevoie de un TRMNL?
     time_saved:
       title: Timp economisit
-      cta: Citește despre
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Bună dimineața
@@ -277,7 +248,6 @@ ro:
     edit:
       accepts_beta_firmware: Firmware lansare anticipată
       accepts_beta_firmware_hint: Activează pentru a primi cele mai recente îmbunătățiri de firmware înaintea altor utilizatori.
-      back_to_devices: Înapoi la dispozitive
       battery_and_sleep: Baterie și repaus
       battery_consumption: Consum baterie
       battery_consumption_hint: Economisește energie și bucură-te de o durată de viață mai lungă a bateriei activând Modul repaus.
@@ -299,7 +269,6 @@ ro:
       device_model_switch_warning: Aceasta este o operațiune periculoasă, află mai mult __aici__
       device_info: Informații dispozitiv
       current_firmware: Firmware curent
-      last_ping: Ultimul ping
       unknown: Necunoscut
       never: Niciodată
       display_calibration: Calibrare afișaj
@@ -345,7 +314,6 @@ ro:
       ota_byod_not_supported: OTA nu este suportat pentru dispozitivele BYOD. Instalează o versiune compatibilă direct de pe trmnl.com/flash
       maximum_compatibility: Activează compatibilitate maximă
       maximum_compatibility_hint: Rezolvă problemele de afișare cauzate de anumite chipuri de driver ePaper. Dezactivează reîmprospătarea rapidă. Necesită firmware 1.6.0+.
-      color_and_rotation: Culoare și rotație
       image_rotation: Image Rotation
       screen_rotation: Rotație ecran
       screen_rotation_not_supported: Rotația ecranului nu este în prezent suportată pe dispozitivul tău.
@@ -367,9 +335,7 @@ ro:
       tidbyt_credentials: Credențiale Tidbyt
       tidbyt_credentials_hint: Introdu credențialele API ale dispozitivului tău Tidbyt din aplicația Tidbyt sub Setări → Dezvoltator → Obține cheie API.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Credențialele API Tidbyt sunt invalide. Verifică și încearcă din nou.
       tidbyt_device_id: ID dispozitiv
-      tidbyt_device_api_key: Cheie API
       unlink: Dezasociază
       unlink_confirm: Ești sigur? Continuă doar dacă dai acest dispozitiv altcuiva sau treci la BYOS. Dezasocierea șterge toate setările plugin-urilor și elementele din listă. Dacă depanezi, contactează asistența la help.trmnl.com.
       unlink_device: Dezasociază dispozitivul
@@ -377,7 +343,6 @@ ro:
       unlink_device_learn_more: Urmează ghidul complet __aici__.
       visibility: Vizibilitate
       visibility_hint: Fă dispozitivul tău TRMNL oglindicibil schimbând setările de mai jos.
-      your_device: TRMNL-ul tău
       upgrade_og:
         title: Upgrade la afișaj 2-bit disponibil
         sub_title: Dispozitivul tău poate fi actualizat pentru a suporta un afișaj îmbunătățit în nuanțe de gri cu 4 niveluri de culoare în loc de 2.
@@ -414,9 +379,6 @@ ro:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ ro:
     index:
       title: Dispozitive
       tagline: Dispozitivele tale TRMNL
-      add_device_modal_title: Adaugă un dispozitiv nou
       add_first_device: Începe prin a adăuga primul tău dispozitiv!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -516,9 +477,6 @@ ro:
     dissociate:
       error: Eroare la deconectarea dispozitivului
       success: Dispozitiv dezasociat cu succes
-    external_credentials:
-      error: Credențiale dispozitiv invalide
-      success: Credențiale dispozitiv actualizate cu succes
     identify:
       error: Eroare la actualizarea dispozitivului
       success: Identificare dispozitiv solicitată
@@ -557,16 +515,11 @@ ro:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Prea multe încercări, așteptați și încercați din nou
-    invoice_not_found: Factură negăsită
   logs:
     index:
       title: Jurnale
       all: Toate
-      bulk_destroy: Ștergere în masă
       dump: Message
-      id: ID
       private_plugins: Plugin-uri private
       source: Sursă
       time: Time (UTC)
@@ -601,9 +554,6 @@ ro:
       live_preview: Previzualizare live
       no_changes_to_save: Nicio modificare de salvat
       pop_out_preview: Deschide previzualizarea
-      quickstart_examples: Exemple de pornire rapidă
-      quickstart_example_applied: Aplicat!
-      quickstart_use_this_example: Folosește acest exemplu
       revert: Revertează
       revert_confirm: Ești sigur că vrei să revertezi? Toate modificările nesalvate vor fi pierdute.
       save_changes: Salvează modificările (⌘﹢S)
@@ -667,9 +617,6 @@ ro:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA dezactivat
@@ -695,21 +642,12 @@ ro:
   playlist_items:
     index:
       title: Listă de redare
-      tagline: Alege ce se afișează pe
-      add_a_group: Adaugă un grup
-      add_a_plugin: Adaugă un plugin
       add_first_device_cta: Începe prin __adăugarea__ primului tău dispozitiv TRMNL!
       add_to_playlist: Adaugă în listă
-      create_first_playlist_cta: Creează lista ta după __conectarea__ primului plugin!
       custom: Personalizat
       device_default: Implicit dispozitiv
-      display_period_from: Afișează de la
-      display_period_to: până la
       display_period_validation: Ora de începere trebuie să fie înainte de ora de încheiere. Creează un alt grup pentru orele de noapte.
-      every: La fiecare
       never_skip: Nu sări niciodată ecranele
-      smart_playlist: Listă inteligentă
-      smart_playlist_hint: Sare automat ecranele al căror conținut nu s-a schimbat de mult timp.
       skip_after:
         one: Sare ecranele vechi după 1 zi
         other: Sare ecranele vechi după %{count} zile
@@ -747,9 +685,6 @@ ro:
       duplicate: Duplică
       duplicate_confirm: Aceasta va crea o copie a acestui element și o va adăuga la sfârșitul listei tale. Continui?
       presentation: Presentation
-      color_palette: Paletă de culori
-      device_default: Implicit dispozitiv (%{name})
-      palette_unavailable: Disponibil doar pentru dispozitive cu mai multe palete de culori
       refresh_rate_disabled:
         default: Rata de reîmprospătare a acestui plugin nu poate fi configurată.
         external: Acest plugin preia date din mers, deci setările ratei de reîmprospătare nu se aplică.
@@ -766,7 +701,6 @@ ro:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Actualizarea listei de redare a eșuat
       success: Listă de redare actualizată
     destroy:
       error: Eroare la eliminarea elementului din listă
@@ -779,8 +713,6 @@ ro:
       success: Ordinea listei actualizată
     set_preferences:
       success: Preferința listei inteligente actualizată
-    update:
-      success: Ordinea listei actualizată
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -811,23 +743,10 @@ ro:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -835,8 +754,6 @@ ro:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -847,9 +764,6 @@ ro:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -865,7 +779,6 @@ ro:
     index:
       title: Plugin-uri
       tagline: Ce vei pune pe TRMNL-ul tău?
-      available: Disponibile
       connected: Conectate
       supported_by_this_device: Supported by this device
       recipes: Rețetare
@@ -877,7 +790,6 @@ ro:
         title: Plugin-urile mele
         tagline: Dezvoltă plugin-uri pentru piața publică
       card:
-        connections: conexiuni
         install: Instalează
         review_are_you_sure: Ești sigur? Echipa TRMNL îl va testa și îți va trimite întrebări prin email.
         submit_for_review: Trimite pentru revizuire
@@ -907,16 +819,11 @@ ro:
     edit:
       title: Editează plugin
       tagline: Actualizează detaliile plugin-ului tău.
-      name: Nume
-      description: Descriere
   plugin_recipes:
     connected: Rețetar conectat
     connections:
       one: Conexiune
       other: Conexiuni
-    forks:
-      one: Fork
-      other: Fork-uri
     forked: Recipe forked
     new:
       error: Rețetar negăsit
@@ -924,18 +831,14 @@ ro:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Activ
     copy_are_you_sure: Ești sigur că vrei să copiezi această setare?
     delete_are_you_sure: Ești sigur că vrei să ștergi această setare?
     delete: Aceasta va elimina complet setările plugin-ului. Pentru a ascunde pur și simplu acest plugin de pe dispozitivul tău, șterge-l din lista de redare.
-    inactive: Inactiv
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: Nu au fost găsite setări de plugin.
     not_supported: Nesuportat pe dispozitivul curent
     refreshing_now_please_wait: Se reîmprospătează acum, reîncarcă această pagină în câteva secunde.
     reset_credentials: Contul %{plugin_name} resetat cu succes
     form:
-      active_hint: Afișează sau ascunde această instanță de plugin pe dispozitivul tău
       advanced_settings: Setări avansate
       back_to_playlist: Înapoi la lista de redare
       back_to_plugin: Înapoi la %{plugin}
@@ -957,15 +860,7 @@ ro:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Află despre acest plugin în baza noastră de cunoștințe
-      learn_more_fork: Acest plugin a fost bifurcat dintr-un Rețetar.
-      learn_more_fork_original: Vezi originalul
-      learn_more_native_long: Acest plugin este nativ și menținut de TRMNL.
-      learn_more_native_short: Acest plugin este menținut de TRMNL.
       learn_more_recipe_author: Ai nevoie de ajutor? Contactează %{recipe_author} pe Discord.
-      learn_more_recipe_long: Acest plugin este un Rețetar al comunității și nu este menținut de TRMNL.
-      learn_more_recipe_short: 'Notă: acest plugin este un Rețetar.'
-      learn_more_third_party_long: Acest plugin aparține unei terțe părți și nu este menținut de TRMNL.
-      learn_more_third_party_short: 'Notă: acest plugin aparține unei terțe părți.'
       linked_account: Cont asociat
       linked_account_success: Asociat cu succes cu %{plugin_name}
       link_oauth: Asociază contul
@@ -987,7 +882,6 @@ ro:
       recipe_cta_body_published: Modificările vor fi reflectate în instalările existente și viitoare/bifurcări.
       recipe_cta_body_in_review: Acest plugin a fost trimis echipei noastre. Stai pe fază.
       recipe_cta_body_not_published: Trimite acest plugin pentru ca alții să îl instaleze. __Află mai mult__.
-      recipe_cta_confirm: Ești sigur? Echipa noastră va analiza și îți va răspunde în câteva zile. Poți continua să faci modificări.
       recipe_mirrored: Acest ecran este oglindit din rețetar.
       recipe_visibility_title: Cum ai dori să publici?
       recipe_visibility_edit_title: Editează trimiterea
@@ -998,8 +892,6 @@ ro:
       recipe_visibility_unlisted: Nelistat
       recipe_visibility_unlisted_hint: Oricine cu link-ul poate instala.
       refresh_rate: Rată de reîmprospătare
-      refresh_rate_hint: Definește cât de frecvent preia date această instanță de plugin
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Sincronizează %{refresh_rate} (neconfigurabil)
       refreshed: Reîmprospătat
       remove_plugin: Elimină plugin-ul
@@ -1056,10 +948,8 @@ ro:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Adaugă un program personalizat
       append: Și în timpul…
       no_schedule: Acest ecran va fi afișat în orice moment.
-      some_schedule: Afișează acest ecran doar în timpul…
       to: până la
       copy_prompt: Copiază programul de la…
       no_days_error: Please select at least one day.
@@ -1085,11 +975,6 @@ ro:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1618,7 +1503,6 @@ ro:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -12,7 +12,6 @@ ru:
   back: Назад
   back_to_all_blog_posts: Назад ко всем записям в блоге
   blog: Блог
-  brand: Brand
   buy_now: Купить сейчас
   cancel: Отмена
   change_password: Изменить пароль
@@ -26,15 +25,11 @@ ru:
   copy: Копировать
   copied_to_clipboard: Скопировано!
   copy_to_clipboard: Копировать в буфер обмена
-  created: Создано
   create_an_account: Создать учётную запись
   current_device: Текущее устройство
-  days: дней
   delete: Удалить
   developers: Developers
   developer_edition_required: Для включения этой функции требуется версия для разработчиков.
-  device_id: ID устройства
-  device: Устройство
   discard: Discard
   edit: Редактировать
   email_address: Адрес электронной почты
@@ -45,7 +40,6 @@ ru:
   forgot_password_title: И вот опять
   friendly_id: Дружелюбный ID
   get_started: Давайте начнём!
-  hidden: hidden
   identify: Идентифицировать
   import: Импорт
   import_new: Импортировать новый
@@ -59,32 +53,23 @@ ru:
   log_out: Выйти
   manage: Управлять
   minimum_characters: минимум символов
-  mins: мин
-  my_playlist: Мой плейлист
   new_password: Новый пароль
   password: Пароль
-  please_wait: Пожалуйста, подождите…
   plugin_not_found: Плагин не найден
   preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
   refresh_rates_hint: Узнайте, как работает частота обновления __здесь__.
   reset_password: Сбросить мой пароль
   reset_to_defaults: Reset to defaults
   required: Required
   save: Сохранить
-  shown: shown
   section: Раздел
   settings: Настройки
   sign_in: Войти
   sign_up: Зарегистрироваться
   something_went_wrong: Что-то пошло не так
   status: Status
-  subscribe: Подписаться
   help_center: Поддержка
-  terms: Terms
   unsaved_changes: You have unsaved changes
-  update: Обновить
   view: Просмотр
   collaboration_request: Wanna collaborate?
   collaboration_request_hint: Partnerships, group sales, special projects, your call.
@@ -175,9 +160,6 @@ ru:
       refer_and_earn_hint: Подарите TRMNL с помощью персонального купона. Зарабатывайте за каждое использование, выплаты ежемесячно.
       refer_and_earn_redemptions: Погашения
       refer_and_earn_request_code: Запросить код
-      device_invoice: Счёт-фактура на устройство
-      device_invoice_label: Загрузите коммерческие документы для своего бухгалтера или (странной) коллекции PDF.
-      device_invoice_hint: Найдите это на странице отслеживания посылки или в электронном письме с уведомлением об отправке.
       email_address_hint: Используется для входа в TRMNL и получения системных сообщений.
       first_name_hint: Мы используем ваше имя, чтобы сделать интерфейс TRMNL более удобным.
       last_name_hint: Мы используем вашу фамилию, чтобы сделать интерфейс TRMNL более удобным.
@@ -256,13 +238,7 @@ ru:
   dashboard:
     index:
       title: Панель управления
-      last_7_days: Последние 7 дней
-      last_30_days: Последние 30 дней
-      last_90_days: Последние 90 дней
-      today: Сегодня
-      yesterday: Вчера
     health:
-      bad: Плагины испытывают проблемы
       good: Плагины в порядке
       next_steps: Мы сообщим вам, если что-то изменится
     news:
@@ -279,14 +255,9 @@ ru:
       new_and_popular: Новые и популярные
     shop:
       title: Магазин
-      need_another: Нужен ещё один TRMNL?
     time_saved:
       title: Сэкономленное время
-      cta: Читать о
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Доброе утро
@@ -299,7 +270,6 @@ ru:
     edit:
       accepts_beta_firmware: Ранний доступ к прошивке
       accepts_beta_firmware_hint: Включите, чтобы получать последние улучшения прошивки устройства раньше других пользователей.
-      back_to_devices: Назад к устройствам
       battery_and_sleep: Battery & Sleep
       battery_consumption: Потребление батареи
       battery_consumption_hint: Сэкономьте энергию и продлите время работы батареи, включив спящий режим.
@@ -321,7 +291,6 @@ ru:
       device_model_switch_warning: Это опасная операция, узнайте больше __здесь__
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -367,7 +336,6 @@ ru:
       ota_byod_not_supported: OTA не поддерживается для устройств BYOD. Прошейте совместимую версию прямо с trmnl.com/flash
       maximum_compatibility: Включить максимальную совместимость
       maximum_compatibility_hint: Устраняет проблемы с отображением, вызванные некоторыми чипами драйверов ePaper. Отключает быстрое обновление. Требуется прошивка 1.6.0+.
-      color_and_rotation: Color & Rotation
       image_rotation: Image Rotation
       screen_rotation: Screen Rotation
       screen_rotation_not_supported: Вращение экрана в настоящее время не поддерживается на вашем устройстве.
@@ -389,9 +357,7 @@ ru:
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
       unlink: Отвязать
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Отвязать устройство
@@ -399,7 +365,6 @@ ru:
       unlink_device_learn_more: Следуйте полному руководству __здесь__.
       visibility: Видимость
       visibility_hint: Сделайте ваше устройство TRMNL зеркалируемым, изменив настройки ниже.
-      your_device: Ваш TRMNL
       upgrade_og:
         title: Доступно обновление для 2-битного дисплея
         sub_title: Ваше устройство можно обновить для поддержки улучшенного отображения в оттенках серого с 4 уровнями цвета вместо 2.
@@ -436,9 +401,6 @@ ru:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -512,7 +474,6 @@ ru:
     index:
       title: Устройства
       tagline: Ваши устройства TRMNL
-      add_device_modal_title: Добавить новое устройство
       add_first_device: Начните с добавления вашего первого устройства!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -538,9 +499,6 @@ ru:
     dissociate:
       error: Ошибка отключения устройства
       success: Устройство успешно отвязано
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: Ошибка обновления устройства
       success: Запрошена идентификация устройства
@@ -579,16 +537,11 @@ ru:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Слишком много попыток, подождите и попробуйте ещё раз
-    invoice_not_found: Счёт-фактура не найдена
   logs:
     index:
       title: Журналы
       all: Все
-      bulk_destroy: Массовое удаление
       dump: Message
-      id: ID
       private_plugins: Приватные плагины
       source: Источник
       time: Time (UTC)
@@ -623,9 +576,6 @@ ru:
       live_preview: Живой предпросмотр
       no_changes_to_save: Нет изменений для сохранения
       pop_out_preview: Вынести предпросмотр
-      quickstart_examples: Примеры для быстрого старта
-      quickstart_example_applied: Применено!
-      quickstart_use_this_example: Использовать этот пример
       revert: Отменить
       revert_confirm: Вы уверены, что хотите отменить? Все несохраненные изменения будут потеряны.
       save_changes: Сохранить изменения (⌘﹢S)
@@ -689,9 +639,6 @@ ru:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA отключена
@@ -717,21 +664,12 @@ ru:
   playlist_items:
     index:
       title: Плейлист
-      tagline: Выберите, что показывать на
-      add_a_group: Добавить группу
-      add_a_plugin: Добавить плагин
       add_first_device_cta: Начните с __добавления__ вашего первого устройства TRMNL!
       add_to_playlist: Добавить в плейлист
-      create_first_playlist_cta: Создайте свой плейлист после __подключения__ вашего первого плагина!
       custom: Пользовательский
       device_default: По умолчанию для устройства
-      display_period_from: Показывать с
-      display_period_to: по
       display_period_validation: Время начала должно быть раньше времени окончания. Создайте другую группу, чтобы охватить ночные часы.
-      every: Каждый
       never_skip: Никогда не пропускать экраны
-      smart_playlist: Умный плейлист
-      smart_playlist_hint: Автоматически пропускать экраны, содержимое которых давно не менялось.
       skip_after:
         one: Пропускать устаревшие экраны через 1 день
         other: Пропускать устаревшие экраны через %{count} дней
@@ -769,9 +707,6 @@ ru:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -788,7 +723,6 @@ ru:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Не удалось обновить плейлист
       success: Плейлист обновлен
     destroy:
       error: Ошибка удаления элемента из плейлиста
@@ -801,8 +735,6 @@ ru:
       success: Порядок плейлиста обновлен
     set_preferences:
       success: Настройки умного плейлиста обновлены
-    update:
-      success: Playlist order updated
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -833,23 +765,10 @@ ru:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -857,8 +776,6 @@ ru:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -869,9 +786,6 @@ ru:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -887,7 +801,6 @@ ru:
     index:
       title: Плагины
       tagline: Что вы разместите на своем TRMNL?
-      available: Доступно
       connected: Подключено
       supported_by_this_device: Supported by this device
       recipes: Рецепты
@@ -899,7 +812,6 @@ ru:
         title: Мои плагины
         tagline: Разрабатывайте плагины для публичного маркетплейса
       card:
-        connections: подключений
         install: Установить
         review_are_you_sure: Вы уверены? Команда TRMNL протестирует его и отправит вам любые вопросы по электронной почте.
         submit_for_review: Отправить на рассмотрение
@@ -929,16 +841,11 @@ ru:
     edit:
       title: Редактировать плагин
       tagline: Обновите данные вашего плагина.
-      name: Название
-      description: Описание
   plugin_recipes:
     connected: Рецепт подключен
     connections:
       one: Подключение
       other: Подключения
-    forks:
-      one: Форк
-      other: Форки
     forked: Recipe forked
     new:
       error: Рецепт не найден
@@ -946,18 +853,14 @@ ru:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Активен
     copy_are_you_sure: Вы уверены, что хотите скопировать эту настройку?
     delete_are_you_sure: Вы уверены, что хотите удалить эту настройку?
     delete: Это полностью удалит настройки плагина. Чтобы просто скрыть этот плагин на вашем устройстве, удалите его из плейлиста.
-    inactive: Неактивен
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: Настройки плагина не найдены.
     not_supported: Не поддерживается на текущем устройстве
     refreshing_now_please_wait: Обновление, перезагрузите страницу через несколько секунд.
     reset_credentials: Учётная запись "%{plugin_name}" успешно сброшена
     form:
-      active_hint: Показать или скрыть этот экземпляр плагина на вашем устройстве
       advanced_settings: Расширенные настройки
       back_to_playlist: Back to Playlist
       back_to_plugin: Назад к %{plugin}
@@ -979,15 +882,7 @@ ru:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Узнайте больше об этом плагине в нашей базе знаний
-      learn_more_fork: Этот плагин был форкнут из рецепта.
-      learn_more_fork_original: Посмотреть оригинал
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
       learn_more_recipe_author: Нужна помощь? Свяжитесь с %{recipe_author} в Discord.
-      learn_more_recipe_long: Этот плагин является рецептом сообщества и не поддерживается TRMNL.
-      learn_more_recipe_short: 'Примечание: этот плагин является рецептом.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       linked_account: Связанная учётная запись
       linked_account_success: Успешно связано с %{plugin_name}
       link_oauth: Связать учётную запись
@@ -1009,7 +904,6 @@ ru:
       recipe_cta_body_published: Изменения будут отражены на существующих установках и будущих установках/форках.
       recipe_cta_body_in_review: Этот плагин был отправлен нашей команде. Ожидайте.
       recipe_cta_body_not_published: Отправьте этот плагин, чтобы другие могли его установить. __Узнать больше__.
-      recipe_cta_confirm: Вы уверены? Наша команда рассмотрит и свяжется с вами в течение нескольких дней. Вы можете продолжать вносить изменения.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: Как бы вы хотели опубликовать?
       recipe_visibility_edit_title: Редактировать отправку
@@ -1020,8 +914,6 @@ ru:
       recipe_visibility_unlisted: Не внесен в список
       recipe_visibility_unlisted_hint: Любой, у кого есть ссылка, может установить.
       refresh_rate: Частота обновления
-      refresh_rate_hint: Определите, как часто этот экземпляр плагина будет запрашивать свежие данные
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Синхронизируется %{refresh_rate} (не настраивается)
       refreshed: Обновлено
       remove_plugin: Удалить плагин
@@ -1078,10 +970,8 @@ ru:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Добавить пользовательское расписание
       append: И в это время…
       no_schedule: Этот экран будет отображаться постоянно.
-      some_schedule: Показывать этот экран только в это время…
       to: по
       copy_prompt: Копировать расписание из…
       no_days_error: Please select at least one day.
@@ -1107,11 +997,6 @@ ru:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1640,7 +1525,6 @@ ru:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -12,7 +12,6 @@ sk:
   back: Back
   back_to_all_blog_posts: Back to all posts
   blog: Blog
-  brand: Brand
   buy_now: Buy Now
   cancel: Cancel
   change_password: Change Password
@@ -26,15 +25,11 @@ sk:
   copy: Copy
   copied_to_clipboard: Copied!
   copy_to_clipboard: Copy to clipboard
-  created: Created
   create_an_account: Create an account
   current_device: Current device
-  days: days
   delete: Delete
   developers: Developers
   developer_edition_required: Developer edition is required to enable this feature.
-  device_id: Device ID
-  device: Device
   discard: Discard
   edit: Edit
   email_address: Email address
@@ -45,7 +40,6 @@ sk:
   forgot_password_title: Here we go again
   friendly_id: Friendly ID
   get_started: Let's get you started!
-  hidden: hidden
   identify: Identify
   import: Import
   import_new: Import new
@@ -59,32 +53,23 @@ sk:
   log_out: Log out
   manage: Manage
   minimum_characters: characters minimum
-  mins: mins
-  my_playlist: My Playlist
   new_password: New password
   password: Password
-  please_wait: Please Wait...
   plugin_not_found: Plugin not found
   preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
   refresh_rates_hint: Learn how refresh rates work __here__.
   reset_password: Reset my password
   reset_to_defaults: Reset to defaults
   required: Required
   save: Save
-  shown: shown
   section: Section
   settings: Settings
   sign_in: Sign in
   sign_up: Sign up
   something_went_wrong: Something went wrong
   status: Status
-  subscribe: Subscribe
   help_center: Support
-  terms: Terms
   unsaved_changes: You have unsaved changes
-  update: Update
   view: View
   collaboration_request: Wanna collaborate?
   collaboration_request_hint: Partnerships, group sales, special projects, your call.
@@ -164,9 +149,6 @@ sk:
       refer_and_earn_hint: Give the gift of TRMNL with a personalized coupon. Earn per use, paid monthly.
       refer_and_earn_redemptions: Redemptions
       refer_and_earn_request_code: Request a Code
-      device_invoice: Device Invoice
-      device_invoice_label: Download commercial documents for your accountant or (weird) PDF collection.
-      device_invoice_hint: Find this on your package tracking page or shipment notification email.
       email_address_hint: Used to sign into TRMNL and receive system messages.
       first_name_hint: We use your name to make the TRMNL interface more comfortable.
       last_name_hint: We use your name to make the TRMNL interface more comfortable.
@@ -245,13 +227,7 @@ sk:
   dashboard:
     index:
       title: Dashboard
-      last_7_days: Last 7 days
-      last_30_days: Last 30 days
-      last_90_days: Last 90 days
-      today: Today
-      yesterday: Yesterday
     health:
-      bad: Plugins are experiencing issues
       good: Plugins are healthy
       next_steps: We will inform you if anything changes
     news:
@@ -268,14 +244,9 @@ sk:
       new_and_popular: New and Popular
     shop:
       title: Shop
-      need_another: Need another TRMNL?
     time_saved:
       title: Time saved
-      cta: Read about
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Good morning
@@ -288,7 +259,6 @@ sk:
     edit:
       accepts_beta_firmware: Firmware Early Release
       accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
-      back_to_devices: Back to Devices
       battery_and_sleep: Battery & Sleep
       battery_consumption: Battery Consumption
       battery_consumption_hint: Save power and enjoy a longer battery life by enabling Sleep Mode.
@@ -310,7 +280,6 @@ sk:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -356,7 +325,6 @@ sk:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
-      color_and_rotation: Farba a otáčanie
       image_rotation: Image Rotation
       screen_rotation: Otáčanie obrazovky
       screen_rotation_not_supported: Otáčanie obrazovky nie je momentálne podporované na vašom zariadení.
@@ -378,9 +346,7 @@ sk:
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
       unlink: Unlink
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Unlink Device
@@ -388,7 +354,6 @@ sk:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
-      your_device: Your TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -425,9 +390,6 @@ sk:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -501,7 +463,6 @@ sk:
     index:
       title: Devices
       tagline: Your TRMNL devices
-      add_device_modal_title: Add a new device
       add_first_device: Start by adding your first device!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -527,9 +488,6 @@ sk:
     dissociate:
       error: Error disconnecting device
       success: Device successfully unlinked
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: Error updating device
       success: Device identification requested
@@ -568,16 +526,11 @@ sk:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Too many attempts, please wait and try again
-    invoice_not_found: Invoice not found
   logs:
     index:
       title: Logs
       all: All
-      bulk_destroy: Bulk Destroy
       dump: Message
-      id: ID
       private_plugins: Private plugins
       source: Source
       time: Time (UTC)
@@ -612,9 +565,6 @@ sk:
       live_preview: Live Preview
       no_changes_to_save: No changes to save
       pop_out_preview: Pop Out Preview
-      quickstart_examples: Quick-start Examples
-      quickstart_example_applied: Applied!
-      quickstart_use_this_example: Use this example
       revert: Revert
       revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
       save_changes: Save Changes (⌘﹢S)
@@ -678,9 +628,6 @@ sk:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA Disabled
@@ -706,21 +653,12 @@ sk:
   playlist_items:
     index:
       title: Playlist
-      tagline: Choose what's shown on
-      add_a_group: Add a Group
-      add_a_plugin: Add a Plugin
       add_first_device_cta: Start by __adding__ your first TRMNL device!
       add_to_playlist: Add to Playlist
-      create_first_playlist_cta: Create your playlist after __connecting__ your first plugin!
       custom: Custom
       device_default: Device default
-      display_period_from: Display from
-      display_period_to: to
       display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
       never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
       skip_after:
         one: Skip stale screens after 1 day
         other: Skip stale screens after %{count} days
@@ -758,9 +696,6 @@ sk:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -777,7 +712,6 @@ sk:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Failed to update playlist
       success: Playlist updated
     destroy:
       error: Error removing item from playlist
@@ -790,8 +724,6 @@ sk:
       success: Playlist order updated
     set_preferences:
       success: Smart playlist preference updated
-    update:
-      success: Playlist order updated
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -822,23 +754,10 @@ sk:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -846,8 +765,6 @@ sk:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -858,9 +775,6 @@ sk:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -876,7 +790,6 @@ sk:
     index:
       title: Plugins
       tagline: What will you put on your TRMNL?
-      available: Available
       connected: Connected
       supported_by_this_device: Supported by this device
       recipes: Recipes
@@ -888,7 +801,6 @@ sk:
         title: My Plugins
         tagline: Develop Plugins for the public marketplace
       card:
-        connections: connections
         install: Install
         review_are_you_sure: Are you sure? The TRMNL team will test it and email you any questions.
         submit_for_review: Submit for Review
@@ -918,16 +830,11 @@ sk:
     edit:
       title: Edit Plugin
       tagline: Update your plugin details.
-      name: Name
-      description: Description
   plugin_recipes:
     connected: Recipe connected
     connections:
       one: Connection
       other: Connections
-    forks:
-      one: Fork
-      other: Forks
     forked: Recipe forked
     new:
       error: Recipe not found
@@ -935,18 +842,14 @@ sk:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Active
     copy_are_you_sure: Are you sure you want to copy this setting?
     delete_are_you_sure: Are you sure you want to delete this setting?
     delete: This will completely remove the plugin's settings. To simply hide this plugin from your device, delete it from your Playlist instead.
-    inactive: Inactive
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: No plugin settings found.
     not_supported: Not supported on current device
     refreshing_now_please_wait: Refreshing now, reload this page in a few seconds.
     reset_credentials: "%{plugin_name} account reset successfully"
     form:
-      active_hint: Show or hide this plugin instance on your device
       advanced_settings: Advanced Settings
       back_to_playlist: Back to Playlist
       back_to_plugin: Back to %{plugin}
@@ -968,15 +871,7 @@ sk:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Learn about this plugin in our knowledge base
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
       learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       linked_account: Linked Account
       linked_account_success: Successfully linked with %{plugin_name}
       link_oauth: Link Account
@@ -998,7 +893,6 @@ sk:
       recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
       recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
       recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: How would you like to publish?
       recipe_visibility_edit_title: Edit Submission
@@ -1009,8 +903,6 @@ sk:
       recipe_visibility_unlisted: Unlisted
       recipe_visibility_unlisted_hint: Anyone with the link can install.
       refresh_rate: Refresh rate
-      refresh_rate_hint: Define how frequently this plugin instance fetches fresh data
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
       refreshed: Refreshed
       remove_plugin: Remove plugin
@@ -1067,10 +959,8 @@ sk:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Add a custom schedule
       append: And during…
       no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
       to: to
       copy_prompt: Copy schedule from…
       no_days_error: Please select at least one day.
@@ -1096,11 +986,6 @@ sk:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1629,7 +1514,6 @@ sk:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -12,7 +12,6 @@ sv:
   back: Back
   back_to_all_blog_posts: Back to all posts
   blog: Blog
-  brand: Brand
   buy_now: Buy Now
   cancel: Cancel
   change_password: Change Password
@@ -26,15 +25,11 @@ sv:
   copy: Copy
   copied_to_clipboard: Copied!
   copy_to_clipboard: Copy to clipboard
-  created: Created
   create_an_account: Create an account
   current_device: Current device
-  days: days
   delete: Delete
   developers: Developers
   developer_edition_required: Developer edition is required to enable this feature.
-  device_id: Device ID
-  device: Device
   discard: Discard
   edit: Edit
   email_address: Email address
@@ -45,7 +40,6 @@ sv:
   forgot_password_title: Here we go again
   friendly_id: Friendly ID
   get_started: Let's get you started!
-  hidden: hidden
   identify: Identify
   import: Import
   import_new: Import new
@@ -59,32 +53,23 @@ sv:
   log_out: Log out
   manage: Manage
   minimum_characters: characters minimum
-  mins: mins
-  my_playlist: My Playlist
   new_password: New password
   password: Password
-  please_wait: Please Wait...
   plugin_not_found: Plugin not found
   preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
   refresh_rates_hint: Learn how refresh rates work __here__.
   reset_password: Reset my password
   reset_to_defaults: Reset to defaults
   required: Required
   save: Save
-  shown: shown
   section: Section
   settings: Settings
   sign_in: Sign in
   sign_up: Sign up
   something_went_wrong: Something went wrong
   status: Status
-  subscribe: Subscribe
   help_center: Support
-  terms: Terms
   unsaved_changes: You have unsaved changes
-  update: Update
   view: View
   collaboration_request: Wanna collaborate?
   collaboration_request_hint: Partnerships, group sales, special projects, your call.
@@ -153,9 +138,6 @@ sv:
       refer_and_earn_hint: Give the gift of TRMNL with a personalized coupon. Earn per use, paid monthly.
       refer_and_earn_redemptions: Redemptions
       refer_and_earn_request_code: Request a Code
-      device_invoice: Device Invoice
-      device_invoice_label: Download commercial documents for your accountant or (weird) PDF collection.
-      device_invoice_hint: Find this on your package tracking page or shipment notification email.
       email_address_hint: Used to sign into TRMNL and receive system messages.
       first_name_hint: We use your name to make the TRMNL interface more comfortable.
       last_name_hint: We use your name to make the TRMNL interface more comfortable.
@@ -234,13 +216,7 @@ sv:
   dashboard:
     index:
       title: Dashboard
-      last_7_days: Last 7 days
-      last_30_days: Last 30 days
-      last_90_days: Last 90 days
-      today: Today
-      yesterday: Yesterday
     health:
-      bad: Plugins are experiencing issues
       good: Plugins are healthy
       next_steps: We will inform you if anything changes
     news:
@@ -257,14 +233,9 @@ sv:
       new_and_popular: New and Popular
     shop:
       title: Shop
-      need_another: Need another TRMNL?
     time_saved:
       title: Time saved
-      cta: Read about
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Good morning
@@ -277,7 +248,6 @@ sv:
     edit:
       accepts_beta_firmware: Firmware Early Release
       accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
-      back_to_devices: Back to Devices
       battery_and_sleep: Battery & Sleep
       battery_consumption: Battery Consumption
       battery_consumption_hint: Save power and enjoy a longer battery life by enabling Sleep Mode.
@@ -299,7 +269,6 @@ sv:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -345,7 +314,6 @@ sv:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
-      color_and_rotation: Färg och rotation
       image_rotation: Image Rotation
       screen_rotation: Skärmrotation
       screen_rotation_not_supported: Skärmrotation stöds för närvarande inte på din enhet.
@@ -367,9 +335,7 @@ sv:
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
       unlink: Unlink
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Unlink Device
@@ -377,7 +343,6 @@ sv:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
-      your_device: Your TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -414,9 +379,6 @@ sv:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ sv:
     index:
       title: Devices
       tagline: Your TRMNL devices
-      add_device_modal_title: Add a new device
       add_first_device: Start by adding your first device!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -516,9 +477,6 @@ sv:
     dissociate:
       error: Error disconnecting device
       success: Device successfully unlinked
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: Error updating device
       success: Device identification requested
@@ -557,16 +515,11 @@ sv:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Too many attempts, please wait and try again
-    invoice_not_found: Invoice not found
   logs:
     index:
       title: Logs
       all: All
-      bulk_destroy: Bulk Destroy
       dump: Message
-      id: ID
       private_plugins: Private plugins
       source: Source
       time: Time (UTC)
@@ -601,9 +554,6 @@ sv:
       live_preview: Live Preview
       no_changes_to_save: No changes to save
       pop_out_preview: Pop Out Preview
-      quickstart_examples: Quick-start Examples
-      quickstart_example_applied: Applied!
-      quickstart_use_this_example: Use this example
       revert: Revert
       revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
       save_changes: Save Changes (⌘﹢S)
@@ -667,9 +617,6 @@ sv:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA Disabled
@@ -695,21 +642,12 @@ sv:
   playlist_items:
     index:
       title: Playlist
-      tagline: Choose what's shown on
-      add_a_group: Add a Group
-      add_a_plugin: Add a Plugin
       add_first_device_cta: Start by __adding__ your first TRMNL device!
       add_to_playlist: Add to Playlist
-      create_first_playlist_cta: Create your playlist after __connecting__ your first plugin!
       custom: Custom
       device_default: Device default
-      display_period_from: Display from
-      display_period_to: to
       display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
       never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
       skip_after:
         one: Skip stale screens after 1 day
         other: Skip stale screens after %{count} days
@@ -747,9 +685,6 @@ sv:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -766,7 +701,6 @@ sv:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Failed to update playlist
       success: Playlist updated
     destroy:
       error: Error removing item from playlist
@@ -779,8 +713,6 @@ sv:
       success: Playlist order updated
     set_preferences:
       success: Smart playlist preference updated
-    update:
-      success: Playlist order updated
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -811,23 +743,10 @@ sv:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -835,8 +754,6 @@ sv:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -847,9 +764,6 @@ sv:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -865,7 +779,6 @@ sv:
     index:
       title: Plugins
       tagline: What will you put on your TRMNL?
-      available: Available
       connected: Connected
       supported_by_this_device: Supported by this device
       recipes: Recipes
@@ -877,7 +790,6 @@ sv:
         title: My Plugins
         tagline: Develop Plugins for the public marketplace
       card:
-        connections: connections
         install: Install
         review_are_you_sure: Are you sure? The TRMNL team will test it and email you any questions.
         submit_for_review: Submit for Review
@@ -907,16 +819,11 @@ sv:
     edit:
       title: Edit Plugin
       tagline: Update your plugin details.
-      name: Name
-      description: Description
   plugin_recipes:
     connected: Recipe connected
     connections:
       one: Connection
       other: Connections
-    forks:
-      one: Fork
-      other: Forks
     forked: Recipe forked
     new:
       error: Recipe not found
@@ -924,18 +831,14 @@ sv:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Active
     copy_are_you_sure: Are you sure you want to copy this setting?
     delete_are_you_sure: Are you sure you want to delete this setting?
     delete: This will completely remove the plugin's settings. To simply hide this plugin from your device, delete it from your Playlist instead.
-    inactive: Inactive
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: No plugin settings found.
     not_supported: Not supported on current device
     refreshing_now_please_wait: Refreshing now, reload this page in a few seconds.
     reset_credentials: "%{plugin_name} account reset successfully"
     form:
-      active_hint: Show or hide this plugin instance on your device
       advanced_settings: Advanced Settings
       back_to_playlist: Back to Playlist
       back_to_plugin: Back to %{plugin}
@@ -957,15 +860,7 @@ sv:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Learn about this plugin in our knowledge base
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
       learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       linked_account: Linked Account
       linked_account_success: Successfully linked with %{plugin_name}
       link_oauth: Link Account
@@ -987,7 +882,6 @@ sv:
       recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
       recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
       recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: How would you like to publish?
       recipe_visibility_edit_title: Edit Submission
@@ -998,8 +892,6 @@ sv:
       recipe_visibility_unlisted: Unlisted
       recipe_visibility_unlisted_hint: Anyone with the link can install.
       refresh_rate: Refresh rate
-      refresh_rate_hint: Define how frequently this plugin instance fetches fresh data
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
       refreshed: Refreshed
       remove_plugin: Remove plugin
@@ -1056,10 +948,8 @@ sv:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Add a custom schedule
       append: And during…
       no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
       to: to
       copy_prompt: Copy schedule from…
       no_days_error: Please select at least one day.
@@ -1085,11 +975,6 @@ sv:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1618,7 +1503,6 @@ sv:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -12,7 +12,6 @@ uk:
   back: Назад
   back_to_all_blog_posts: Back to all posts
   blog: Blog
-  brand: Brand
   buy_now: Придбати зараз
   cancel: Скасувати
   change_password: Змінити пароль
@@ -26,15 +25,11 @@ uk:
   copy: Copy
   copied_to_clipboard: Copied!
   copy_to_clipboard: Copy to clipboard
-  created: Created
   create_an_account: Створити акаунт
   current_device: Current device
-  days: днів
   delete: Видалити
   developers: Developers
   developer_edition_required: Developer edition is required to enable this feature.
-  device_id: ID пристрою
-  device: пристрою
   discard: Discard
   edit: Редагувати
   email_address: Адреса електронної пошти
@@ -45,7 +40,6 @@ uk:
   forgot_password_title: Отакої…Гайда знову
   friendly_id: Friendly ID
   get_started: Почнемо!
-  hidden: hidden
   identify: Ідентифікувати
   import: Import
   import_new: Import new
@@ -59,32 +53,23 @@ uk:
   log_out: Вийти
   manage: Manage
   minimum_characters: мінімум символів
-  mins: хв
-  my_playlist: My Playlist
   new_password: Новий пароль
   password: Пароль
-  please_wait: Please Wait...
   plugin_not_found: Plugin not found
   preview: Preview
-  privacy: Privacy
-  refresh_rate: Refresh rate
   refresh_rates_hint: Learn how refresh rates work __here__.
   reset_password: Скинути мій пароль
   reset_to_defaults: Reset to defaults
   required: Required
   save: Зберегти
-  shown: shown
   section: Section
   settings: Settings
   sign_in: Увійти
   sign_up: Реєстрація
   something_went_wrong: Something went wrong
   status: Status
-  subscribe: Subscribe
   help_center: Support
-  terms: Terms
   unsaved_changes: You have unsaved changes
-  update: Оновити
   view: Переглянути
   collaboration_request: Wanna collaborate?
   collaboration_request_hint: Partnerships, group sales, special projects, your call.
@@ -175,9 +160,6 @@ uk:
       refer_and_earn_hint: Give the gift of TRMNL with a personalized coupon. Earn per use, paid monthly.
       refer_and_earn_redemptions: Redemptions
       refer_and_earn_request_code: Request a Code
-      device_invoice: Device Invoice
-      device_invoice_label: Download commercial documents for your accountant or (weird) PDF collection.
-      device_invoice_hint: Find this on your package tracking page or shipment notification email.
       email_address_hint: Використовується для входу в TRMNL та для отримання системних повідомлень.
       first_name_hint: Ми використовуємо ваше ім'я, щоб зробити інтерфейс TRMNL більш зручним.
       last_name_hint: Ми використовуємо ваше прізвище, щоб зробити інтерфейс TRMNL більш зручним.
@@ -256,13 +238,7 @@ uk:
   dashboard:
     index:
       title: Панель управління
-      last_7_days: Останні 7 днів
-      last_30_days: Останні 30 днів
-      last_90_days: Останні 90 днів
-      today: Сьогодні
-      yesterday: Вчора
     health:
-      bad: У роботі плагінів виникли неполадки
       good: Плагіни в нормі
       next_steps: Ми повідомимо вас, якщо щось зміниться
     news:
@@ -279,14 +255,9 @@ uk:
       new_and_popular: Нові та популярні
     shop:
       title: Shop
-      need_another: Need another TRMNL?
     time_saved:
       title: Зекономлений час
-      cta: Читати далі
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: Good morning
@@ -299,7 +270,6 @@ uk:
     edit:
       accepts_beta_firmware: Firmware Early Release
       accepts_beta_firmware_hint: Toggle on to get the latest device firmware improvements before other users.
-      back_to_devices: Назад до пристроїв
       battery_and_sleep: Battery & Sleep
       battery_consumption: Споживання батареї
       battery_consumption_hint: Заощаджуйте енергію та насолоджуйтесь тривалим часом роботи батареї, увімкнувши Режим сну.
@@ -321,7 +291,6 @@ uk:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
-      last_ping: Last ping
       unknown: Unknown
       never: Never
       display_calibration: Display Calibration
@@ -367,7 +336,6 @@ uk:
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
       maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
-      color_and_rotation: Колір і обертання
       image_rotation: Image Rotation
       screen_rotation: Обертання екрану
       screen_rotation_not_supported: Обертання екрану в даний час не підтримується на вашому пристрої.
@@ -389,9 +357,7 @@ uk:
       tidbyt_credentials: Tidbyt Credentials
       tidbyt_credentials_hint: Enter your Tidbyt device's API credentials from the Tidbyt app under Settings → Developer → Get API Key.
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API credentials are invalid. Please double-check and try again.
       tidbyt_device_id: Device ID
-      tidbyt_device_api_key: API Key
       unlink: Відв'язати
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Відв'язати пристрій
@@ -399,7 +365,6 @@ uk:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Спільний доступ
       visibility_hint: Зробіть ваш пристрій TRMNL доступним для віддзеркалення, змінивши налаштування нижче.
-      your_device: Ваш TRMNL
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -436,9 +401,6 @@ uk:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -512,7 +474,6 @@ uk:
     index:
       title: Пристрої
       tagline: Ваші пристрої TRMNL
-      add_device_modal_title: Додати новий пристрій
       add_first_device: Почніть, додавши свій перший пристрій!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -538,9 +499,6 @@ uk:
     dissociate:
       error: Помилка видалення пристрою
       success: Пристрій успішно видалено
-    external_credentials:
-      error: Invalid device credentials
-      success: Device credentials updated successfully
     identify:
       error: Помилка оновлення пристрою
       success: Запит на ідентифікацію пристрою надіслано
@@ -579,16 +537,11 @@ uk:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: Too many attempts, please wait and try again
-    invoice_not_found: Invoice not found
   logs:
     index:
       title: Logs
       all: All
-      bulk_destroy: Bulk Destroy
       dump: Message
-      id: ID
       private_plugins: Private plugins
       source: Source
       time: Time (UTC)
@@ -623,9 +576,6 @@ uk:
       live_preview: Live Preview
       no_changes_to_save: No changes to save
       pop_out_preview: Pop Out Preview
-      quickstart_examples: Quick-start Examples
-      quickstart_example_applied: Applied!
-      quickstart_use_this_example: Use this example
       revert: Revert
       revert_confirm: Are you sure you want to revert? All unsaved changes will be lost.
       save_changes: Save Changes (⌘﹢S)
@@ -689,9 +639,6 @@ uk:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 2FA Disabled
@@ -717,21 +664,12 @@ uk:
   playlist_items:
     index:
       title: Плейлист
-      tagline: Виберіть, що відображається на
-      add_a_group: Add a Group
-      add_a_plugin: Add a Plugin
       add_first_device_cta: Почніть з __додавання__ вашого першого пристрою TRMNL!
       add_to_playlist: Додати до плейлиста
-      create_first_playlist_cta: Створіть свій плейлист після __підключення__ вашого першого плагіна!
       custom: Custom
       device_default: Device default
-      display_period_from: Display from
-      display_period_to: to
       display_period_validation: Start time must be before end time. Create another group to span overnight hours.
-      every: Every
       never_skip: Never skip screens
-      smart_playlist: Smart Playlist
-      smart_playlist_hint: Automatically skip screens whose contents haven't changed in a while.
       skip_after:
         one: Skip stale screens after 1 day
         other: Skip stale screens after %{count} days
@@ -769,9 +707,6 @@ uk:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: This plugin's refresh rate cannot be configured.
         external: This plugin fetches data on the fly, so refresh rate settings don't apply.
@@ -788,7 +723,6 @@ uk:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: Не вдалося оновити плейлист
       success: Плейлист оновлено
     destroy:
       error: Помилка видалення елементу з плейлиста
@@ -801,8 +735,6 @@ uk:
       success: Playlist order updated
     set_preferences:
       success: Smart playlist preference updated
-    update:
-      success: Порядок елементів оновлено
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -833,23 +765,10 @@ uk:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -857,8 +776,6 @@ uk:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -869,9 +786,6 @@ uk:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -887,7 +801,6 @@ uk:
     index:
       title: Плагіни
       tagline: Що ви бажаєте додати на свій TRMNL?
-      available: Доступні
       connected: Підключені
       supported_by_this_device: Supported by this device
       recipes: Recipes
@@ -899,7 +812,6 @@ uk:
         title: My Plugins
         tagline: Develop Plugins for the public marketplace
       card:
-        connections: connections
         install: Install
         review_are_you_sure: Are you sure? The TRMNL team will test it and email you any questions.
         submit_for_review: Submit for Review
@@ -929,16 +841,11 @@ uk:
     edit:
       title: Edit Plugin
       tagline: Update your plugin details.
-      name: Name
-      description: Description
   plugin_recipes:
     connected: Recipe connected
     connections:
       one: Connection
       other: Connections
-    forks:
-      one: Fork
-      other: Forks
     forked: Recipe forked
     new:
       error: Recipe not found
@@ -946,18 +853,14 @@ uk:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: Активний
     copy_are_you_sure: Are you sure you want to copy this setting?
     delete_are_you_sure: Are you sure you want to delete this setting?
     delete: Це повністю видалить налаштування плагіна. Щоб просто приховати цей плагін з вашого пристрою, видаліть його з плейлиста.
-    inactive: Неактивний
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: Налаштування плагінів не знайдено.
     not_supported: Not supported on current device
     refreshing_now_please_wait: Refreshing now, reload this page in a few seconds.
     reset_credentials: "%{plugin_name} account reset successfully"
     form:
-      active_hint: Показати чи приховати цей екземпляр плагіна на вашому пристрої
       advanced_settings: Advanced Settings
       back_to_playlist: Back to Playlist
       back_to_plugin: Назад до %{plugin}
@@ -979,15 +882,7 @@ uk:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: Дізнайтеся більше про цей плагін у нашій базі знань
-      learn_more_fork: This plugin was forked from a Recipe.
-      learn_more_fork_original: See Original
-      learn_more_native_long: This plugin is native and maintained by TRMNL.
-      learn_more_native_short: This plugin is maintained by TRMNL.
       learn_more_recipe_author: Need help? Contact %{recipe_author} on Discord.
-      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
-      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
-      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
-      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       linked_account: Linked Account
       linked_account_success: Successfully linked with %{plugin_name}
       link_oauth: Підключити обліковий запис
@@ -1009,7 +904,6 @@ uk:
       recipe_cta_body_published: Changes will be reflected on existing installs and future installs/forks.
       recipe_cta_body_in_review: This plugin has been submitted to our team. Stand by.
       recipe_cta_body_not_published: Submit this plugin for others to install. __Learn more__.
-      recipe_cta_confirm: Are you sure? Our team will review and get back to you within a couple days. You may continue making changes.
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: How would you like to publish?
       recipe_visibility_edit_title: Edit Submission
@@ -1020,8 +914,6 @@ uk:
       recipe_visibility_unlisted: Unlisted
       recipe_visibility_unlisted_hint: Anyone with the link can install.
       refresh_rate: Частота оновлення
-      refresh_rate_hint: Оберіть, як часто цей екземпляр плагіна отримує свіжі дані
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: Syncs %{refresh_rate} (not configurable)
       refreshed: Оновлено
       remove_plugin: Remove plugin
@@ -1078,10 +970,8 @@ uk:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: Add a custom schedule
       append: And during…
       no_schedule: This screen will be shown at all times.
-      some_schedule: Only show this screen during…
       to: to
       copy_prompt: Copy schedule from…
       no_days_error: Please select at least one day.
@@ -1107,11 +997,6 @@ uk:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1640,7 +1525,6 @@ uk:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -12,7 +12,6 @@ zh-CN:
   back: 后退
   back_to_all_blog_posts: 返回所有文章
   blog: 博客
-  brand: 品牌
   buy_now: 立即购买
   cancel: 取消
   change_password: 修改密码
@@ -26,15 +25,11 @@ zh-CN:
   copy: 复制
   copied_to_clipboard: 已复制
   copy_to_clipboard: 复制到剪贴板
-  created: 新建于
   create_an_account: 创建账号
   current_device: 当前设备
-  days: 天
   delete: 删除
   developers: 开发者
   developer_edition_required: 此功能需要升级至开发者版。
-  device_id: 设备ID
-  device: 设备
   discard: 放弃
   edit: 编辑
   email_address: 邮箱
@@ -45,7 +40,6 @@ zh-CN:
   forgot_password_title: 重新设置密码
   friendly_id: 友好 ID
   get_started: 开始使用
-  hidden: 隐藏
   identify: 识别
   import: 导入
   import_new: 导入
@@ -59,32 +53,23 @@ zh-CN:
   log_out: 登出
   manage: 管理
   minimum_characters: 最少字符
-  mins: 分
-  my_playlist: 我的播放列表
   new_password: 新密码
   password: 密码
-  please_wait: 请稍候…
   plugin_not_found: 未发现插件
   preview: 预览
-  privacy: 隐私
-  refresh_rate: 刷新频率
   refresh_rates_hint: 点击__此处__了解刷新频次。
   reset_password: 重置密码
   reset_to_defaults: 恢复默认设置
   required: 必填
   save: 保存
-  shown: 显示
   section: 分区
   settings: 设置
   sign_in: 登录
   sign_up: 注册
   something_went_wrong: 未知错误
   status: 状态
-  subscribe: 订阅
   help_center: 技术支持
-  terms: 条款
   unsaved_changes: 您有未保存的更改
-  update: 更新
   view: 查看
   collaboration_request: 想合作吗？
   collaboration_request_hint: 合作伙伴、团体采购、特别项目，由您决定。
@@ -188,9 +173,6 @@ zh-CN:
       refer_and_earn_hint: 通过个性化的优惠券赠送 TRMNL 设备。按使用次数付费，按月支付。
       refer_and_earn_redemptions: 兑换次数
       refer_and_earn_request_code: 生成兑换码
-      device_invoice: 设备发票
-      device_invoice_label: 下载您的商业发票或者 PDF 汇款证明。
-      device_invoice_hint: 您可以在包裹追踪页面或发货提醒的电子邮箱中找到。
       email_address_hint: 用于登录 TRMNL 和接收系统通知
       first_name_hint: 用于 TRMNL 界面
       last_name_hint: 用于 TRMNL 界面
@@ -269,13 +251,7 @@ zh-CN:
   dashboard:
     index:
       title: 仪表盘
-      last_7_days: 过去 7 日
-      last_30_days: 过去 30 日
-      last_90_days: 过去 90 日
-      today: 今日
-      yesterday: 昨日
     health:
-      bad: 插件出现错误
       good: 插件正常
       next_steps: 若有进一步变化，将通知您
     news:
@@ -292,14 +268,9 @@ zh-CN:
       new_and_popular: 热门插件
     shop:
       title: 店铺
-      need_another: 又需要一个 TRMNL 吗？
     time_saved:
       title: 节省时间
-      cta: 详细信息
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: 早上好
@@ -312,7 +283,6 @@ zh-CN:
     edit:
       accepts_beta_firmware: beta 测试固件
       accepts_beta_firmware_hint: 打开以提前使用最新固件
-      back_to_devices: 返回设备列表
       battery_and_sleep: 电池与睡眠
       battery_consumption: 电池消耗
       battery_consumption_hint: 启用睡眠模式可节省电量并延长电池寿命。
@@ -334,7 +304,6 @@ zh-CN:
       device_model_switch_warning: 这是一个危险操作，__了解详情__。
       device_info: 设备信息
       current_firmware: 当前固件
-      last_ping: 上次响应
       unknown: 未知
       never: 从未
       display_calibration: 显示校准
@@ -380,7 +349,6 @@ zh-CN:
       ota_byod_not_supported: 自带设备（BYOD）不支持 OTA 固件更新。请直接从 trmnl.com/flash 刷入兼容版本。
       maximum_compatibility: 启用最大兼容模式
       maximum_compatibility_hint: 解决由某些电子墨水驱动芯片引发的显示问题。禁用快速刷新功能。需固件版本 1.6.0 及以上。
-      color_and_rotation: 颜色和旋转
       image_rotation: Image Rotation
       screen_rotation: 屏幕旋转
       screen_rotation_not_supported: 屏幕旋转目前不支持您的设备。
@@ -402,9 +370,7 @@ zh-CN:
       tidbyt_credentials: Tidbyt 凭据
       tidbyt_credentials_hint: 从 Tidbyt 应用的「设置」→「开发者」→「获取 API 密钥」中输入您的 Tidbyt 设备的 API 凭据。
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API 凭据无效。请仔细检查后重试。
       tidbyt_device_id: 设备 ID
-      tidbyt_device_api_key: API 密钥
       unlink: 解绑
       unlink_confirm: 您确定吗？解绑仅适用于在将此设备交给他人或切换到自带设备（BYOD）的情况。解绑会删除所有插件设置和播放列表项。如果遇到问题，请访问 help.trmnl.com。
       unlink_device: 解绑设备
@@ -412,7 +378,6 @@ zh-CN:
       unlink_device_learn_more: __点击此处__阅读完整说明。
       visibility: 隐藏
       visibility_hint: 让 TRMNL 设备显示镜像播放列表
-      your_device: 您的 TRMNL
       upgrade_og:
         title: 可升级至 2 位显示
         sub_title: 您的设备可升级至增强型灰度显示，支持从 2 级色彩升级至 4 级。
@@ -449,9 +414,6 @@ zh-CN:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -525,7 +487,6 @@ zh-CN:
     index:
       title: 设备列表
       tagline: 您的 TRMNL 设备
-      add_device_modal_title: 添加新 TRMNL 设备
       add_first_device: 添加您的第一个 TRMNL 设备！
       go_to_settings: 前往设置
       clear_playlist: 清空播放列表
@@ -551,9 +512,6 @@ zh-CN:
     dissociate:
       error: 设备解绑错误
       success: 设备解绑成功
-    external_credentials:
-      error: 无效的设备凭据
-      success: 设备凭据更新成功
     identify:
       error: 设备识别请求错误
       success: 设备识别请求成功
@@ -592,16 +550,11 @@ zh-CN:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: 尝试次数过多，请耐心等待之后再次尝试
-    invoice_not_found: 未找到发票
   logs:
     index:
       title: 日志
       all: 全部
-      bulk_destroy: 批量删除
       dump: Message
-      id: ID
       private_plugins: 私有插件
       source: 来源
       time: Time (UTC)
@@ -636,9 +589,6 @@ zh-CN:
       live_preview: 实时预览
       no_changes_to_save: 没有可以保存的更改
       pop_out_preview: 弹出预览窗口
-      quickstart_examples: 快速入门示例
-      quickstart_example_applied: 已应用！
-      quickstart_use_this_example: 使用此示例
       revert: 还原
       revert_confirm: 确定要还原吗？所有未保存的更改都将丢失。
       save_changes: 保存更改（⌘﹢S）
@@ -702,9 +652,6 @@ zh-CN:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 已禁用双重认证
@@ -730,21 +677,12 @@ zh-CN:
   playlist_items:
     index:
       title: 播放列表
-      tagline: 管理您的播放列表
-      add_a_group: 添加分组
-      add_a_plugin: 添加插件
       add_first_device_cta: 添加您的第一个 TRMNL 设备！
       add_to_playlist: 添加到播放列表
-      create_first_playlist_cta: 连接您的第一个插件以创建播放列表！
       custom: 自定义
       device_default: 系统默认
-      display_period_from: 开始时间
-      display_period_to: 结束时间
       display_period_validation: 开始时间必须早于结束时间。请创建另一个组来覆盖跨夜时段。
-      every: 每
       never_skip: 不跳过屏幕
-      smart_playlist: 智能播放列表
-      smart_playlist_hint: 自动跳过内容长时间未更新的画面。
       skip_after:
         one: 跳过超过 1 天未更新的画面
         other: 跳过超过 %{count} 天未更新的画面
@@ -782,9 +720,6 @@ zh-CN:
       duplicate: 复制
       duplicate_confirm: 这将创建此项的副本并将其添加到播放列表的底部。是否继续？
       presentation: Presentation
-      color_palette: 颜色调色板
-      device_default: 设备默认（%{name}）
-      palette_unavailable: 仅适用于具有多个颜色调色板的设备
       refresh_rate_disabled:
         default: 此插件的刷新率无法配置。
         external: 此插件实时获取数据，因此刷新率设置不适用。
@@ -801,7 +736,6 @@ zh-CN:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: 创建播放列表错误
       success: 播放列表创建成功
     destroy:
       error: 删除播放列表错误
@@ -814,8 +748,6 @@ zh-CN:
       success: 更新顺序成功
     set_preferences:
       success: 智能播放列表设定更新成功
-    update:
-      success: 播放列表更新成功
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -846,23 +778,10 @@ zh-CN:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -870,8 +789,6 @@ zh-CN:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -882,9 +799,6 @@ zh-CN:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -900,7 +814,6 @@ zh-CN:
     index:
       title: 插件
       tagline: 让您的 TRMNL 更加强大
-      available: 可用
       connected: 已连接
       supported_by_this_device: Supported by this device
       recipes: 配方
@@ -912,7 +825,6 @@ zh-CN:
         title: 我的插件
         tagline: 开发插件并与其他用户共享
       card:
-        connections: 连接
         install: 安装
         review_are_you_sure: 您确定吗？TRMNL 团队将进行测试，如有任何疑问会通过邮件联系您。
         submit_for_review: 提交审核
@@ -942,16 +854,11 @@ zh-CN:
     edit:
       title: 编辑插件
       tagline: 修改您的插件
-      name: 名称
-      description: 简介
   plugin_recipes:
     connected: 已连接配方
     connections:
       one: 连接
       other: 连接
-    forks:
-      one: 分支
-      other: 分支
     forked: 配方分支成功
     new:
       error: 未找到配方
@@ -959,18 +866,14 @@ zh-CN:
       more_by_author: 更多来自此作者的配方
       view_all: 查看全部
   plugin_settings:
-    active: 激活
     copy_are_you_sure: 您确定要复制此设置吗？
     delete_are_you_sure: 您确定要删除此设置吗？
     delete: 删除。这将完全删除插件的设置。要仅隐藏此插件，请从播放列表中删除。
-    inactive: 停用
     no_matches_found: 未找到匹配的插件。
-    no_plugin_settings_found: 未找到插件信息
     not_supported: 不支持当前设备
     refreshing_now_please_wait: 正在刷新，请稍后重新加载此页面。
     reset_credentials: "%{plugin_name} 账户重置成功"
     form:
-      active_hint: 显示/隐藏此插件
       advanced_settings: 高级设置
       back_to_playlist: 返回播放列表
       back_to_plugin: 返回 %{plugin}
@@ -992,15 +895,7 @@ zh-CN:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: 了解更多
-      learn_more_fork: 此插件从配方分支而来。
-      learn_more_fork_original: 查看原始版本
-      learn_more_native_long: 此插件为原生插件，由 TRMNL 维护。
-      learn_more_native_short: 此插件由 TRMNL 维护。
       learn_more_recipe_author: 需要帮助？请在 Discord 上联系 %{recipe_author}。
-      learn_more_recipe_long: 此插件为社区配方，不由 TRMNL 维护。
-      learn_more_recipe_short: 注意：此插件为配方。
-      learn_more_third_party_long: 此插件由第三方提供，不由 TRMNL 维护。
-      learn_more_third_party_short: 注意：此插件由第三方提供。
       linked_account: 关联账户
       linked_account_success: 已成功关联 %{plugin_name}
       link_oauth: 链接账户
@@ -1022,7 +917,6 @@ zh-CN:
       recipe_cta_body_published: 更改将反映到现有安装和未来的安装和分支上。
       recipe_cta_body_in_review: 此插件已提交至我们的团队。请稍候。
       recipe_cta_body_not_published: 发布此插件以供他人安装。__了解更多__。
-      recipe_cta_confirm: 您确定吗？我们的团队将进行审核，并在几天内与您联系。您可以继续进行更改。
       recipe_mirrored: 此屏幕从配方镜像而来。
       recipe_visibility_title: 您希望如何发布？
       recipe_visibility_edit_title: 编辑提交
@@ -1033,8 +927,6 @@ zh-CN:
       recipe_visibility_unlisted: 不公开
       recipe_visibility_unlisted_hint: 任何拥有链接的人都可以安装。
       refresh_rate: 刷新率
-      refresh_rate_hint: 设置插件刷新频率
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: "%{refresh_rate}同步（不可配置）"
       refreshed: 已刷新
       remove_plugin: 移除插件
@@ -1091,10 +983,8 @@ zh-CN:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: 添加自定义时间表
       append: 追加时段…
       no_schedule: 此屏幕将始终显示。
-      some_schedule: 仅在以下时间显示此屏幕…
       to: 到
       copy_prompt: 复制现有时间表…
       no_days_error: 请至少选择一天。
@@ -1120,11 +1010,6 @@ zh-CN:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1653,7 +1538,6 @@ zh-CN:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -12,7 +12,6 @@ zh-HK:
   back: 返回
   back_to_all_blog_posts: 返回所有貼文
   blog: 網誌
-  brand: 品牌
   buy_now: 立即購買
   cancel: 取消
   change_password: 更改密碼
@@ -26,15 +25,11 @@ zh-HK:
   copy: 複製
   copied_to_clipboard: 已複製！
   copy_to_clipboard: 複製至剪貼簿
-  created: 新增於
   create_an_account: 新增帳戶
   current_device: 現時裝置
-  days: 日
   delete: 刪除
   developers: 開發者
   developer_edition_required: 需要開發者版本才能啟用此功能。
-  device_id: 裝置ID
-  device: 裝置
   discard: Discard
   edit: 編輯
   email_address: 電郵地址
@@ -45,7 +40,6 @@ zh-HK:
   forgot_password_title: 再次輸入
   friendly_id: Friendly ID
   get_started: 讓我們開始吧！
-  hidden: 隱藏
   identify: 識別
   import: 匯入
   import_new: 匯入新項目
@@ -59,32 +53,23 @@ zh-HK:
   log_out: 登出
   manage: 管理
   minimum_characters: 個字元（最少）
-  mins: 分鐘
-  my_playlist: 我的播放清單
   new_password: 新密碼
   password: 密碼
-  please_wait: 請稍候⋯
   plugin_not_found: 找不到外掛
   preview: 預覽
-  privacy: 私隱
-  refresh_rate: 重新整理頻率
   refresh_rates_hint: __按此__了解重新整理頻率如何運作。
   reset_password: 重設密碼
   reset_to_defaults: 重設為預設值
   required: 必填
   save: 儲存
-  shown: 顯示
   section: 區塊
   settings: 設定
   sign_in: 登入
   sign_up: 註冊
   something_went_wrong: 發生錯誤
   status: 狀態
-  subscribe: 訂閱
   help_center: 支援
-  terms: 條款
   unsaved_changes: You have unsaved changes
-  update: 更新
   view: 查看
   collaboration_request: 想合作嗎？
   collaboration_request_hint: 合作伙伴、團體銷售、特別項目，由你話事。
@@ -153,9 +138,6 @@ zh-HK:
       refer_and_earn_hint: 分享TRMNL專屬優惠券。每次使用均可賺取獎金，按月支付。
       refer_and_earn_redemptions: 兌換次數
       refer_and_earn_request_code: 索取推薦碼
-      device_invoice: 裝置發票
-      device_invoice_label: 下載商業文件以作會計用途。
-      device_invoice_hint: 可在包裹追蹤頁面或發貨通知電郵中找到此代碼。
       email_address_hint: 用於登入TRMNL及接收系統訊息。
       first_name_hint: 我們使用你的名字讓TRMNL介面更具親切感。
       last_name_hint: 我們使用你的名字讓TRMNL介面更具親切感。
@@ -234,13 +216,7 @@ zh-HK:
   dashboard:
     index:
       title: 儀表板
-      last_7_days: 過去7日
-      last_30_days: 過去30日
-      last_90_days: 過去90日
-      today: 今日
-      yesterday: 昨日
     health:
-      bad: 外掛出現問題
       good: 外掛運作正常
       next_steps: 如有任何變更，我們會通知你
     news:
@@ -257,14 +233,9 @@ zh-HK:
       new_and_popular: 最新及熱門項目
     shop:
       title: 商店
-      need_another: 需要另一部TRMNL？
     time_saved:
       title: 已節省時間
-      cta: 閱讀詳情
     discover_callout:
-      manage_persona: Manage persona
-      dismiss: Dismiss
-    saved_discovery_setup:
       manage_persona: Manage persona
     welcome_message:
       morning_salutation: 早晨
@@ -277,7 +248,6 @@ zh-HK:
     edit:
       accepts_beta_firmware: 韌體搶先體驗
       accepts_beta_firmware_hint: 啟用設定後，你會在其他用戶之前取得最新的韌體改進。
-      back_to_devices: 返回裝置
       battery_and_sleep: 電池與睡眠
       battery_consumption: 電池消耗
       battery_consumption_hint: 啟用「睡眠模式」可節省電量，並延長電池續航時間。
@@ -299,7 +269,6 @@ zh-HK:
       device_model_switch_warning: 這是危險操作，請__按此__了解更多。
       device_info: 裝置資訊
       current_firmware: 現時韌體版本
-      last_ping: 最後連線時間
       unknown: 未知
       never: 從未
       display_calibration: 螢幕校準
@@ -345,7 +314,6 @@ zh-HK:
       ota_byod_not_supported: 自攜裝置 (BYOD) 不支援自動更新。請直接從 trmnl.com/flash 下載並刷寫兼容版本。
       maximum_compatibility: 啟用最大兼容性
       maximum_compatibility_hint: 解決由某些電子墨水驅動晶片引起的顯示問題。會停用快速重新整理。需要韌體版本1.6.0或以上。
-      color_and_rotation: 顏色和旋轉
       image_rotation: Image Rotation
       screen_rotation: 屏幕旋轉
       screen_rotation_not_supported: 屏幕旋轉目前不支援你的裝置。
@@ -367,9 +335,7 @@ zh-HK:
       tidbyt_credentials: Tidbyt憑證
       tidbyt_credentials_hint: 在Tidbyt應用程式前往「Settings → Developer → Get API Key」尋找你的Tidbyt裝置API憑證。
       tidbyt_api_key: Tidbyt API Key
-      tidbyt_credentials_invalid: Tidbyt API憑證無效。請檢查並重試。
       tidbyt_device_id: 裝置ID
-      tidbyt_device_api_key: API金鑰
       unlink: 取消連結
       unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: 取消連結裝置
@@ -377,7 +343,6 @@ zh-HK:
       unlink_device_learn_more: __按此__查看完整指南。
       visibility: 共享狀態
       visibility_hint: 調整下方設定使你的TRMNL裝置可被鏡像共享。
-      your_device: 你的TRMNL
       upgrade_og:
         title: 可升級至 2-bit 顯示
         sub_title: 你的裝置可升級以支援增強的灰階顯示，從2個顏色級別升級至4個。
@@ -414,9 +379,6 @@ zh-HK:
       waits_for_next_render_hint: When this device shows a single plugin or mashup, it waits for that plugin's next scheduled update instead of checking in at the refresh rate above. Turn this off to check in at the refresh rate regardless.
       battery_advice:
         title: Battery advice
-        wakes_per_day:
-          one: This device wakes about once a day.
-          other: This device wakes about %{count} times a day.
         days_per_charge:
           one: At that rate a charge lasts about a day.
           other: At that rate a charge lasts about %{count} days.
@@ -490,7 +452,6 @@ zh-HK:
     index:
       title: 裝置
       tagline: 你的TRMNL裝置
-      add_device_modal_title: 新增裝置
       add_first_device: 請先新增你的第一部裝置！
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -516,9 +477,6 @@ zh-HK:
     dissociate:
       error: 中斷連接裝置時發生錯誤
       success: 成功中斷連接裝置
-    external_credentials:
-      error: 裝置憑證無效
-      success: 成功更新裝置憑證
     identify:
       error: 更新裝置時發生錯誤
       success: 已請求裝置識別
@@ -557,16 +515,11 @@ zh-HK:
         title: Set up a persona for %{device_label}
         subtext: Answer a few questions so recommendations fit this TRMNL's role.
         primary_label: Set up persona
-  invoices:
-    rate_limit: 嘗試次數過多，請稍後再試
-    invoice_not_found: 找不到發票
   logs:
     index:
       title: 記錄檔
       all: 所有
-      bulk_destroy: 批量銷毀
       dump: Message
-      id: ID
       private_plugins: 客製外掛
       source: 來源
       time: Time (UTC)
@@ -601,9 +554,6 @@ zh-HK:
       live_preview: 即時預覽
       no_changes_to_save: 沒有可儲存的變更
       pop_out_preview: 彈出預覽視窗
-      quickstart_examples: 快速入門範例
-      quickstart_example_applied: 已套用！
-      quickstart_use_this_example: 套用此範例
       revert: 還原
       revert_confirm: 確定要還原嗎？所有未儲存的變更將會遺失。
       save_changes: 儲存變更 (⌘﹢S)
@@ -667,9 +617,6 @@ zh-HK:
       workspace_ready: Your workspace is set how you like.
       zoom_in: Zoom in
       zoom_out: Zoom out
-  notices:
-    dismiss:
-      discover_callout: You can always set up or change your Persona in the device settings.
   mfa:
     disable_otp:
       success: 已停用雙重驗證
@@ -695,21 +642,12 @@ zh-HK:
   playlist_items:
     index:
       title: 播放清單
-      tagline: 選擇在裝置上顯示的內容
-      add_a_group: 新增群組
-      add_a_plugin: 加入外掛
       add_first_device_cta: 請先__新增__你的第一部TRMNL裝置！
       add_to_playlist: 加入至播放清單
-      create_first_playlist_cta: 在__連接__第一個外掛後，即可建立播放清單！
       custom: 自訂
       device_default: 裝置預設
-      display_period_from: 顯示時間
-      display_period_to: 至
       display_period_validation: 開始時間必須早於結束時間。如要跨越午夜，請新增另一個群組。
-      every: 頻率
       never_skip: 永不跳過畫面
-      smart_playlist: 智能播放清單
-      smart_playlist_hint: 自動跳過內容長段時間未變更的畫面。
       skip_after:
         one: 1日未更新後跳過畫面
         other: "%{count}日未更新後跳過畫面"
@@ -747,9 +685,6 @@ zh-HK:
       duplicate: Duplicate
       duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
       presentation: Presentation
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
       refresh_rate_disabled:
         default: 無法設定此外掛的重新整理頻率。
         external: 此外掛即時擷取數據，因此重新整理頻率設定不適用。
@@ -766,7 +701,6 @@ zh-HK:
       render_overdue: A render has been overdue since %{time}
       no_next_render: No render before then, %{reason}
     create:
-      error: 更新播放清單時發生錯誤
       success: 已更新播放清單
     destroy:
       error: 從播放清單移除項目時發生錯誤
@@ -779,8 +713,6 @@ zh-HK:
       success: 已更新播放清單順序
     set_preferences:
       success: 已更新智能播放清單偏好設定
-    update:
-      success: Playlist order updated
     refresh:
       success: Refreshing now — the preview updates when the render finishes
       placeholder: Configure this playlist item before refreshing it
@@ -811,23 +743,10 @@ zh-HK:
         other: Custom (%{count} windows)
       important_title: Important
       important_description: Only shown alongside other important screens during its schedule.
-    column:
-      schedule: Schedule
-      status: Status
-    skip_reasons:
-      needs_configuration: Needs setup
-      hidden: Hidden
-      skipped: Skipped by plugin
-      schedule: Out of schedule
-      stale: Stale
     bulk_actions:
-      selected:
-        one: 1 selected
-        other: "%{count} selected"
       hide: Hide
       show: Show
       delete: Delete
-      cancel: Cancel
       destroy_confirm: Remove the selected items from this playlist?
       success:
         hide: Items hidden
@@ -835,8 +754,6 @@ zh-HK:
         destroy: Items removed from playlist
       error: Bulk action failed
     time_travel_modal:
-      title: Time Travel
-      apply: Apply
       false: false
     smart_skip_modal:
       title: Smart Skip
@@ -847,9 +764,6 @@ zh-HK:
       error: Playlist order could not be saved
     day_ahead:
       title: The day ahead
-      window: next 24 hours
-      open: Open the day ahead
-      toggle: Hide or show the day ahead
       times:
         one: once
         other: "%{count}×"
@@ -865,7 +779,6 @@ zh-HK:
     index:
       title: 外掛功能
       tagline: 你會在TRMNL上顯示什麼？
-      available: 可使用
       connected: 已連接
       supported_by_this_device: Supported by this device
       recipes: 模板(Recipe)
@@ -877,7 +790,6 @@ zh-HK:
         title: 我的外掛
         tagline: 為其他用戶開發外掛
       card:
-        connections: 連接數量
         install: 安裝
         review_are_you_sure: 確定提交？TRMNL團隊會進行測試。如有任何問題，我們會以電郵聯絡你。
         submit_for_review: 提交審核
@@ -907,16 +819,11 @@ zh-HK:
     edit:
       title: 編輯外掛
       tagline: 更新你的外掛詳情。
-      name: 名稱
-      description: 描述
   plugin_recipes:
     connected: 已連接模板
     connections:
       one: 個連接
       other: 個連接
-    forks:
-      one: 個分叉
-      other: 個分叉
     forked: Recipe forked
     new:
       error: 找不到模板
@@ -924,18 +831,14 @@ zh-HK:
       more_by_author: More by this Author
       view_all: View all
   plugin_settings:
-    active: 啟用
     copy_are_you_sure: 確定要複製此設定嗎？
     delete_are_you_sure: 確定要刪除此設定嗎？
     delete: 這將完全移除此外掛的設定。如只想在裝置上隱藏，請從播放清單中刪除。
-    inactive: 停用
     no_matches_found: No plugins match your filters.
-    no_plugin_settings_found: 找不到外掛設定。
     not_supported: 此裝置不支援
     refreshing_now_please_wait: 正在重新整理，請在幾秒鐘後重新載入此頁面。
     reset_credentials: 成功重設「%{plugin_name}」帳戶
     form:
-      active_hint: 在裝置上顯示或隱藏此外掛實例
       advanced_settings: 進階設定
       back_to_playlist: Back to Playlist
       back_to_plugin: 返回%{plugin}
@@ -957,15 +860,7 @@ zh-HK:
       health_notifications_hint: Get an email when this plugin's state changes to degraded or erroring. You'll receive at most one email per state per incident; alerts re-arm once the plugin returns to healthy.
       health_notifications_checkbox: Email me when this plugin becomes unhealthy
       learn_more: 前往知識庫以了解此外掛
-      learn_more_fork: 此外掛是從模板分叉(fork)而來。
-      learn_more_fork_original: 查看原始版本
-      learn_more_native_long: 此外掛為原生，並由TRMNL維護。
-      learn_more_native_short: 此外掛由TRMNL維護。
       learn_more_recipe_author: 需要協助？請在Discord上聯絡%{recipe_author}。
-      learn_more_recipe_long: 此外掛為社群用戶開發的模板，並非由TRMNL維護。
-      learn_more_recipe_short: 注意：此外掛是模板。
-      learn_more_third_party_long: 此外掛由第三方開發，並非由TRMNL維護。
-      learn_more_third_party_short: 注意：此外掛由第三方開發。
       linked_account: 已連結帳戶
       linked_account_success: 成功連結%{plugin_name}
       link_oauth: 連結帳戶
@@ -987,7 +882,6 @@ zh-HK:
       recipe_cta_body_published: 變更將反映在現有安裝及未來安裝/分叉的外掛上。
       recipe_cta_body_in_review: 此外掛已提交給我們的團隊審核。請稍候。
       recipe_cta_body_not_published: 提交此外掛以供其他人安裝。__了解更多__。
-      recipe_cta_confirm: 確定嗎？我們的團隊將進行審核，並在數日內回覆你。你可以繼續進行變更。
       recipe_mirrored: This screen is mirrored from the recipe.
       recipe_visibility_title: 你想如何發佈？
       recipe_visibility_edit_title: 編輯提交內容
@@ -998,8 +892,6 @@ zh-HK:
       recipe_visibility_unlisted: 不公開
       recipe_visibility_unlisted_hint: 擁有連結的任何人都可以安裝。
       refresh_rate: 重新整理頻率
-      refresh_rate_hint: 設定此外掛每隔多久後擷取新資料。
-      refresh_rate_jit_hint: This plugin automatically refreshes on-demand. Learn more __here__.
       refresh_rate_not_configurable: 重新整理頻率 %{refresh_rate}（固定）
       refreshed: 已重新整理
       remove_plugin: 移除外掛
@@ -1056,10 +948,8 @@ zh-HK:
       search_placeholder: 'Search eg: Comic'
   schedules:
     form:
-      add: 加入自訂時間表
       append: 以及⋯
       no_schedule: 此畫面將一直顯示。
-      some_schedule: 只於此期間顯示畫面⋯
       to: 至
       copy_prompt: 複製時間表⋯
       no_days_error: Please select at least one day.
@@ -1085,11 +975,6 @@ zh-HK:
       day_events:
         one: "%{day}: 1 event"
         other: "%{day}: %{count} events"
-      time: Time (UTC)
-      event: Event
-      screen: Screen
-      device: Device
-      detail: What happened
     link:
       title: Activity
       device_hint: When this device checked in, what it scheduled, and which screens it received.
@@ -1618,7 +1503,6 @@ zh-HK:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
-      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:


### PR DESCRIPTION
Removes 103 web UI keys that no code reads. They are carried in all 29 locales, so this is 3,364 deleted lines and nothing else.

They survived because core handed whole i18n subtrees to JavaScript. i18n-tasks records a bare namespace as a used leaf, a leaf has no children, and every key beneath it dropped out of the used tree. usetrmnl/core#4799 stopped the subtree dumps, which is what made the usage report worth reading.

- checks each key against core rather than taking the report at face value, since it over-reports through helper scoping, controller two-tier lookups, ternaries inside `t()`, multi-segment lazy keys and keys reached only from JavaScript
- leaves `custom_plugins` and `plugin_renders` alone, because user Liquid templates reach those at runtime and no scanner sees them
- deletes structurally rather than by line, and every file round-trips byte for byte through `Psych.dump(indentation: 2, line_width: -1)` before and after, so the diff carries no reformatting

Verified against core with its `Gemfile` pointed at this branch: `spec/config/translation_keys_spec.rb`, which asserts every key core reads is defined here, passes. The gem's own suite is green at 106 examples.

Largest groups removed: 15 top-level single words (`brand`, `days`, `mins`, `hidden`), 12 `plugin_settings.form.learn_more_*`, 8 `playlist_items.index.*`, 7 `devices.edit.*`, 5 each of `activity_logs.index.*`, `dashboard.index.last_*_days` and `playlist_items.skip_reasons.*`.
