### PR TITLE
Added the English keys core is waiting on

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -1062,6 +1062,7 @@ cs:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -1063,6 +1063,7 @@ da:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -693,7 +693,7 @@ de-AT:
         global: Diese Erweiterung wird plattformweit nach einem festen Zeitplan aktualisiert.
         mashup: Das Mashup wird so oft aktualisiert wie seine schnellste Erweiterung.
         readonly: Diese Erweiterung hat eine feste Aktualisierungsrate, die nicht konfiguriert werden kann.
-      last_shown: "Zuletzt gezeigt: %{time}"
+      last_shown: 'Zuletzt gezeigt: %{time}'
       title_tooltip:
         source_plugin: Quell-Erweiterung
       force_refresh: Jetzt aktualisieren
@@ -1062,6 +1062,7 @@ de-AT:
       no_appearances_to_render: keine Bildschirmgrößen mehr zu rendern
       no_render_slot: kein Render-Slot war vor der Frist frei
       render_lock_held: ein anderes Render für dieses Plugin lief bereits
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Bildschirm an Gerät gesendet
       alias: Alias-Bild an Gerät gesendet

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -693,7 +693,7 @@ de:
         global: Diese Erweiterung wird plattformweit nach einem festen Zeitplan aktualisiert.
         mashup: Das Mashup wird so oft aktualisiert wie seine schnellste Erweiterung.
         readonly: Diese Erweiterung hat eine feste Aktualisierungsrate, die nicht konfiguriert werden kann.
-      last_shown: "Zuletzt gezeigt: %{time}"
+      last_shown: 'Zuletzt gezeigt: %{time}'
       title_tooltip:
         source_plugin: Quell-Erweiterung
       force_refresh: Jetzt aktualisieren
@@ -1062,6 +1062,7 @@ de:
       no_appearances_to_render: keine Bildschirmgrößen mehr zu rendern
       no_render_slot: kein Render-Slot war vor der Frist frei
       render_lock_held: ein anderes Render für dieses Plugin lief bereits
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Bildschirm an Gerät gesendet
       alias: Alias-Bild an Gerät gesendet

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -1062,6 +1062,7 @@ en-AU:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -1063,6 +1063,7 @@ en-GB:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -1062,6 +1062,7 @@ en:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -1063,6 +1063,7 @@ es-ES:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -1065,6 +1065,7 @@ fr:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -1065,6 +1065,7 @@ he:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -1063,6 +1063,7 @@ hu:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -1065,6 +1065,7 @@ id:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -1063,6 +1063,7 @@ is:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -1063,6 +1063,7 @@ it:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -1063,6 +1063,7 @@ ja:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -1063,6 +1063,7 @@ ko:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -1063,6 +1063,7 @@ lt:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -1063,6 +1063,7 @@ nl:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -1063,6 +1063,7 @@
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -1085,6 +1085,7 @@ pl:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -1063,6 +1063,7 @@ pt-BR:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -1063,6 +1063,7 @@ raw:
       no_appearances_to_render: activity_logs.render_reasons.no_appearances_to_render
       no_render_slot: activity_logs.render_reasons.no_render_slot
       render_lock_held: activity_logs.render_reasons.render_lock_held
+      no_document_changed: activity_logs.render_reasons.no_document_changed
     serve_statuses:
       served: activity_logs.serve_statuses.served
       alias: activity_logs.serve_statuses.alias

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -1063,6 +1063,7 @@ ro:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -1085,6 +1085,7 @@ ru:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -1074,6 +1074,7 @@ sk:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -1063,6 +1063,7 @@ sv:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -1085,6 +1085,7 @@ uk:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -1098,6 +1098,7 @@ zh-CN:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -1063,6 +1063,7 @@ zh-HK:
       no_appearances_to_render: no screen sizes left to render
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
+      no_document_changed: no change in the page it renders
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device


### PR DESCRIPTION
Opened automatically from usetrmnl/core. These keys already ship in core's
`config/locales/pending`, which shadows this gem's English until they land
here. Merging lets core drop its copy and lets translators pick the copy up.

Only additions — copy this repository already holds is left alone. The other
locales carry the new keys too, from this repository's own `bin/sync`.