### PR TITLE
Added the English keys core is waiting on

### DIFF
--- a/lib/trmnl/i18n/locales/plugin_renders/cs.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/cs.yml
@@ -298,6 +298,6 @@ cs:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Vítejte
+      greeting: Ahoj, %{name}
+      greeting_blank: Ahoj

--- a/lib/trmnl/i18n/locales/plugin_renders/cs.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/cs.yml
@@ -297,3 +297,7 @@ cs:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/da.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/da.yml
@@ -298,6 +298,6 @@ da:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Velkommen
+      greeting: Hej %{name}
+      greeting_blank: Hej

--- a/lib/trmnl/i18n/locales/plugin_renders/da.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/da.yml
@@ -297,3 +297,7 @@ da:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
@@ -298,6 +298,6 @@ de-AT:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Willkommen
+      greeting: Hallo, %{name}
+      greeting_blank: Hallo

--- a/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
@@ -297,3 +297,7 @@ de-AT:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/de.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de.yml
@@ -297,3 +297,7 @@ de:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/de.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de.yml
@@ -298,6 +298,6 @@ de:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Willkommen
+      greeting: Hallo, %{name}
+      greeting_blank: Hallo

--- a/lib/trmnl/i18n/locales/plugin_renders/en.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/en.yml
@@ -297,3 +297,7 @@ en:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
@@ -298,6 +298,6 @@ es-ES:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Bienvenido
+      greeting: Hola, %{name}
+      greeting_blank: Hola

--- a/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
@@ -297,3 +297,7 @@ es-ES:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/fr.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/fr.yml
@@ -297,3 +297,7 @@ fr:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/fr.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/fr.yml
@@ -298,6 +298,6 @@ fr:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Bienvenue
+      greeting: Bonjour %{name}
+      greeting_blank: Bonjour

--- a/lib/trmnl/i18n/locales/plugin_renders/he.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/he.yml
@@ -297,3 +297,7 @@ he:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/he.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/he.yml
@@ -298,6 +298,6 @@ he:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: ברוכים הבאים
+      greeting: שלום, %{name}
+      greeting_blank: שלום

--- a/lib/trmnl/i18n/locales/plugin_renders/hu.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/hu.yml
@@ -298,6 +298,6 @@ hu:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Üdvözlünk
+      greeting: Szia, %{name}
+      greeting_blank: Szia

--- a/lib/trmnl/i18n/locales/plugin_renders/hu.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/hu.yml
@@ -297,3 +297,7 @@ hu:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/id.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/id.yml
@@ -298,6 +298,6 @@ id:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Selamat datang
+      greeting: Halo %{name}
+      greeting_blank: Halo

--- a/lib/trmnl/i18n/locales/plugin_renders/id.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/id.yml
@@ -297,3 +297,7 @@ id:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/is.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/is.yml
@@ -297,3 +297,7 @@ is:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/is.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/is.yml
@@ -298,6 +298,6 @@ is:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Velkomin
+      greeting: Halló, %{name}
+      greeting_blank: Halló

--- a/lib/trmnl/i18n/locales/plugin_renders/it.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/it.yml
@@ -298,6 +298,6 @@ it:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Benvenuto/a
+      greeting: Ciao, %{name}
+      greeting_blank: Ciao

--- a/lib/trmnl/i18n/locales/plugin_renders/it.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/it.yml
@@ -297,3 +297,7 @@ it:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/ja.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ja.yml
@@ -298,6 +298,6 @@ ja:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: ようこそ
+      greeting: こんにちは、%{name}さん
+      greeting_blank: こんにちは

--- a/lib/trmnl/i18n/locales/plugin_renders/ja.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ja.yml
@@ -297,3 +297,7 @@ ja:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/ko.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ko.yml
@@ -297,3 +297,7 @@ ko:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/ko.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ko.yml
@@ -298,6 +298,6 @@ ko:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: 환영해요
+      greeting: 안녕하세요, %{name}님
+      greeting_blank: 안녕하세요

--- a/lib/trmnl/i18n/locales/plugin_renders/lt.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/lt.yml
@@ -297,3 +297,7 @@ lt:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/lt.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/lt.yml
@@ -298,6 +298,6 @@ lt:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Sveiki atvykę
+      greeting: Sveiki, %{name}
+      greeting_blank: Sveiki

--- a/lib/trmnl/i18n/locales/plugin_renders/nl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/nl.yml
@@ -298,6 +298,6 @@ nl:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Welkom
+      greeting: Hallo, %{name}
+      greeting_blank: Hallo

--- a/lib/trmnl/i18n/locales/plugin_renders/nl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/nl.yml
@@ -297,3 +297,7 @@ nl:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/no.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/no.yml
@@ -298,6 +298,6 @@
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Velkommen
+      greeting: Hei, %{name}
+      greeting_blank: Hei

--- a/lib/trmnl/i18n/locales/plugin_renders/no.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/no.yml
@@ -297,3 +297,7 @@
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/pl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pl.yml
@@ -298,3 +298,7 @@ pl:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/pl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pl.yml
@@ -299,6 +299,6 @@ pl:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Witamy
+      greeting: Cześć, %{name}
+      greeting_blank: Cześć

--- a/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
@@ -297,3 +297,7 @@ pt-BR:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
@@ -298,6 +298,6 @@ pt-BR:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Bem-vindo
+      greeting: Olá, %{name}
+      greeting_blank: Olá

--- a/lib/trmnl/i18n/locales/plugin_renders/raw.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/raw.yml
@@ -297,3 +297,7 @@ raw:
       square_km: renders.place_of_the_day.square_km
       city: renders.place_of_the_day.city
       wonder: renders.place_of_the_day.wonder
+    welcome:
+      title: renders.welcome.title
+      greeting: renders.welcome.greeting
+      greeting_blank: renders.welcome.greeting_blank

--- a/lib/trmnl/i18n/locales/plugin_renders/ro.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ro.yml
@@ -297,3 +297,7 @@ ro:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/ro.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ro.yml
@@ -298,6 +298,6 @@ ro:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Bun venit
+      greeting: Bună, %{name}
+      greeting_blank: Bună

--- a/lib/trmnl/i18n/locales/plugin_renders/ru.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ru.yml
@@ -298,6 +298,6 @@ ru:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Добро пожаловать
+      greeting: Привет, %{name}
+      greeting_blank: Привет

--- a/lib/trmnl/i18n/locales/plugin_renders/ru.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ru.yml
@@ -297,3 +297,7 @@ ru:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/sk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sk.yml
@@ -298,6 +298,6 @@ sk:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Vitajte
+      greeting: Ahoj, %{name}
+      greeting_blank: Ahoj

--- a/lib/trmnl/i18n/locales/plugin_renders/sk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sk.yml
@@ -297,3 +297,7 @@ sk:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/sv.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sv.yml
@@ -297,3 +297,7 @@ sv:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/sv.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sv.yml
@@ -298,6 +298,6 @@ sv:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Välkommen
+      greeting: Hej, %{name}
+      greeting_blank: Hej

--- a/lib/trmnl/i18n/locales/plugin_renders/uk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/uk.yml
@@ -297,3 +297,7 @@ uk:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/uk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/uk.yml
@@ -298,6 +298,6 @@ uk:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: Ласкаво просимо
+      greeting: Привіт, %{name}
+      greeting_blank: Привіт

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
@@ -297,3 +297,7 @@ zh-CN:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
@@ -298,6 +298,6 @@ zh-CN:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: 欢迎
+      greeting: 你好，%{name}
+      greeting_blank: 你好

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
@@ -297,3 +297,7 @@ zh-HK:
       square_km: "%{count} km²"
       city: City
       wonder: Wonder
+    welcome:
+      title: Welcome
+      greeting: Hello, %{name}
+      greeting_blank: Hello

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
@@ -298,6 +298,6 @@ zh-HK:
       city: City
       wonder: Wonder
     welcome:
-      title: Welcome
-      greeting: Hello, %{name}
-      greeting_blank: Hello
+      title: 歡迎
+      greeting: 你好，%{name}
+      greeting_blank: 你好


### PR DESCRIPTION
Opened automatically from usetrmnl/core. These keys already ship in core's
`config/locales/pending`, which shadows this gem's English until they land
here. Merging lets core drop its copy and lets translators pick the copy up.

Only additions — copy this repository already holds is left alone. The other
locales carry the new keys too, from this repository's own `bin/sync`.