### PR TITLE
Added the English keys core is waiting on

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -908,6 +908,8 @@ cs:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: Soubor ZIP je příliš velký (maximálně %{max_mb} MB)
       missing_entry: Soubor ZIP neobsahuje %{filename}
@@ -934,6 +936,9 @@ cs:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Žádost byla přijata, zkontrolujte svou e-mailovou schránku

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -909,6 +909,8 @@ da:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP-fil er for stor (%{max_mb} MB maksimum)
       missing_entry: ZIP-filen indeholder ikke %{filename}
@@ -935,6 +937,9 @@ da:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Anmodning modtaget, tjek din indbakke

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -908,6 +908,8 @@ de-AT:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP-Datei ist zu groß (maximal %{max_mb} MB)
       missing_entry: Die ZIP-Datei enthält nicht %{filename}
@@ -934,6 +936,9 @@ de-AT:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Anfrage erhalten, bitte Posteingang überprüfen

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -908,6 +908,8 @@ de:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP-Datei ist zu groß (maximal %{max_mb} MB)
       missing_entry: Die ZIP-Datei enthält nicht %{filename}
@@ -934,6 +936,9 @@ de:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Anfrage erhalten, bitte Posteingang überprüfen

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -908,6 +908,8 @@ en-AU:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -934,6 +936,9 @@ en-AU:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -909,6 +909,8 @@ en-GB:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -935,6 +937,9 @@ en-GB:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -908,6 +908,8 @@ en:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -934,6 +936,9 @@ en:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -909,6 +909,8 @@ es-ES:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: El archivo ZIP es demasiado grande (%{max_mb} MB máximo)
       missing_entry: El archivo ZIP no contiene %{filename}
@@ -935,6 +937,9 @@ es-ES:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Solicitud recibida, compruebe su bandeja de entrada

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -911,6 +911,8 @@ fr:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: Le fichier ZIP est trop volumineux (%{max_mb} MB maximum)
       missing_entry: Le fichier ZIP ne contient pas %{filename}
@@ -937,6 +939,9 @@ fr:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Demande reçue, vérifiez votre boîte de réception

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -911,6 +911,8 @@ he:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -937,6 +939,9 @@ he:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -909,6 +909,8 @@ hu:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: A ZIP fájl túl nagy (%{max_mb} MB a maximális méret)
       missing_entry: A ZIP fájl nem tartalmazza a(z) %{filename} fájlt
@@ -935,6 +937,9 @@ hu:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Kérés fogadva, ellenőrizd az e-mail fiókodat

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -911,6 +911,8 @@ id:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -937,6 +939,9 @@ id:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -909,6 +909,8 @@ is:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP skrá er of stór (%{max_mb} MB hámark)
       missing_entry: ZIP skrá inniheldur ekki %{filename}
@@ -935,6 +937,9 @@ is:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Beiðni móttekin, skoðaðu pósthólfið þitt

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -909,6 +909,8 @@ it:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: File ZIP troppo grande (%{max_mb} MB massimi)
       missing_entry: Il file ZIP non contiene %{filename}
@@ -935,6 +937,9 @@ it:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Richiesta ricevuta, controlla la tua posta

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -909,6 +909,8 @@ ja:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -935,6 +937,9 @@ ja:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: リクエストを受信しました。受信箱を確認してください

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -909,6 +909,8 @@ ko:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP 파일이 너무 커요 (최대 %{max_mb} MB)
       missing_entry: ZIP 파일에 %{filename}이(가) 없어요
@@ -935,6 +937,9 @@ ko:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: 요청을 받았어요. 이메일을 확인해주세요

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -909,6 +909,8 @@ lt:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP failas yra per didelis (maksimaliai %{max_mb} MB)
       missing_entry: ZIP faile nėra %{filename}
@@ -935,6 +937,9 @@ lt:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Užklausa gauta, patikrinkite savo pašto dėžutę

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -909,6 +909,8 @@ nl:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP bestand is te groot (%{max_mb} MB max)
       missing_entry: Het ZIP bestand bevat %{filename} niet
@@ -935,6 +937,9 @@ nl:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Request ontvangen, check je inbox

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -909,6 +909,8 @@
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP-filen er for stor (maksimum %{max_mb} MB)
       missing_entry: ZIP-filen inneholder ikke %{filename}
@@ -935,6 +937,9 @@
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Forespørsel mottatt, sjekk innboksen din

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -931,6 +931,8 @@ pl:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: Archiwum ZIP jest zbyt duże (maksimum %{max_mb} MB)
       missing_entry: Archiwum ZIP nie zawiera %{filename}
@@ -957,6 +959,9 @@ pl:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Zgłoszenie przyjęte, sprawdź swoją skrzynkę odbiorczą

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -909,6 +909,8 @@ pt-BR:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: O arquivo ZIP é muito grande (máximo de %{max_mb} MB)
       missing_entry: O arquivo ZIP não contém %{filename}
@@ -935,6 +937,9 @@ pt-BR:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Pedido recebido, verifique sua caixa de entrada

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -909,6 +909,8 @@ raw:
       refresh_paused_merge: plugin_settings.form.refresh_paused_merge
       refresh_paused_merge_hint: plugin_settings.form.refresh_paused_merge_hint
       clear_state: plugin_settings.form.clear_state
+      virtual_device_short_heading: plugin_settings.form.virtual_device_short_heading
+      virtual_device_long_heading: plugin_settings.form.virtual_device_long_heading
     import:
       archive_too_large: plugin_settings.import.archive_too_large
       missing_entry: plugin_settings.import.missing_entry
@@ -935,6 +937,9 @@ raw:
     state_cleared: plugin_settings.state_cleared
     index:
       no_plugin_settings_found: plugin_settings.index.no_plugin_settings_found
+    health_status_banner:
+      short_heading: plugin_settings.health_status_banner.short_heading
+      long_heading: plugin_settings.health_status_banner.long_heading
   referral_code:
     create:
       request_received: referral_code.create.request_received

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -909,6 +909,8 @@ ro:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: Fișierul ZIP este prea mare (%{max_mb} MB maxim)
       missing_entry: Fișierul ZIP nu conține %{filename}
@@ -935,6 +937,9 @@ ro:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Cerere primită, verifică inbox-ul

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -931,6 +931,8 @@ ru:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP-файл слишком большой (максимум %{max_mb} МБ)
       missing_entry: ZIP-файл не содержит %{filename}
@@ -957,6 +959,9 @@ ru:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Запрос получен, проверьте свой почтовый ящик

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -920,6 +920,8 @@ sk:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -946,6 +948,9 @@ sk:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -909,6 +909,8 @@ sv:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -935,6 +937,9 @@ sv:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -931,6 +931,8 @@ uk:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -957,6 +959,9 @@ uk:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -944,6 +944,8 @@ zh-CN:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP 文件过大（最大 %{max_mb} MB）
       missing_entry: ZIP 文件不包含 %{filename}
@@ -970,6 +972,9 @@ zh-CN:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: 已收到请求，请查收邮箱

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -909,6 +909,8 @@ zh-HK:
       refresh_paused_merge: Refreshing via Plugin Merge
       refresh_paused_merge_hint: Auto-refresh is paused because this plugin is hidden. Its data is kept fresh by %{names} via Plugin Merge.
       clear_state: Clear Saved State
+      virtual_device_short_heading: Virtual device? Click below to generate screens.
+      virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
     import:
       archive_too_large: ZIP檔案太大（最大%{max_mb} MB）
       missing_entry: ZIP檔案未包含「%{filename}」
@@ -935,6 +937,9 @@ zh-HK:
     state_cleared: Saved state cleared. The next refresh starts from scratch.
     index:
       no_plugin_settings_found: You have not set up this plugin yet.
+    health_status_banner:
+      short_heading: Plugin analytics
+      long_heading: Monitor plugin analytics and health across installs
   referral_code:
     create:
       request_received: 已收到請求，請查看收件箱


### PR DESCRIPTION
Opened automatically from usetrmnl/core. These keys already ship in core's
`config/locales/pending`, which shadows this gem's English until they land
here. Merging lets core drop its copy and lets translators pick the copy up.

Only additions — copy this repository already holds is left alone. The other
locales carry the new keys too, from this repository's own `bin/sync`.