### PR TITLE
Added the English keys core is waiting on

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -1081,6 +1081,11 @@ cs:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1633,3 +1638,49 @@ cs:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -1082,6 +1082,11 @@ da:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1634,3 +1639,49 @@ da:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -1081,6 +1081,11 @@ de-AT:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1633,3 +1638,49 @@ de-AT:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -1081,6 +1081,11 @@ de:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1633,3 +1638,49 @@ de:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -1081,6 +1081,11 @@ en-AU:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1633,3 +1638,49 @@ en-AU:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -1082,6 +1082,11 @@ en-GB:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1634,3 +1639,49 @@ en-GB:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -1081,6 +1081,11 @@ en:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1633,3 +1638,49 @@ en:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -1082,6 +1082,11 @@ es-ES:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1634,3 +1639,49 @@ es-ES:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -1084,6 +1084,11 @@ fr:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1636,3 +1641,49 @@ fr:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -1084,6 +1084,11 @@ he:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1636,3 +1641,49 @@ he:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -1082,6 +1082,11 @@ hu:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1634,3 +1639,49 @@ hu:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -1084,6 +1084,11 @@ id:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1636,3 +1641,49 @@ id:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -1082,6 +1082,11 @@ is:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1634,3 +1639,49 @@ is:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -1082,6 +1082,11 @@ it:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1634,3 +1639,49 @@ it:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -1082,6 +1082,11 @@ ja:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1634,3 +1639,49 @@ ja:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -1082,6 +1082,11 @@ ko:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1634,3 +1639,49 @@ ko:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -1082,6 +1082,11 @@ lt:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1634,3 +1639,49 @@ lt:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -1082,6 +1082,11 @@ nl:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1634,3 +1639,49 @@ nl:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -1082,6 +1082,11 @@
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1634,3 +1639,49 @@
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -1104,6 +1104,11 @@ pl:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1656,3 +1661,49 @@ pl:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -1082,6 +1082,11 @@ pt-BR:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1634,3 +1639,49 @@ pt-BR:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -1082,6 +1082,11 @@ raw:
               owner: activerecord.errors.models.account_membership.attributes.email.owner
             owner:
               admin: activerecord.errors.models.account_membership.attributes.owner.admin
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: activerecord.errors.models.github_sync.attributes.directory.invalid_folder
+              taken_by_another_plugin: activerecord.errors.models.github_sync.attributes.directory.taken_by_another_plugin
   apps:
     core:
       public:
@@ -1632,3 +1637,49 @@ raw:
         guide_link: pages.flash_firmware.serial_failure.guide_link
         port_unavailable: pages.flash_firmware.serial_failure.port_unavailable
         reset_refused: pages.flash_firmware.serial_failure.reset_refused
+  github_syncs:
+    alerts:
+      connection_failed: github_syncs.alerts.connection_failed
+      import_failed: github_syncs.alerts.import_failed
+      no_repository: github_syncs.alerts.no_repository
+      unsyncable: github_syncs.alerts.unsyncable
+      unverified_installation: github_syncs.alerts.unverified_installation
+    card:
+      at_commit_html: github_syncs.card.at_commit_html
+      disconnect: github_syncs.card.disconnect
+      disconnect_confirm: github_syncs.card.disconnect_confirm
+      drifted: github_syncs.card.drifted
+      import: github_syncs.card.import
+      learn_more: github_syncs.card.learn_more
+      overwrite_warning: github_syncs.card.overwrite_warning
+      pitch: github_syncs.card.pitch
+      reconnect: github_syncs.card.reconnect
+      stopped: github_syncs.card.stopped
+      synced_to_html: github_syncs.card.synced_to_html
+      title_connected: github_syncs.card.title_connected
+      title_disconnected: github_syncs.card.title_disconnected
+      view_diff: github_syncs.card.view_diff
+    errors:
+      commit_rejected: github_syncs.errors.commit_rejected
+      retries_exhausted: github_syncs.errors.retries_exhausted
+    lander:
+      report_issue: github_syncs.lander.report_issue
+      view_on_github: github_syncs.lander.view_on_github
+    notices:
+      connected: github_syncs.notices.connected
+      disconnected: github_syncs.notices.disconnected
+      imported: github_syncs.notices.imported
+    setup:
+      after_create: github_syncs.setup.after_create
+      connect_different: github_syncs.setup.connect_different
+      create_repository: github_syncs.setup.create_repository
+      folder_hint_html: github_syncs.setup.folder_hint_html
+      folder_label: github_syncs.setup.folder_label
+      folder_optional: github_syncs.setup.folder_optional
+      heading: github_syncs.setup.heading
+      need_repository: github_syncs.setup.need_repository
+      page_title: github_syncs.setup.page_title
+      repository_label: github_syncs.setup.repository_label
+      repository_placeholder: github_syncs.setup.repository_placeholder
+      submit: github_syncs.setup.submit
+      wrong_account: github_syncs.setup.wrong_account

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -1082,6 +1082,11 @@ ro:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1634,3 +1639,49 @@ ro:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -1104,6 +1104,11 @@ ru:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1656,3 +1661,49 @@ ru:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -1093,6 +1093,11 @@ sk:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1645,3 +1650,49 @@ sk:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -1082,6 +1082,11 @@ sv:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1634,3 +1639,49 @@ sv:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -1104,6 +1104,11 @@ uk:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1656,3 +1661,49 @@ uk:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -1117,6 +1117,11 @@ zh-CN:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1669,3 +1674,49 @@ zh-CN:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -1082,6 +1082,11 @@ zh-HK:
               owner: is the account owner's own address
             owner:
               admin: is an admin login and cannot be shared
+        github_sync:
+          attributes:
+            directory:
+              invalid_folder: must be a folder path like plugins/clock
+              taken_by_another_plugin: is already synced to another plugin in this repository
   apps:
     core:
       public:
@@ -1634,3 +1639,49 @@ zh-HK:
         guide_link: See the flashing mode guide
         port_unavailable: Couldn't open the serial port. Your USB-C cable may only be able to charge, or your device isn't in flashing mode.
         reset_refused: Your device didn't enter flashing mode, so the reset failed. Repeat Step 3 and try again.
+  github_syncs:
+    alerts:
+      connection_failed: 'GitHub connection failed: %{detail}'
+      import_failed: Import failed.
+      no_repository: Pick a repository to connect.
+      unsyncable: GitHub sync is only available for private plugins you own outright.
+      unverified_installation: 'GitHub connection failed: could not verify the app installation belongs to you. Please reconnect.'
+    card:
+      at_commit_html: at %{commit}
+      disconnect: Disconnect
+      disconnect_confirm: Disconnect this repository? The repo and its history stay on GitHub.
+      drifted: GitHub has newer changes
+      import: Import from GitHub
+      learn_more: Learn more
+      overwrite_warning: Saving here overwrites them.
+      pitch: Connect a repo and every save becomes a commit.
+      reconnect: Reconnect
+      stopped: 'Sync stopped: %{message}'
+      synced_to_html: Synced to %{repository}
+      title_connected: GitHub sync
+      title_disconnected: Sync to GitHub?
+      view_diff: view diff
+    errors:
+      commit_rejected: GitHub rejected the commit (%{detail}). Reconnect to retry.
+      retries_exhausted: GitHub kept rejecting the commit (%{detail}). Reconnect to retry.
+    lander:
+      report_issue: Report an issue
+      view_on_github: View on GitHub
+    notices:
+      connected: Connected to %{repository}. First commit is on its way.
+      disconnected: GitHub sync disconnected.
+      imported: Imported the latest changes from GitHub.
+    setup:
+      after_create: then reload this page to pick it. If your installation covers only select repositories, add the new repo in GitHub settings first.
+      connect_different: Connect a different one
+      create_repository: Create one on GitHub
+      folder_hint_html: Leave this blank when the repository holds one plugin. Name a folder to keep several plugins in one repository — this plugin then writes to <code>&lt;folder&gt;/src/</code>, and <code>trmnlp serve</code> works from inside the folder.
+      folder_label: Folder in the repository
+      folder_optional: "(optional)"
+      heading: Connect "%{plugin}" to GitHub
+      need_repository: Need a repository?
+      page_title: Connect GitHub
+      repository_label: Choose a repository
+      repository_placeholder: Please select...
+      submit: Connect
+      wrong_account: Wrong account?


### PR DESCRIPTION
Opened automatically from usetrmnl/core. These keys already ship in core's
`config/locales/pending`, which shadows this gem's English until they land
here. Merging lets core drop its copy and lets translators pick the copy up.

Only additions — copy this repository already holds is left alone. The other
locales carry the new keys too, from this repository's own `bin/sync`.