### PR TITLE
Added the English keys core is waiting on

### DIFF
--- a/lib/trmnl/i18n/locales/plugin_renders/cs.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/cs.yml
@@ -72,6 +72,7 @@ cs:
         connection_failed: Nelze se připojit ke stanici Netatmo. Zkontrolujte prosím své připojení k internetu.
         data_retrieval_failed: Nelze načíst data o počasí. Zkuste to prosím později.
         session_expired: Relace vypršela. Připojte prosím znovu svůj účet Netatmo v nastavení.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Doručení do
       empty: Žádné zásilky

--- a/lib/trmnl/i18n/locales/plugin_renders/da.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/da.yml
@@ -72,6 +72,7 @@ da:
         connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
         data_retrieval_failed: Unable to retrieve weather data. Please try again later.
         session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Leveres senest
       empty: Der er ingen leveringer

--- a/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
@@ -72,6 +72,7 @@ de-AT:
         connection_failed: Verbindung zur Netatmo-Station fehlgeschlagen. Bitte überprüfe deine Internetverbindung.
         data_retrieval_failed: Wetterdaten konnten nicht abgerufen werden. Bitte später erneut versuchen.
         session_expired: Sitzung abgelaufen. Bitte verbinde dein Netatmo-Konto erneut in den Einstellungen.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Lieferung bis
       empty: Es gibt keine Lieferungen

--- a/lib/trmnl/i18n/locales/plugin_renders/de.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de.yml
@@ -72,6 +72,7 @@ de:
         connection_failed: Verbindung zur Netatmo-Station fehlgeschlagen. Bitte überprüfe deine Internetverbindung.
         data_retrieval_failed: Wetterdaten konnten nicht abgerufen werden. Bitte später erneut versuchen.
         session_expired: Sitzung abgelaufen. Bitte verbinde dein Netatmo-Konto erneut in den Einstellungen.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Lieferung bis
       empty: Es gibt keine Lieferungen

--- a/lib/trmnl/i18n/locales/plugin_renders/en.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/en.yml
@@ -72,6 +72,7 @@ en:
         connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
         data_retrieval_failed: Unable to retrieve weather data. Please try again later.
         session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
@@ -72,6 +72,7 @@ es-ES:
         connection_failed: No se puede conectar con la Estación Netatmo. Revisa tu conexión.
         data_retrieval_failed: Error al obtener datos. Inténtalo más tarde.
         session_expired: Sesión caducada. Por favor, reconecta tu cuenta Netatmo en ajustes.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Entrega Prevista
       empty: No hay envíos

--- a/lib/trmnl/i18n/locales/plugin_renders/fr.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/fr.yml
@@ -72,6 +72,7 @@ fr:
         connection_failed: Impossible de se connecter à la station Netatmo. Vérifiez votre connexion Internet.
         data_retrieval_failed: Impossible de récupérer les données météo. Veuillez réessayer plus tard.
         session_expired: Session expirée. Veuillez reconnecter votre compte Netatmo dans les paramètres.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Livraison par
       empty: Aucune livraison

--- a/lib/trmnl/i18n/locales/plugin_renders/he.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/he.yml
@@ -72,6 +72,7 @@ he:
         connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
         data_retrieval_failed: Unable to retrieve weather data. Please try again later.
         session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/hu.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/hu.yml
@@ -72,6 +72,7 @@ hu:
         connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
         data_retrieval_failed: Unable to retrieve weather data. Please try again later.
         session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Kézbesítés ekkorra
       empty: Nincsenek kézbesítések

--- a/lib/trmnl/i18n/locales/plugin_renders/id.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/id.yml
@@ -72,6 +72,7 @@ id:
         connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
         data_retrieval_failed: Unable to retrieve weather data. Please try again later.
         session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/is.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/is.yml
@@ -72,6 +72,7 @@ is:
         connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
         data_retrieval_failed: Unable to retrieve weather data. Please try again later.
         session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Afhending fyrir
       empty: Engar sendingar

--- a/lib/trmnl/i18n/locales/plugin_renders/it.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/it.yml
@@ -72,6 +72,7 @@ it:
         connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
         data_retrieval_failed: Unable to retrieve weather data. Please try again later.
         session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Consegna da
       empty: Non ci sono spedizioni

--- a/lib/trmnl/i18n/locales/plugin_renders/ja.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ja.yml
@@ -72,6 +72,7 @@ ja:
         connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
         data_retrieval_failed: Unable to retrieve weather data. Please try again later.
         session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/ko.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ko.yml
@@ -72,6 +72,7 @@ ko:
         connection_failed: Netatmo 관측소에 연결할 수 없어요. 인터넷 연결을 확인하세요.
         data_retrieval_failed: 날씨 데이터를 가져올 수 없어요. 나중에 다시 시도하세요.
         session_expired: 세션이 만료됐어요. 설정에서 Netatmo 계정을 다시 연결하세요.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: 배송 예정
       empty: 배송 내역이 없어요

--- a/lib/trmnl/i18n/locales/plugin_renders/lt.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/lt.yml
@@ -72,6 +72,7 @@ lt:
         connection_failed: Nepavyko prisijungti prie Netatmo stotelės. Patikrinkite interneto ryšį.
         data_retrieval_failed: Nepavyko gauti orų duomenų. Bandykite vėliau.
         session_expired: Sesija baigėsi. Nustatymuose iš naujo prijunkite Netatmo paskyrą.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Pristatys iki
       empty: Pristatymų nėra

--- a/lib/trmnl/i18n/locales/plugin_renders/nl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/nl.yml
@@ -72,6 +72,7 @@ nl:
         connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
         data_retrieval_failed: Unable to retrieve weather data. Please try again later.
         session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Levering door
       empty: Er zijn geen leveringen

--- a/lib/trmnl/i18n/locales/plugin_renders/no.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/no.yml
@@ -72,6 +72,7 @@
         connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
         data_retrieval_failed: Unable to retrieve weather data. Please try again later.
         session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/pl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pl.yml
@@ -72,6 +72,7 @@ pl:
         connection_failed: Połączenie ze stacją Netatmo nie powiodło się. Sprawdź swoje połączenie z Internetem.
         data_retrieval_failed: Nie można pobrać danych o pogodzie. Spróbuj ponownie później.
         session_expired: Sesja wygasła. Proszę podłączyć swoje konto Netatmo w ustawieniach.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
       feels_like: Odczuwalna
     parcel:
       delivery_by: Dostawa do

--- a/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
@@ -72,6 +72,7 @@ pt-BR:
         connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
         data_retrieval_failed: Unable to retrieve weather data. Please try again later.
         session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Entregue por
       empty: Não há entregas

--- a/lib/trmnl/i18n/locales/plugin_renders/raw.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/raw.yml
@@ -72,6 +72,7 @@ raw:
         connection_failed: renders.netatmo_weather_station.errors.connection_failed
         data_retrieval_failed: renders.netatmo_weather_station.errors.data_retrieval_failed
         session_expired: renders.netatmo_weather_station.errors.session_expired
+        indoor_module_missing: renders.netatmo_weather_station.errors.indoor_module_missing
     parcel:
       delivery_by: parcel.delivery_by
       empty: parcel.empty

--- a/lib/trmnl/i18n/locales/plugin_renders/ro.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ro.yml
@@ -72,6 +72,7 @@ ro:
         connection_failed: Imposibil de conectat la stația Netatmo. Verifică conexiunea la internet.
         data_retrieval_failed: Imposibil de preluat datele meteo. Încearcă din nou mai târziu.
         session_expired: Sesiunea a expirat. Reconectează-ți contul Netatmo în setări.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Livrare de
       empty: Nu există livrări

--- a/lib/trmnl/i18n/locales/plugin_renders/ru.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ru.yml
@@ -72,6 +72,7 @@ ru:
         connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
         data_retrieval_failed: Unable to retrieve weather data. Please try again later.
         session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Доставка до
       empty: Нет доставок

--- a/lib/trmnl/i18n/locales/plugin_renders/sk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sk.yml
@@ -72,6 +72,7 @@ sk:
         connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
         data_retrieval_failed: Unable to retrieve weather data. Please try again later.
         session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Doručenie do
       empty: Žiadne zásielky

--- a/lib/trmnl/i18n/locales/plugin_renders/sv.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sv.yml
@@ -72,6 +72,7 @@ sv:
         connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
         data_retrieval_failed: Unable to retrieve weather data. Please try again later.
         session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/uk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/uk.yml
@@ -72,6 +72,7 @@ uk:
         connection_failed: Unable to connect to Netatmo station. Please check your internet connection.
         data_retrieval_failed: Unable to retrieve weather data. Please try again later.
         session_expired: Session expired. Please reconnect your Netatmo account in settings.
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: Delivery by
       empty: There are no deliveries

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
@@ -72,6 +72,7 @@ zh-CN:
         connection_failed: 无法连接到 Netatmo 站。请检查您的网络连接。
         data_retrieval_failed: 无法获取天气数据。请稍后再试。
         session_expired: 会话已过期。请在设置中重新连接您的 Netatmo 账户。
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: 送达日期
       empty: 暂时没有快递

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
@@ -72,6 +72,7 @@ zh-HK:
         connection_failed: 無法連線至Netatmo氣象站，請檢查網絡連線。
         data_retrieval_failed: 無法取得天氣數據，請稍後再試。
         session_expired: 登入時效已過，請在設定中重新連接Netatmo帳戶。
+        indoor_module_missing: Selected indoor module not found. Please reconfigure in settings.
     parcel:
       delivery_by: 預計送達時間
       empty: 沒有任何包裹


### PR DESCRIPTION
Opened automatically from usetrmnl/core. These keys already ship in core's
`config/locales/pending`, which shadows this gem's English until they land
here. Merging lets core drop its copy and lets translators pick the copy up.

Only additions — copy this repository already holds is left alone. The other
locales carry the new keys too, from this repository's own `bin/sync`.