### PR TITLE
Added the English keys core is waiting on

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -1057,6 +1057,11 @@ cs:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -1058,6 +1058,11 @@ da:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -1057,6 +1057,11 @@ de-AT:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -1057,6 +1057,11 @@ de:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -1057,6 +1057,11 @@ en-AU:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -1058,6 +1058,11 @@ en-GB:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -1057,6 +1057,11 @@ en:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -1058,6 +1058,11 @@ es-ES:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -1060,6 +1060,11 @@ fr:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -1060,6 +1060,11 @@ he:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -1058,6 +1058,11 @@ hu:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -1060,6 +1060,11 @@ id:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -1058,6 +1058,11 @@ is:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -1058,6 +1058,11 @@ it:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -1058,6 +1058,11 @@ ja:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -1058,6 +1058,11 @@ ko:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -1058,6 +1058,11 @@ lt:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -1058,6 +1058,11 @@ nl:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -1058,6 +1058,11 @@
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -1080,6 +1080,11 @@ pl:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -1058,6 +1058,11 @@ pt-BR:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -1058,6 +1058,11 @@ raw:
       dead_session: activity_logs.render_reasons.dead_session
       command_timeout: activity_logs.render_reasons.command_timeout
       unhandled_error: activity_logs.render_reasons.unhandled_error
+      batch_deadline_passed: activity_logs.render_reasons.batch_deadline_passed
+      mashup_member_refreshed: activity_logs.render_reasons.mashup_member_refreshed
+      no_appearances_to_render: activity_logs.render_reasons.no_appearances_to_render
+      no_render_slot: activity_logs.render_reasons.no_render_slot
+      render_lock_held: activity_logs.render_reasons.render_lock_held
     serve_statuses:
       served: activity_logs.serve_statuses.served
       alias: activity_logs.serve_statuses.alias

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -1058,6 +1058,11 @@ ro:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -1080,6 +1080,11 @@ ru:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -1069,6 +1069,11 @@ sk:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -1058,6 +1058,11 @@ sv:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -1080,6 +1080,11 @@ uk:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -1093,6 +1093,11 @@ zh-CN:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -1058,6 +1058,11 @@ zh-HK:
       dead_session: the browser session ended mid-render
       command_timeout: the browser stopped responding
       unhandled_error: unexpected error
+      batch_deadline_passed: the batch ran out of time before this screen started
+      mashup_member_refreshed: refreshed as part of a mashup
+      no_appearances_to_render: no screen sizes left to render
+      no_render_slot: no render slot was free before the deadline
+      render_lock_held: another render for this plugin was already running
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device


### PR DESCRIPTION
Opened automatically from usetrmnl/core. These keys already ship in core's
`config/locales/pending`, which shadows this gem's English until they land
here. Merging lets core drop its copy and lets translators pick the copy up.

Only additions — copy this repository already holds is left alone. The other
locales carry the new keys too, from this repository's own `bin/sync`.