### PR TITLE
Restored the plugin kind banner copy

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -910,6 +910,12 @@ cs:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: Tento plugin je spravován společností TRMNL.
+      learn_more_native_long: Tento plugin je nativní a je spravován společností TRMNL.
+      learn_more_recipe_short: 'Poznámka: tento plugin je Recept.'
+      learn_more_recipe_long: Tento plugin je komunitní Recept a není spravován společností TRMNL.
+      learn_more_third_party_short: 'Poznámka: tento plugin pochází od 3. strany.'
+      learn_more_third_party_long: Tento plugin pochází od 3. strany a není spravován společností TRMNL.
     import:
       archive_too_large: Soubor ZIP je příliš velký (maximálně %{max_mb} MB)
       missing_entry: Soubor ZIP neobsahuje %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -911,6 +911,12 @@ da:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long: This plugin is native and maintained by TRMNL.
+      learn_more_recipe_short: 'Bemærk: dette plugin er en opskrift.'
+      learn_more_recipe_long: Dette plugin er en community-opskrift og vedligeholdes ikke af TRMNL.
+      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
     import:
       archive_too_large: ZIP-fil er for stor (%{max_mb} MB maksimum)
       missing_entry: ZIP-filen indeholder ikke %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -910,6 +910,12 @@ de-AT:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: Diese Erweiterung wird von TRMNL gewartet.
+      learn_more_native_long: Dies ist eine offizielle Erweiterung, die von TRMNL gewartet wird.
+      learn_more_recipe_short: 'Hinweis: Diese Erweiterung ist eine Blaupause.'
+      learn_more_recipe_long: Diese Erweiterung ist eine Community-Blaupause und wird nicht von TRMNL gewartet.
+      learn_more_third_party_short: 'Hinweis: Diese Erweiterung stammt von einem Drittanbieter.'
+      learn_more_third_party_long: Diese Erweiterung stammt von einem Drittanbieter und wird nicht von TRMNL gewartet.
     import:
       archive_too_large: ZIP-Datei ist zu groß (maximal %{max_mb} MB)
       missing_entry: Die ZIP-Datei enthält nicht %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -910,6 +910,12 @@ de:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: Diese Erweiterung wird von TRMNL gewartet.
+      learn_more_native_long: Dies ist eine offizielle Erweiterung, die von TRMNL gewartet wird.
+      learn_more_recipe_short: 'Hinweis: Diese Erweiterung ist eine Blaupause.'
+      learn_more_recipe_long: Diese Erweiterung ist eine Community-Blaupause und wird nicht von TRMNL gewartet.
+      learn_more_third_party_short: 'Hinweis: Diese Erweiterung stammt von einem Drittanbieter.'
+      learn_more_third_party_long: Diese Erweiterung stammt von einem Drittanbieter und wird nicht von TRMNL gewartet.
     import:
       archive_too_large: ZIP-Datei ist zu groß (maximal %{max_mb} MB)
       missing_entry: Die ZIP-Datei enthält nicht %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -910,6 +910,12 @@ en-AU:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long: This plugin is native and maintained by TRMNL.
+      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
+      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
+      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -911,6 +911,12 @@ en-GB:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long: This plugin is native and maintained by TRMNL.
+      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
+      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
+      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -910,6 +910,12 @@ en:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long: This plugin is native and maintained by TRMNL.
+      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
+      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
+      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -911,6 +911,12 @@ es-ES:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: Mantenido por TRMNL.
+      learn_more_native_long: Este plugin es nativo y está mantenido por TRMNL.
+      learn_more_recipe_short: 'Nota: este plugin es una receta.'
+      learn_more_recipe_long: Este plugin es una receta de la comunidad y no es mantenido por TRMNL.
+      learn_more_third_party_short: 'Nota: este plugin es de un tercero.'
+      learn_more_third_party_long: Este plugin es de un tercero y no está mantenido por TRMNL.
     import:
       archive_too_large: El archivo ZIP es demasiado grande (%{max_mb} MB máximo)
       missing_entry: El archivo ZIP no contiene %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -913,6 +913,12 @@ fr:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: Ce plugin est maintenu par TRMNL.
+      learn_more_native_long: Ce plugin est natif et maintenu par TRMNL.
+      learn_more_recipe_short: 'Note : ce plugin est une Recette.'
+      learn_more_recipe_long: Ce plugin est une Recette communautaire et n'est pas maintenu par TRMNL.
+      learn_more_third_party_short: 'Note : ce plugin est tiers.'
+      learn_more_third_party_long: Ce plugin est tiers et n'est pas maintenu par TRMNL.
     import:
       archive_too_large: Le fichier ZIP est trop volumineux (%{max_mb} MB maximum)
       missing_entry: Le fichier ZIP ne contient pas %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -913,6 +913,12 @@ he:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long: This plugin is native and maintained by TRMNL.
+      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
+      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
+      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -911,6 +911,12 @@ hu:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long: This plugin is native and maintained by TRMNL.
+      learn_more_recipe_short: 'Megjegyzés: ez a bővítmény egy recept.'
+      learn_more_recipe_long: Ez a bővítmény egy közösségi recept, amelyet nem a TRMNL tart karban.
+      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
     import:
       archive_too_large: A ZIP fájl túl nagy (%{max_mb} MB a maximális méret)
       missing_entry: A ZIP fájl nem tartalmazza a(z) %{filename} fájlt

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -913,6 +913,12 @@ id:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long: This plugin is native and maintained by TRMNL.
+      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
+      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
+      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -911,6 +911,12 @@ is:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long: This plugin is native and maintained by TRMNL.
+      learn_more_recipe_short: 'Athugið: þessi viðbót er uppskrift.'
+      learn_more_recipe_long: Þessi viðbót er frá samfélaginu og er ekki viðhaldið af TRMNL.
+      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
     import:
       archive_too_large: ZIP skrá er of stór (%{max_mb} MB hámark)
       missing_entry: ZIP skrá inniheldur ekki %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -911,6 +911,12 @@ it:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: Questo plugin è manutenuto da  TRMNL.
+      learn_more_native_long: Questo plugin è nativo e manutenuto da TRMNL.
+      learn_more_recipe_short: 'Note: questo plugin è una Recipe'
+      learn_more_recipe_long: Questi plugin è una Recipe della comunità e non viene manutenuta da TRMNL.
+      learn_more_third_party_short: 'Note: Questo plugin è creato da terzi.'
+      learn_more_third_party_long: Questo pliugin è creato da terzi e non viene manutenuto da TRMNL.
     import:
       archive_too_large: File ZIP troppo grande (%{max_mb} MB massimi)
       missing_entry: Il file ZIP non contiene %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -911,6 +911,12 @@ ja:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long: This plugin is native and maintained by TRMNL.
+      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
+      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
+      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -911,6 +911,12 @@ ko:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: TRMNL이 관리하는 플러그인이에요.
+      learn_more_native_long: 이 플러그인은 TRMNL이 개발하고 관리해요.
+      learn_more_recipe_short: '참고: 이 플러그인은 레시피예요.'
+      learn_more_recipe_long: 이 플러그인은 커뮤니티 레시피이며 TRMNL이 관리하지 않아요.
+      learn_more_third_party_short: '참고: 이 플러그인은 서드파티 제공이에요.'
+      learn_more_third_party_long: 이 플러그인은 서드파티가 만들었으며 TRMNL이 관리하지 않아요.
     import:
       archive_too_large: ZIP 파일이 너무 커요 (최대 %{max_mb} MB)
       missing_entry: ZIP 파일에 %{filename}이(가) 없어요

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -911,6 +911,12 @@ lt:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: Šį įskiepį prižiūri TRMNL.
+      learn_more_native_long: Šis įskiepis yra vietinis ir jį prižiūri TRMNL.
+      learn_more_recipe_short: 'Pastaba: šis įskiepis yra receptas.'
+      learn_more_recipe_long: Šis įskiepis yra bendruomenės receptas ir jo neprižiūri TRMNL.
+      learn_more_third_party_short: 'Pastaba: šis įskiepis yra sukurtas trečiosios šalies.'
+      learn_more_third_party_long: Šis įskiepis yra trečiosios šalies ir jo neprižiūri TRMNL.
     import:
       archive_too_large: ZIP failas yra per didelis (maksimaliai %{max_mb} MB)
       missing_entry: ZIP faile nėra %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -911,6 +911,12 @@ nl:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long: This plugin is native and maintained by TRMNL.
+      learn_more_recipe_short: 'Noot: deze plugin is een recept'
+      learn_more_recipe_long: Deze plugin is een recept uit de community, en wordt niet onderhouden door TRMNL.
+      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
     import:
       archive_too_large: ZIP bestand is te groot (%{max_mb} MB max)
       missing_entry: Het ZIP bestand bevat %{filename} niet

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -911,6 +911,12 @@
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long: This plugin is native and maintained by TRMNL.
+      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
+      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
+      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
     import:
       archive_too_large: ZIP-filen er for stor (maksimum %{max_mb} MB)
       missing_entry: ZIP-filen inneholder ikke %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -933,6 +933,12 @@ pl:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: Ten plugin jest wspierany przez TRMNL.
+      learn_more_native_long: To jest natywny plugin, wspierany przez TRMNL.
+      learn_more_recipe_short: 'Uwaga: ten plugin jest Recepturą.'
+      learn_more_recipe_long: Ten plugin jest Recepturą społecznościową i nie jest utrzymywany przez TRMNL.
+      learn_more_third_party_short: 'Uwaga: wtyczka stworzona przez osoby trzecie.'
+      learn_more_third_party_long: Wtyczka została stworzona przez osoby trzecie i nie jest wspierana przez TRMNL.
     import:
       archive_too_large: Archiwum ZIP jest zbyt duże (maksimum %{max_mb} MB)
       missing_entry: Archiwum ZIP nie zawiera %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -911,6 +911,12 @@ pt-BR:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long: This plugin is native and maintained by TRMNL.
+      learn_more_recipe_short: 'Nota: esse plugin é uma Receita.'
+      learn_more_recipe_long: Esse plugin é uma Receita da comunidade e não é mantido pelo TRMNL.
+      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
     import:
       archive_too_large: O arquivo ZIP é muito grande (máximo de %{max_mb} MB)
       missing_entry: O arquivo ZIP não contém %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -911,6 +911,12 @@ raw:
       clear_state: plugin_settings.form.clear_state
       virtual_device_short_heading: plugin_settings.form.virtual_device_short_heading
       virtual_device_long_heading: plugin_settings.form.virtual_device_long_heading
+      learn_more_native_short: plugin_settings.form.learn_more_native_short
+      learn_more_native_long: plugin_settings.form.learn_more_native_long
+      learn_more_recipe_short: plugin_settings.form.learn_more_recipe_short
+      learn_more_recipe_long: plugin_settings.form.learn_more_recipe_long
+      learn_more_third_party_short: plugin_settings.form.learn_more_third_party_short
+      learn_more_third_party_long: plugin_settings.form.learn_more_third_party_long
     import:
       archive_too_large: plugin_settings.import.archive_too_large
       missing_entry: plugin_settings.import.missing_entry

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -911,6 +911,12 @@ ro:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: Acest plugin este menținut de TRMNL.
+      learn_more_native_long: Acest plugin este nativ și menținut de TRMNL.
+      learn_more_recipe_short: 'Notă: acest plugin este un Rețetar.'
+      learn_more_recipe_long: Acest plugin este un Rețetar al comunității și nu este menținut de TRMNL.
+      learn_more_third_party_short: 'Notă: acest plugin aparține unei terțe părți.'
+      learn_more_third_party_long: Acest plugin aparține unei terțe părți și nu este menținut de TRMNL.
     import:
       archive_too_large: Fișierul ZIP este prea mare (%{max_mb} MB maxim)
       missing_entry: Fișierul ZIP nu conține %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -933,6 +933,12 @@ ru:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long: This plugin is native and maintained by TRMNL.
+      learn_more_recipe_short: 'Примечание: этот плагин является рецептом.'
+      learn_more_recipe_long: Этот плагин является рецептом сообщества и не поддерживается TRMNL.
+      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
     import:
       archive_too_large: ZIP-файл слишком большой (максимум %{max_mb} МБ)
       missing_entry: ZIP-файл не содержит %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -922,6 +922,12 @@ sk:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long: This plugin is native and maintained by TRMNL.
+      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
+      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
+      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -911,6 +911,12 @@ sv:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long: This plugin is native and maintained by TRMNL.
+      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
+      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
+      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -933,6 +933,12 @@ uk:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: This plugin is maintained by TRMNL.
+      learn_more_native_long: This plugin is native and maintained by TRMNL.
+      learn_more_recipe_short: 'Note: this plugin is a Recipe.'
+      learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
+      learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
+      learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -946,6 +946,12 @@ zh-CN:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: 此插件由 TRMNL 维护。
+      learn_more_native_long: 此插件为原生插件，由 TRMNL 维护。
+      learn_more_recipe_short: 注意：此插件为配方。
+      learn_more_recipe_long: 此插件为社区配方，不由 TRMNL 维护。
+      learn_more_third_party_short: 注意：此插件由第三方提供。
+      learn_more_third_party_long: 此插件由第三方提供，不由 TRMNL 维护。
     import:
       archive_too_large: ZIP 文件过大（最大 %{max_mb} MB）
       missing_entry: ZIP 文件不包含 %{filename}

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -911,6 +911,12 @@ zh-HK:
       clear_state: Clear Saved State
       virtual_device_short_heading: Virtual device? Click below to generate screens.
       virtual_device_long_heading: Virtual device? Use this to generate screens on demand.
+      learn_more_native_short: 此外掛由TRMNL維護。
+      learn_more_native_long: 此外掛為原生，並由TRMNL維護。
+      learn_more_recipe_short: 注意：此外掛是模板。
+      learn_more_recipe_long: 此外掛為社群用戶開發的模板，並非由TRMNL維護。
+      learn_more_third_party_short: 注意：此外掛由第三方開發。
+      learn_more_third_party_long: 此外掛由第三方開發，並非由TRMNL維護。
     import:
       archive_too_large: ZIP檔案太大（最大%{max_mb} MB）
       missing_entry: ZIP檔案未包含「%{filename}」


### PR DESCRIPTION
#290 removed these six keys as unread. They are read, by `PluginSettingsHelper#plugin_kind_banner`:

```ruby
short_heading = t("#{locale_prefix}_#{plugin_kind}_short")
```

The key is assembled entirely from interpolation, so it appears nowhere in the source and no usage report can see it. Without them the banner on the plugin settings form renders the key name instead of English for every native, recipe and third-party plugin. A render-time guard in core's request specs caught it on usetrmnl/core#4805.

Restores `learn_more_native`, `learn_more_recipe` and `learn_more_third_party`, short and long, in all 29 locales. Additions only.

`learn_more_fork` and `learn_more_fork_original` stay removed: `PluginSetting#plugin_kind` answers only `private`, `recipe`, `third_party` or `native`, so nothing can build those key names.
