### PR TITLE
Restored the copy a controller resolves from its running action

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -492,6 +492,9 @@ cs:
     update:
       error: Chyba při aktualizaci zařízení
       success: Nastavení zařízení %{device} byla úspěšně aktualizována
+    external_credentials:
+      error: Neplatné přihlašovací údaje zařízení
+      success: Přihlašovací údaje zařízení úspěšně aktualizovány
   discovery:
     dashboard_action:
       saved:
@@ -701,6 +704,7 @@ cs:
       no_next_render: No render before then, %{reason}
     create:
       success: Playlist aktualizován
+      error: Aktualizace playlistu se nezdařila
     destroy:
       error: Chyba při odebrání položky z playlistu
       success: Plugin odebrán z playlistu
@@ -774,6 +778,8 @@ cs:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Pořadí playlistu aktualizováno
   plugins:
     index:
       title: Pluginy
@@ -1513,6 +1519,7 @@ cs:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -493,6 +493,9 @@ da:
     update:
       error: Fejl ved opdatering af enhed
       success: "%{device} enhedsindstillinger opdateret med succes"
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -702,6 +705,7 @@ da:
       no_next_render: No render before then, %{reason}
     create:
       success: Playliste opdateret
+      error: Fejl ved opdatering af playliste
     destroy:
       error: Fejl ved fjernelse af element fra playliste
       success: Plugin fjernet fra playliste
@@ -775,6 +779,8 @@ da:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Playlistens rækkefølge opdateret
   plugins:
     index:
       title: Plugins
@@ -1514,6 +1520,7 @@ da:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -492,6 +492,9 @@ de-AT:
     update:
       error: Fehler beim Aktualisieren des Gerätes
       success: Einstellungen von %{device} erfolgreich aktualisiert
+    external_credentials:
+      error: Ungültige Gerätezugangsdaten
+      success: Gerätezugangsdaten erfolgreich aktualisiert
   discovery:
     dashboard_action:
       saved:
@@ -701,6 +704,7 @@ de-AT:
       no_next_render: No render before then, %{reason}
     create:
       success: Wiedergabeliste aktualisiert
+      error: Fehler beim Aktualisieren der Wiedergabeliste
     destroy:
       error: Fehler beim Entfernen von der Wiedergabeliste
       success: Erweiterung von der Wiedergabeliste entfernt
@@ -774,6 +778,8 @@ de-AT:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Wiedergabereihenfolge aktualisiert
   plugins:
     index:
       title: Erweiterungen
@@ -1513,6 +1519,7 @@ de-AT:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -492,6 +492,9 @@ de:
     update:
       error: Fehler beim Aktualisieren des Gerätes
       success: Einstellungen von %{device} erfolgreich aktualisiert
+    external_credentials:
+      error: Ungültige Gerätezugangsdaten
+      success: Gerätezugangsdaten erfolgreich aktualisiert
   discovery:
     dashboard_action:
       saved:
@@ -701,6 +704,7 @@ de:
       no_next_render: No render before then, %{reason}
     create:
       success: Wiedergabeliste aktualisiert
+      error: Fehler beim Aktualisieren der Wiedergabeliste
     destroy:
       error: Fehler beim Entfernen von der Wiedergabeliste
       success: Erweiterung von der Wiedergabeliste entfernt
@@ -774,6 +778,8 @@ de:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Wiedergabereihenfolge aktualisiert
   plugins:
     index:
       title: Erweiterungen
@@ -1513,6 +1519,7 @@ de:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -492,6 +492,9 @@ en-AU:
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -701,6 +704,7 @@ en-AU:
       no_next_render: No render before then, %{reason}
     create:
       success: Playlist updated
+      error: Failed to update Playlist
     destroy:
       error: Error removing item from playlist
       success: Plugin removed from playlist
@@ -774,6 +778,8 @@ en-AU:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Playlist order updated
   plugins:
     index:
       title: Plugins
@@ -1513,6 +1519,7 @@ en-AU:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -493,6 +493,9 @@ en-GB:
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -702,6 +705,7 @@ en-GB:
       no_next_render: No render before then, %{reason}
     create:
       success: Playlist updated
+      error: Failed to update Playlist
     destroy:
       error: Error removing item from playlist
       success: Plugin removed from playlist
@@ -775,6 +779,8 @@ en-GB:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Playlist order updated
   plugins:
     index:
       title: Plugins
@@ -1514,6 +1520,7 @@ en-GB:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -492,6 +492,9 @@ en:
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -701,6 +704,7 @@ en:
       no_next_render: No render before then, %{reason}
     create:
       success: Playlist updated
+      error: Failed to update Playlist
     destroy:
       error: Error removing item from playlist
       success: Plugin removed from playlist
@@ -774,6 +778,8 @@ en:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Playlist order updated
   plugins:
     index:
       title: Plugins
@@ -1513,6 +1519,7 @@ en:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -493,6 +493,9 @@ es-ES:
     update:
       error: Error al actualizar el dispositivo
       success: Configuración del dispositivo %{device} actualizada con éxito
+    external_credentials:
+      error: Credenciales del dispositivo inválidas
+      success: Credenciales del dispositivo actualizadas correctamente
   discovery:
     dashboard_action:
       saved:
@@ -702,6 +705,7 @@ es-ES:
       no_next_render: No render before then, %{reason}
     create:
       success: Lista actualizada
+      error: Falló la actualización de la lista
     destroy:
       error: Error al eliminar el elemento de la lista
       success: Plugin eliminado de la lista
@@ -775,6 +779,8 @@ es-ES:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Orden de la lista actualizado
   plugins:
     index:
       title: Plugins
@@ -1514,6 +1520,7 @@ es-ES:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -495,6 +495,9 @@ fr:
     update:
       error: Erreur lors de la mise à jour de l'appareil
       success: "%{device} mis à jour avec succès"
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -704,6 +707,7 @@ fr:
       no_next_render: No render before then, %{reason}
     create:
       success: Playlist mise à jour
+      error: Échec de la mise à jour de la playlist
     destroy:
       error: Erreur lors de la suppression de l'élément de la playlist
       success: Plugin retiré de la playlist
@@ -777,6 +781,8 @@ fr:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Ordre de la playlist mis à jour
   plugins:
     index:
       title: Plugins
@@ -1516,6 +1522,7 @@ fr:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -495,6 +495,9 @@ he:
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -704,6 +707,7 @@ he:
       no_next_render: No render before then, %{reason}
     create:
       success: Playlist updated
+      error: Failed to update playlist
     destroy:
       error: Error removing item from playlist
       success: Plugin removed from Playlist
@@ -777,6 +781,8 @@ he:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Playlist order updated
   plugins:
     index:
       title: Plugins
@@ -1516,6 +1522,7 @@ he:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -493,6 +493,9 @@ hu:
     update:
       error: Hiba az eszköz frissítésekor
       success: "%{device} eszközbeállításai sikeresen frissítve"
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -702,6 +705,7 @@ hu:
       no_next_render: No render before then, %{reason}
     create:
       success: Lejátszási lista frissítve
+      error: Hiba történt a lejátszási lista frissítésekor
     destroy:
       error: Hiba történt az elem eltávolításakor a lejátszási listáról
       success: A bővítmény eltávolítva a lejátszási listáról
@@ -775,6 +779,8 @@ hu:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Playlist order updated
   plugins:
     index:
       title: Bővítmények
@@ -1514,6 +1520,7 @@ hu:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -495,6 +495,9 @@ id:
     update:
       error: Terjadi kesalahan saat memperbarui perangkat
       success: Pengaturan perangkat %{device} berhasil diperbarui
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -704,6 +707,7 @@ id:
       no_next_render: No render before then, %{reason}
     create:
       success: Daftar putar berhasil diperbarui
+      error: Gagal memperbarui daftar putar
     destroy:
       error: Terjadi kesalahan saat menghapus item dari daftar putar
       success: Plugin berhasil dihapus dari Daftar Putar
@@ -777,6 +781,8 @@ id:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Urutan daftar putar berhasil diperbarui
   plugins:
     index:
       title: Plugin
@@ -1516,6 +1522,7 @@ id:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -493,6 +493,9 @@ is:
     update:
       error: Villa við að uppfæra tæki
       success: Stillingar tækis %{device} uppfærðar
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -702,6 +705,7 @@ is:
       no_next_render: No render before then, %{reason}
     create:
       success: Spilunarlisti uppfærður
+      error: Gat ekki uppfært spilunarlista
     destroy:
       error: Villa við að fjarlægja atriði úr spilunarlista
       success: Viðbót fjarlægð úr spilunarlista
@@ -775,6 +779,8 @@ is:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Playlist order updated
   plugins:
     index:
       title: Viðbætur
@@ -1514,6 +1520,7 @@ is:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -493,6 +493,9 @@ it:
     update:
       error: Errore nell'aggiornamento del dispositivo
       success: "%{device} impostazioni dispositivo aggiornate con successo"
+    external_credentials:
+      error: Credenziali dispositivo invalide
+      success: Credenziali dispositivo aggiornate correttamente
   discovery:
     dashboard_action:
       saved:
@@ -702,6 +705,7 @@ it:
       no_next_render: No render before then, %{reason}
     create:
       success: Playlist aggiornata
+      error: Aggiornamento Playlist fallito
     destroy:
       error: Errore nella rimozione dell'elemento dalla Playlist
       success: Plugin rimosso dalla Playlist
@@ -775,6 +779,8 @@ it:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Ordinamento Playlist aggiornato
   plugins:
     index:
       title: Plugin
@@ -1514,6 +1520,7 @@ it:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -493,6 +493,9 @@ ja:
     update:
       error: デバイス更新エラー
       success: "%{device}デバイスの設定が正常に更新されました"
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -702,6 +705,7 @@ ja:
       no_next_render: No render before then, %{reason}
     create:
       success: プレイリストが更新されました
+      error: プレイリストの更新に失敗しました
     destroy:
       error: プレイリスト内のプラグイン削除エラー
       success: プラグインがプレイリストから削除されました。
@@ -775,6 +779,8 @@ ja:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: 新しいプレイリストの順序が更新されました
   plugins:
     index:
       title: プラグイン管理
@@ -1514,6 +1520,7 @@ ja:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -493,6 +493,9 @@ ko:
     update:
       error: 기기 업데이트 오류
       success: "%{device} 기기 설정을 업데이트했어요"
+    external_credentials:
+      error: 기기 인증 정보가 올바르지 않아요
+      success: 기기 인증 정보를 업데이트했어요
   discovery:
     dashboard_action:
       saved:
@@ -702,6 +705,7 @@ ko:
       no_next_render: No render before then, %{reason}
     create:
       success: 플레이리스트를 업데이트했어요
+      error: 플레이리스트 업데이트 실패
     destroy:
       error: 플레이리스트 항목 삭제 오류
       success: 플러그인을 플레이리스트에서 삭제했어요
@@ -775,6 +779,8 @@ ko:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: 플레이리스트 순서를 업데이트했어요
   plugins:
     index:
       title: 플러그인
@@ -1514,6 +1520,7 @@ ko:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -493,6 +493,9 @@ lt:
     update:
       error: Klaida atnaujinant įrenginį
       success: "%{device} įrenginio nustatymai sėkmingai atnaujinti"
+    external_credentials:
+      error: Neteisingi įrenginio kredencialai
+      success: Įrenginio kredencialai sėkmingai atnaujinti
   discovery:
     dashboard_action:
       saved:
@@ -702,6 +705,7 @@ lt:
       no_next_render: No render before then, %{reason}
     create:
       success: Grojaraštis atnaujintas
+      error: Nepavyko atnaujinti grojaraščio
     destroy:
       error: Klaida šalinant elementą iš grojaraščio
       success: Įskiepis pašalintas iš grojaraščio
@@ -775,6 +779,8 @@ lt:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Grojaraščio tvarka atnaujinta
   plugins:
     index:
       title: Įskiepiai
@@ -1514,6 +1520,7 @@ lt:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -493,6 +493,9 @@ nl:
     update:
       error: Fout bij updaten apparaat
       success: "%{device} apparaatinstellingen succesvol bijgewerkt"
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -702,6 +705,7 @@ nl:
       no_next_render: No render before then, %{reason}
     create:
       success: Afspeellijst is bijgewerkt
+      error: Bijwerken van afspeellijst is mislukt
     destroy:
       error: Fout bij het verwijderen van afspeellijst
       success: Plugin verwijderd van afspeellijst
@@ -775,6 +779,8 @@ nl:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Volgorde afspeellijst bijgewerkt
   plugins:
     index:
       title: Plugins
@@ -1514,6 +1520,7 @@ nl:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -493,6 +493,9 @@
     update:
       error: Feil ved oppdatering av enhet
       success: "%{device} enhetsinnstillingene ble oppdatert"
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -702,6 +705,7 @@
       no_next_render: No render before then, %{reason}
     create:
       success: Spilleliste oppdatert
+      error: Kunne ikke oppdatere spillelisten
     destroy:
       error: Feil ved fjerning av element fra spilleliste
       success: Plugin fjernet fra spilleliste
@@ -775,6 +779,8 @@
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Rekkefølgen i spillelisten er oppdatert
   plugins:
     index:
       title: Plugins
@@ -1514,6 +1520,7 @@
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -515,6 +515,9 @@ pl:
     update:
       error: Błąd podczas aktualizacji urządzenia
       success: Ustawienia urządzenia %{device} zostały pomyślnie zaktualizowane
+    external_credentials:
+      error: Niepoprawne poświadczenia urządzenia
+      success: Poświadczenia urządzenia zostały pomyślnie zaktualizowane
   discovery:
     dashboard_action:
       saved:
@@ -724,6 +727,7 @@ pl:
       no_next_render: No render before then, %{reason}
     create:
       success: Playlista zaktualizowana
+      error: Aktualizacja playlisty nie powiodła się
     destroy:
       error: Usunięcie elementu z playlisty nie powiodło się
       success: Plugin został usunięty z playlisty
@@ -797,6 +801,8 @@ pl:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Zaktualizowano kolejność odtwarzania
   plugins:
     index:
       title: Pluginy
@@ -1536,6 +1542,7 @@ pl:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -493,6 +493,9 @@ pt-BR:
     update:
       error: Erro ao atualizar dispositivo
       success: Configurações do dispositivo %{device} atualizadas com sucesso
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -702,6 +705,7 @@ pt-BR:
       no_next_render: No render before then, %{reason}
     create:
       success: Playlist atualizada
+      error: Falha ao atualizar a playlist
     destroy:
       error: Erro ao remover item da playlist
       success: Plugin removido da Playlist
@@ -775,6 +779,8 @@ pt-BR:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Ordem da Playlist atualizada
   plugins:
     index:
       title: Plugins
@@ -1514,6 +1520,7 @@ pt-BR:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -493,6 +493,9 @@ raw:
     update:
       error: devices.update.error
       success: devices.update.success
+    external_credentials:
+      error: devices.external_credentials.error
+      success: devices.external_credentials.success
   discovery:
     dashboard_action:
       saved:
@@ -702,6 +705,7 @@ raw:
       no_next_render: playlist_items.playlist_item.no_next_render
     create:
       success: playlists.create.success
+      error: playlists.create.error
     destroy:
       error: playlists.destroy.error
       success: playlists.destroy.success
@@ -775,6 +779,8 @@ raw:
       window_hours: playlist_items.day_ahead.window_hours
       window_label: playlist_items.day_ahead.window_label
       window_option: playlist_items.day_ahead.window_option
+    update:
+      success: playlists.update.success
   plugins:
     index:
       title: plugins.index.title
@@ -1512,6 +1518,7 @@ raw:
       add_to_playlist: mashups.mashup.add_to_playlist
     update:
       success: mashups.update.success
+      error: mashups.update.error
     render_section_error:
       error: mashups.render_section_error.error
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -493,6 +493,9 @@ ro:
     update:
       error: Eroare la actualizarea dispozitivului
       success: Setările dispozitivului %{device} actualizate cu succes
+    external_credentials:
+      error: Credențiale dispozitiv invalide
+      success: Credențiale dispozitiv actualizate cu succes
   discovery:
     dashboard_action:
       saved:
@@ -702,6 +705,7 @@ ro:
       no_next_render: No render before then, %{reason}
     create:
       success: Listă de redare actualizată
+      error: Actualizarea listei de redare a eșuat
     destroy:
       error: Eroare la eliminarea elementului din listă
       success: Plugin eliminat din lista de redare
@@ -775,6 +779,8 @@ ro:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Ordinea listei actualizată
   plugins:
     index:
       title: Plugin-uri
@@ -1514,6 +1520,7 @@ ro:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -515,6 +515,9 @@ ru:
     update:
       error: Ошибка обновления устройства
       success: Настройки устройства "%{device}" успешно обновлены
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -724,6 +727,7 @@ ru:
       no_next_render: No render before then, %{reason}
     create:
       success: Плейлист обновлен
+      error: Не удалось обновить плейлист
     destroy:
       error: Ошибка удаления элемента из плейлиста
       success: Плагин удален из плейлиста
@@ -797,6 +801,8 @@ ru:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Playlist order updated
   plugins:
     index:
       title: Плагины
@@ -1536,6 +1542,7 @@ ru:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -504,6 +504,9 @@ sk:
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -713,6 +716,7 @@ sk:
       no_next_render: No render before then, %{reason}
     create:
       success: Playlist updated
+      error: Failed to update playlist
     destroy:
       error: Error removing item from playlist
       success: Plugin removed from Playlist
@@ -786,6 +790,8 @@ sk:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Playlist order updated
   plugins:
     index:
       title: Plugins
@@ -1525,6 +1531,7 @@ sk:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -493,6 +493,9 @@ sv:
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -702,6 +705,7 @@ sv:
       no_next_render: No render before then, %{reason}
     create:
       success: Playlist updated
+      error: Failed to update playlist
     destroy:
       error: Error removing item from playlist
       success: Plugin removed from Playlist
@@ -775,6 +779,8 @@ sv:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Playlist order updated
   plugins:
     index:
       title: Plugins
@@ -1514,6 +1520,7 @@ sv:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -515,6 +515,9 @@ uk:
     update:
       error: Помилка оновлення пристрою
       success: Налаштування пристрою %{device} успішно оновлено
+    external_credentials:
+      error: Invalid device credentials
+      success: Device credentials updated successfully
   discovery:
     dashboard_action:
       saved:
@@ -724,6 +727,7 @@ uk:
       no_next_render: No render before then, %{reason}
     create:
       success: Плейлист оновлено
+      error: Не вдалося оновити плейлист
     destroy:
       error: Помилка видалення елементу з плейлиста
       success: Плагін видалено з плейлиста
@@ -797,6 +801,8 @@ uk:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Порядок елементів оновлено
   plugins:
     index:
       title: Плагіни
@@ -1536,6 +1542,7 @@ uk:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -528,6 +528,9 @@ zh-CN:
     update:
       error: 设备更新错误
       success: "“%{device} 更新成功”"
+    external_credentials:
+      error: 无效的设备凭据
+      success: 设备凭据更新成功
   discovery:
     dashboard_action:
       saved:
@@ -737,6 +740,7 @@ zh-CN:
       no_next_render: No render before then, %{reason}
     create:
       success: 播放列表创建成功
+      error: 创建播放列表错误
     destroy:
       error: 删除播放列表错误
       success: 播放列表删除成功
@@ -810,6 +814,8 @@ zh-CN:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: 播放列表更新成功
   plugins:
     index:
       title: 插件
@@ -1549,6 +1555,7 @@ zh-CN:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -493,6 +493,9 @@ zh-HK:
     update:
       error: 更新裝置時發生錯誤
       success: 成功更新「%{device}」的裝置設定
+    external_credentials:
+      error: 裝置憑證無效
+      success: 成功更新裝置憑證
   discovery:
     dashboard_action:
       saved:
@@ -702,6 +705,7 @@ zh-HK:
       no_next_render: No render before then, %{reason}
     create:
       success: 已更新播放清單
+      error: 更新播放清單時發生錯誤
     destroy:
       error: 從播放清單移除項目時發生錯誤
       success: 已從播放清單移除外掛
@@ -775,6 +779,8 @@ zh-HK:
       window_hours: next %{count} hours
       window_label: How far ahead to look
       window_option: "%{count}h"
+    update:
+      success: Playlist order updated
   plugins:
     index:
       title: 外掛功能
@@ -1514,6 +1520,7 @@ zh-HK:
       add_to_playlist: Add to playlist
     update:
       success: Mashup updated
+      error: Every section needs a plugin — pick one for each and save again.
     render_section_error:
       error: That section could not be rendered — try again.
   playlist_coverage:


### PR DESCRIPTION
#290 removed these five keys as unread. A controller's lazy `t('.error')` resolves against the action being processed, not the method the call sits in, so a private method called during `update` reaches `mashups.update.error` even though nothing in the source spells that key. Core's request specs caught `mashups.update.error` rendering its own name in a flash.

Restores, in all 29 locales, additions only:

- `mashups.update.error`
- `playlist_items.create.error`
- `playlist_items.update.success`
- `devices.external_credentials.error`
- `devices.external_credentials.success`

The last four go back on the same reasoning rather than waiting for another report. Follows usetrmnl/trmnl-i18n#293, which restored the plugin kind banner copy after the same audit missed it for a different reason.
