### PR TITLE
Added the English keys core is waiting on

### DIFF
--- a/lib/trmnl/i18n/locales/custom_plugins/cs.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/cs.yml
@@ -96,6 +96,44 @@ cs:
         - Kohout
         - Pes
         - Vepř
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ cs:
       today_only: "{#mainLabel}Dnes je{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Zítra je{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} dní do{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}Konec přidaných svátků.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/da.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/da.yml
@@ -96,6 +96,44 @@ da:
         - Hane
         - Hund
         - Gris
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ da:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/de-AT.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/de-AT.yml
@@ -96,6 +96,44 @@ de-AT:
         - Hahn
         - Huhn
         - Schwein
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ de-AT:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/de.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/de.yml
@@ -96,6 +96,44 @@ de:
         - Hahn
         - Huhn
         - Schwein
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ de:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/en.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/en.yml
@@ -96,6 +96,44 @@ en:
         - Rooster
         - Dog
         - Pig
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ en:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/es-ES.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/es-ES.yml
@@ -96,6 +96,44 @@ es-ES:
         - Gallo
         - Perro
         - Cerdo
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ es-ES:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/fr.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/fr.yml
@@ -96,6 +96,44 @@ fr:
         - Coq
         - Chien
         - Cochon
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -212,3 +250,4 @@ fr:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/he.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/he.yml
@@ -96,6 +96,44 @@ he:
         - Rooster
         - Dog
         - Pig
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ he:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/hu.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/hu.yml
@@ -96,6 +96,44 @@ hu:
         - Rooster
         - Dog
         - Pig
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ hu:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/id.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/id.yml
@@ -96,6 +96,44 @@ id:
         - Rooster
         - Dog
         - Pig
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ id:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/is.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/is.yml
@@ -96,6 +96,44 @@ is:
         - Han
         - Hundur
         - Svín
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ is:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/it.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/it.yml
@@ -96,6 +96,44 @@ it:
         - Rooster
         - Dog
         - Pig
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ it:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/ja.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/ja.yml
@@ -96,6 +96,44 @@ ja:
         - 酉
         - 戌
         - 亥
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ ja:
       today_only: "{#mainLabel}今日は{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}{#br/}{#mainLabel}です{/mainLabel}"
       next_only: ".input {$nextDays :number} .match $nextDays 1 {{ {#mainLabel}明日は{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue}{#br/}{#mainLabel}です{/mainLabel} }} 2 {{ {#mainLabel}明後日は{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue}{#br/}{#mainLabel}です{/mainLabel} }} * {{ {#mainValue}{$nextName}{/mainValue}{#br/}{#mainLabel}まであと {/mainLabel}{#mainValue}{$nextDays}{/mainValue}{#mainLabel} 日{/mainLabel} }}"
       no_holidays: "{#subLabel}登録された祝日はすべて終了しました。{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/ko.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/ko.yml
@@ -96,6 +96,44 @@ ko:
         - 유
         - 술
         - 해
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ ko:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/lt.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/lt.yml
@@ -96,6 +96,44 @@ lt:
         - Gaidys
         - Šuo
         - Kiaulė
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ lt:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/nl.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/nl.yml
@@ -96,6 +96,44 @@ nl:
         - Rooster
         - Dog
         - Pig
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ nl:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/pl.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/pl.yml
@@ -96,6 +96,44 @@ pl:
         - Kogut
         - Pies
         - Świnia
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ pl:
       today_only: "{#mainLabel}Dziś jest{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Jutro jest{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} dni do{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}Brak dodanych świąt.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/pt-BR.yml
@@ -96,6 +96,44 @@ pt-BR:
         - Galo
         - Cachorro
         - Porco
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ pt-BR:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/raw.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/raw.yml
@@ -96,6 +96,44 @@ raw:
         - Rooster
         - Dog
         - Pig
+        zodiac_animals:
+        - custom_plugins.simple_calendar.chinese_korean.zodiac_animals[0]
+        - custom_plugins.simple_calendar.chinese_korean.zodiac_animals[1]
+        - custom_plugins.simple_calendar.chinese_korean.zodiac_animals[2]
+        - custom_plugins.simple_calendar.chinese_korean.zodiac_animals[3]
+        - custom_plugins.simple_calendar.chinese_korean.zodiac_animals[4]
+        - custom_plugins.simple_calendar.chinese_korean.zodiac_animals[5]
+        - custom_plugins.simple_calendar.chinese_korean.zodiac_animals[6]
+        - custom_plugins.simple_calendar.chinese_korean.zodiac_animals[7]
+        - custom_plugins.simple_calendar.chinese_korean.zodiac_animals[8]
+        - custom_plugins.simple_calendar.chinese_korean.zodiac_animals[9]
+        - custom_plugins.simple_calendar.chinese_korean.zodiac_animals[10]
+        - custom_plugins.simple_calendar.chinese_korean.zodiac_animals[11]
+        solar_terms:
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[0]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[1]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[2]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[3]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[4]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[5]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[6]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[7]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[8]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[9]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[10]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[11]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[12]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[13]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[14]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[15]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[16]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[17]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[18]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[19]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[20]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[21]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[22]
+        - custom_plugins.simple_calendar.chinese_korean.solar_terms[23]
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ raw:
       today_only: custom_plugins.custom_next_holiday.today_only
       next_only: custom_plugins.custom_next_holiday.next_only
       no_holidays: custom_plugins.custom_next_holiday.no_holidays
+    sun_chart: custom_plugins.sun_chart

--- a/lib/trmnl/i18n/locales/custom_plugins/ro.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/ro.yml
@@ -96,6 +96,44 @@ ro:
         - Cocoș
         - Câine
         - Porc
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ ro:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/ru.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/ru.yml
@@ -96,6 +96,44 @@ ru:
         - Петух
         - Собака
         - Свинья
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ ru:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/sk.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/sk.yml
@@ -96,6 +96,44 @@ sk:
         - Rooster
         - Dog
         - Pig
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ sk:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/sv.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/sv.yml
@@ -96,6 +96,44 @@ sv:
         - Rooster
         - Dog
         - Pig
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ sv:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/uk.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/uk.yml
@@ -96,6 +96,44 @@ uk:
         - Rooster
         - Dog
         - Pig
+        zodiac_animals:
+        - Rat
+        - Ox
+        - Tiger
+        - Rabbit
+        - Dragon
+        - Snake
+        - Horse
+        - Goat
+        - Monkey
+        - Rooster
+        - Dog
+        - Pig
+        solar_terms:
+        - Minor Cold
+        - Major Cold
+        - Start of Spring
+        - Rain Water
+        - Awakening of Insects
+        - Spring Equinox
+        - Pure Brightness
+        - Grain Rain
+        - Start of Summer
+        - Grain Buds
+        - Grain in Ear
+        - Summer Solstice
+        - Minor Heat
+        - Major Heat
+        - Start of Autumn
+        - End of Heat
+        - White Dew
+        - Autumn Equinox
+        - Cold Dew
+        - Frost's Descent
+        - Start of Winter
+        - Minor Snow
+        - Major Snow
+        - Winter Solstice
       japanese:
         rokuyo_terms:
         - 先勝
@@ -213,3 +251,4 @@ uk:
       today_only: "{#mainLabel}Today is{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays one {{ {#mainLabel}Tomorrow is{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}* {{ {#mainValue}{$nextDays}{/mainValue}{#mainLabel} days until{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }}"
       no_holidays: "{#subLabel}End of added holidays.{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/zh-CN.yml
@@ -251,3 +251,4 @@ zh-CN:
       today_only: "{#mainLabel}今天是{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays 1 {{ {#mainLabel}明天是{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }} 2 {{ {#mainLabel}后天是{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }} * {{ {#mainLabel}距离{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue}{#br/}{#mainLabel}还有 {/mainLabel}{#mainValue}{$nextDays}{/mainValue}{#mainLabel} 天{/mainLabel} }}"
       no_holidays: "{#subLabel}已添加的节日已全部结束。{/subLabel}"
+    sun_chart: Sun Chart

--- a/lib/trmnl/i18n/locales/custom_plugins/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/zh-HK.yml
@@ -251,3 +251,4 @@ zh-HK:
       today_only: "{#mainLabel}今日是{/mainLabel}{#br/}{#mainValue}{$name}{/mainValue}"
       next_only: ".input {$nextDays :number} .match $nextDays 1 {{ {#mainLabel}明日是{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }} 2 {{ {#mainLabel}後日是{/mainLabel}{#br/}{#mainValue}{$nextName}{/mainValue} }} * {{ {#mainValue}{$nextName}{/mainValue}{#br/}{#mainLabel}還有 {/mainLabel}{#mainValue}{$nextDays}{/mainValue}{#mainLabel} 日{/mainLabel} }}"
       no_holidays: "{#subLabel}已添加的假期已全部結束。{/subLabel}"
+    sun_chart: Sun Chart


### PR DESCRIPTION
Opened automatically from usetrmnl/core. These keys already ship in core's
`config/locales/pending`, which shadows this gem's English until they land
here. Merging lets core drop its copy and lets translators pick the copy up.

Only additions — copy this repository already holds is left alone. The other
locales carry the new keys too, from this repository's own `bin/sync`.