### PR TITLE
Add more keys for currently hardcoded strings

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -269,8 +269,11 @@ cs:
       device_model_switch_warning: Toto je nebezpečná operace, dozvíte se více __zde__
       device_info: Informace o zařízení
       current_firmware: Aktuální firmware
+      pinned_firmware: Pinned firmware
       unknown: Neznámý
       never: Nikdy
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Kalibrace displeje
       display_calibration_hint: Dolaďte vykreslování pro váš displej. Ponechte prázdné pro použití výchozích hodnot modelu.
       display_calibration_pixel_ratio: Poměr pixelů
@@ -343,6 +346,9 @@ cs:
       unlink_device_learn_more: Postupujte podle kompletního průvodce __zde__.
       visibility: Viditelnost
       visibility_hint: Změňte nastavení níže, aby bylo vaše zařízení TRMNL zrcadlitelné.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: K dispozici je upgrade na 2bitový displej
         sub_title: Vaše zařízení lze upgradovat na podporu vylepšených stupňů šedi se 4 úrovněmi barev namísto 2.
@@ -452,6 +458,7 @@ cs:
     index:
       title: Zařízení
       tagline: Vaše zařízení TRMNL
+      virtual: Virtual
       add_first_device: Začněte přidáním svého prvního zařízení!
       go_to_settings: Přejít do nastavení
       clear_playlist: Vyprázdnit playlist
@@ -656,6 +663,7 @@ cs:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -269,8 +269,11 @@ da:
       device_model_switch_warning: Dette er en risikabel handling, læs mere __her__
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -343,6 +346,9 @@ da:
       unlink_device_learn_more: Følg den fulde guide __her__.
       visibility: Synlighed
       visibility_hint: Gør din TRMNL-enhed spejlbar ved at ændre indstillingerne nedenfor.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Opgradering til 2-bit Display tilgængelig
         sub_title: Din enhed kan opgraderes til forbedret gråtonedisplay med 4 farveniveauer i stedet for 2.
@@ -452,6 +458,7 @@ da:
     index:
       title: Enheder
       tagline: Dine TRMNL-enheder
+      virtual: Virtual
       add_first_device: Start med at tilføje din første enhed!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -657,6 +664,7 @@ da:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -269,8 +269,11 @@ de-AT:
       device_model_switch_warning: Diese Aktion kann gefährlich sein, erfahre __hier__ mehr darüber
       device_info: Geräteinformationen
       current_firmware: Aktuelle Firmware
+      pinned_firmware: Pinned firmware
       unknown: Unbekannt
       never: Nie
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Bildschirmkalibrierung
       display_calibration_hint: Rendering deines Displays anpassen. Feld leer lassen, um die Standardwerte zu verwenden.
       display_calibration_pixel_ratio: Pixelverhältnis
@@ -343,6 +346,9 @@ de-AT:
       unlink_device_learn_more: __Hier__ gibt es die vollständige Anleitung dazu.
       visibility: Sichtbarkeit
       visibility_hint: Macht das TRMNL öffentlich sichtbar.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Upgrade auf 2-bit-Anzeige verfügbar
         sub_title: Dein Gerät kann ein Upgrade erhalten und damit eine verbesserte Graustufendarstellung mit 4 anstelle von 2 Farbwerten unterstützen.
@@ -452,6 +458,7 @@ de-AT:
     index:
       title: Geräte
       tagline: Deine TRMNL-Geräte
+      virtual: Virtual
       add_first_device: Beginne mit dem Hinzufügen deines ersten Gerätes!
       go_to_settings: Zu den Einstellungen
       clear_playlist: Wiedergabeliste leeren
@@ -656,6 +663,7 @@ de-AT:
       add_plugin: Erweiterung hinzufügen
       select: Auswählen
       exit_select: Auswahlmodus verlassen
+      time_travel: Time Travel
       time_travel_now: Jetzt
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -269,8 +269,11 @@ de:
       device_model_switch_warning: Diese Aktion kann gefährlich sein, erfahre __hier__ mehr darüber
       device_info: Geräteinformationen
       current_firmware: Aktuelle Firmware
+      pinned_firmware: Pinned firmware
       unknown: Unbekannt
       never: Nie
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Bildschirmkalibrierung
       display_calibration_hint: Rendering deines Displays anpassen. Feld leer lassen, um die Standardwerte zu verwenden.
       display_calibration_pixel_ratio: Pixelverhältnis
@@ -343,6 +346,9 @@ de:
       unlink_device_learn_more: __Hier__ gibt es die vollständige Anleitung dazu.
       visibility: Sichtbarkeit
       visibility_hint: Macht das TRMNL öffentlich sichtbar.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Upgrade auf 2-bit-Anzeige verfügbar
         sub_title: Dein Gerät kann ein Upgrade erhalten und damit eine verbesserte Graustufendarstellung mit 4 anstelle von 2 Farbwerten unterstützen.
@@ -452,6 +458,7 @@ de:
     index:
       title: Geräte
       tagline: Deine TRMNL-Geräte
+      virtual: Virtual
       add_first_device: Beginne mit dem Hinzufügen deines ersten Gerätes!
       go_to_settings: Zu den Einstellungen
       clear_playlist: Wiedergabeliste leeren
@@ -656,6 +663,7 @@ de:
       add_plugin: Erweiterung hinzufügen
       select: Auswählen
       exit_select: Auswahlmodus verlassen
+      time_travel: Time Travel
       time_travel_now: Jetzt
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -269,8 +269,11 @@ en-AU:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -343,6 +346,9 @@ en-AU:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -452,6 +458,7 @@ en-AU:
     index:
       title: Devices
       tagline: Your TRMNL devices
+      virtual: Virtual
       add_first_device: Start by adding your first device!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -656,6 +663,7 @@ en-AU:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -269,8 +269,11 @@ en-GB:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -343,6 +346,9 @@ en-GB:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 colour levels instead of 2.
@@ -452,6 +458,7 @@ en-GB:
     index:
       title: Devices
       tagline: Your TRMNL devices
+      virtual: Virtual
       add_first_device: Start by adding your first device!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -657,6 +664,7 @@ en-GB:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -269,8 +269,11 @@ en:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -343,6 +346,9 @@ en:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -452,6 +458,7 @@ en:
     index:
       title: Devices
       tagline: Your TRMNL devices
+      virtual: Virtual
       add_first_device: Start by adding your first device!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -656,6 +663,7 @@ en:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -269,8 +269,11 @@ es-ES:
       device_model_switch_warning: Esta es una operación peligrosa, aprende más __aquí__
       device_info: Información del dispositivo
       current_firmware: Firmware actual
+      pinned_firmware: Pinned firmware
       unknown: Desconocido
       never: Nunca
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Calibración de pantalla
       display_calibration_hint: Ajusta el renderizado de tu pantalla. Déjalo vacío para usar los valores predeterminados del modelo.
       display_calibration_pixel_ratio: Relación de píxeles
@@ -343,6 +346,9 @@ es-ES:
       unlink_device_learn_more: Sigue la guía completa __aquí__.
       visibility: Visibilidad
       visibility_hint: Haz que tu dispositivo TRMNL pueda ser replicado cambiando la configuración a continuación.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Actualización a pantalla de 2 bits disponible
         sub_title: Tu dispositivo puede actualizarse para soportar una pantalla de escala de grises mejorada con 4 niveles de color en lugar de 2.
@@ -452,6 +458,7 @@ es-ES:
     index:
       title: Dispositivos
       tagline: Tus dispositivos TRMNL
+      virtual: Virtual
       add_first_device: "¡Añade tu primer dispositivo!"
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -657,6 +664,7 @@ es-ES:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -271,8 +271,11 @@ fr:
       device_model_switch_warning: Cette opération est dangereuse, en savoir plus __ici__
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -345,6 +348,9 @@ fr:
       unlink_device_learn_more: Suivez le guide complet __ici__.
       visibility: Visibilité
       visibility_hint: Synchroniser votre appareil TRMNL en changeant la configuration ci-dessous.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Mise à niveau vers écran 2 bits disponible
         sub_title: Votre appareil peut être mis à niveau pour prendre en charge un affichage en niveaux de gris amélioré avec 4 niveaux au lieu de 2.
@@ -454,6 +460,7 @@ fr:
     index:
       title: Appareils
       tagline: Vos appareils TRMNL
+      virtual: Virtual
       add_first_device: Commencez en ajoutant votre premier appareil !
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -659,6 +666,7 @@ fr:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -271,8 +271,11 @@ he:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -345,6 +348,9 @@ he:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -454,6 +460,7 @@ he:
     index:
       title: Devices
       tagline: Your TRMNL devices
+      virtual: Virtual
       add_first_device: Start by adding your first device!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -659,6 +666,7 @@ he:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -269,8 +269,11 @@ hu:
       device_model_switch_warning: Ez veszélyes művelet, tudj meg róla többet __itt__.
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -343,6 +346,9 @@ hu:
       unlink_device_learn_more: Kövesd a teljes útmutatót __itt__.
       visibility: Láthatóság
       visibility_hint: Állítsd be, hogy a TRMNL eszközöd tükrözhető legyen az alábbi beállításokkal.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Elérhető 2-bites kijelző frissítés
         sub_title: Az eszközöd frissíthető, hogy 2 helyett 4 szürkeárnyalati szintet támogasson.
@@ -452,6 +458,7 @@ hu:
     index:
       title: Eszközök
       tagline: A te TRMNL eszközeid
+      virtual: Virtual
       add_first_device: Kezdd az első eszközöd hozzáadásával!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -657,6 +664,7 @@ hu:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -271,8 +271,11 @@ id:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -345,6 +348,9 @@ id:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibilitas
       visibility_hint: Jadikan perangkat TRMNL Anda dapat di-mirroring dengan mengubah pengaturan di bawah ini.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -454,6 +460,7 @@ id:
     index:
       title: Perangkat
       tagline: Perangkat TRMNL Anda
+      virtual: Virtual
       add_first_device: Mulai dengan menambahkan perangkat pertama Anda!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -659,6 +666,7 @@ id:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -269,8 +269,11 @@ is:
       device_model_switch_warning: Þetta er hættuleg aðgerð, lestu meira __hér__
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -343,6 +346,9 @@ is:
       unlink_device_learn_more: Fylgdu leiðbeiningum __hér__.
       visibility: Sýnileiki
       visibility_hint: Gera TRMNL tækið þitt speglanlegt með því að breyta stillingunum hér að neðan.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Uppfærsla í 2-bita skjá í boði
         sub_title: Tækið þitt getur verið uppfært til að styðja betri grátóna með 4 litastigum í stað 2.
@@ -452,6 +458,7 @@ is:
     index:
       title: Tæki
       tagline: TRMNL tækin þín
+      virtual: Virtual
       add_first_device: Byrjaðu á því að bæta við fyrsta tækinu þínu!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -657,6 +664,7 @@ is:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -269,8 +269,11 @@ it:
       device_model_switch_warning: Questa è un operazione pericolosa, scopri di più __qui__
       device_info: Informazioni Dispositivo
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Mai
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Calibrazione Schermo
       display_calibration_hint: Personalizza il rendering del tuo schermo. Lascia vuoto per usare le impostazioni default del tuo modello.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -343,6 +346,9 @@ it:
       unlink_device_learn_more: Segui la guida completa __qui__.
       visibility: Visibilità
       visibility_hint: Permetti la duplicazione di questo dispositivo TRMNL modificando le impostazioni seguenti.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Aggiornamento per display a 2-bit disponibile
         sub_title: Il tuo dispositivo può essere aggiornato per suportare una migliorata visualizzazione di grigi a quattro liveli al posto di 2.
@@ -452,6 +458,7 @@ it:
     index:
       title: Dispositivi
       tagline: I tuoi dispositivi TRMNL
+      virtual: Virtual
       add_first_device: Inizia aggiungendo il tuo primo dispositivo!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -657,6 +664,7 @@ it:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -269,8 +269,11 @@ ja:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -343,6 +346,9 @@ ja:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: 共有設定
       visibility_hint: 以下の設定を使用して、TRMNLデバイスをミラーモードにすることができます。
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -452,6 +458,7 @@ ja:
     index:
       title: デバイス管理
       tagline: あなたのTRMNLデバイス
+      virtual: Virtual
       add_first_device: 始めるには最初のデバイスを追加してください！
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -657,6 +664,7 @@ ja:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -269,8 +269,11 @@ ko:
       device_model_switch_warning: 위험한 작업이에요. __여기서__ 자세히 알아보세요.
       device_info: 기기 정보
       current_firmware: 현재 펌웨어
+      pinned_firmware: Pinned firmware
       unknown: 알 수 없음
       never: 없음
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: 디스플레이 보정
       display_calibration_hint: 렌더링을 세밀하게 조정하세요. 비워두면 모델 기본값이 적용돼요.
       display_calibration_pixel_ratio: 픽셀 비율
@@ -343,6 +346,9 @@ ko:
       unlink_device_learn_more: 전체 가이드를 __여기서__ 확인하세요.
       visibility: 공개 설정
       visibility_hint: 아래 설정을 바꾸면 다른 기기에서 미러링할 수 있어요.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: 2-bit 디스플레이 업그레이드 가능
         sub_title: 4단계 그레이스케일 디스플레이로 업그레이드할 수 있어요.
@@ -452,6 +458,7 @@ ko:
     index:
       title: 기기 관리
       tagline: 내 TRMNL 기기
+      virtual: Virtual
       add_first_device: 첫 기기를 추가해서 시작하세요!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -657,6 +664,7 @@ ko:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -269,8 +269,11 @@ lt:
       device_model_switch_warning: Tai pavojingas veiksmas, sužinokite daugiau __čia__.
       device_info: Įrenginio informacija
       current_firmware: Dabartinė programinė įranga
+      pinned_firmware: Pinned firmware
       unknown: Nežinoma
       never: Niekada
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Ekrano kalibravimas
       display_calibration_hint: Tiksliai sureguliuokite atvaizdavimą savo ekranui. Palikite tuščią, kad naudotumėte numatytuosius modelio nustatymus.
       display_calibration_pixel_ratio: Pikselių santykis
@@ -343,6 +346,9 @@ lt:
       unlink_device_learn_more: Sekite pilną gidą __čia__.
       visibility: Matomumas
       visibility_hint: Padarykite savo TRMNL įrenginį atspindimą pakeisdami žemiau esančius nustatymus.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Galimas atnaujinimas į 2-bitų ekraną
         sub_title: Jūsų įrenginį galima atnaujinti, kad jis palaikytų patobulintą pilkų atspalvių ekraną su 4 spalvų lygiais vietoj 2.
@@ -452,6 +458,7 @@ lt:
     index:
       title: Įrenginiai
       tagline: Jūsų TRMNL įrenginiai
+      virtual: Virtual
       add_first_device: Pradėkite pridėdami savo pirmąjį įrenginį!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -657,6 +664,7 @@ lt:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -269,8 +269,11 @@ nl:
       device_model_switch_warning: Dit is een gevaarlijke actie, lees __hier__ meer
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -343,6 +346,9 @@ nl:
       unlink_device_learn_more: Volg __hier__ de volledige handleiding.
       visibility: Vindbaarheid
       visibility_hint: Maak jouw TRMNL apparaat spiegelbaar door onderstaande instelling aan te passen.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Upgrade naar 2-bit scherm beschikbaar
         sub_title: Jouw device kan geupgrade worden om uitgebreide grijswaarden te ondersteunen, met 4 kleurniveau's ipv 2.
@@ -452,6 +458,7 @@ nl:
     index:
       title: Apparaten
       tagline: Jouw TRMNL apparaten
+      virtual: Virtual
       add_first_device: Begin door jouw eerste apparaat toe te voegen!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -657,6 +664,7 @@ nl:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -269,8 +269,11 @@
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -343,6 +346,9 @@
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Synlighet
       visibility_hint: Gjør TRMNL-enheten din speilbar ved å endre innstillingene nedenfor.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -452,6 +458,7 @@
     index:
       title: Enheter
       tagline: Dine TRMNL-enheter
+      virtual: Virtual
       add_first_device: Start med å legge til din første enhet!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -657,6 +664,7 @@
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -291,8 +291,11 @@ pl:
       device_model_switch_warning: Zmiana jest obarczona ryzykiem. Przeczytaj więcej __tutaj__
       device_info: Informacje o urządzeniu
       current_firmware: Obecny firmware
+      pinned_firmware: Pinned firmware
       unknown: Nieznane
       never: Nigdy
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Kalibracja wyświetlacza
       display_calibration_hint: Dostosuj renderowanie na swoim wyświetlaczu. Zostaw puste, aby użyć wartości domyślnych.
       display_calibration_pixel_ratio: Proporcja pikseli
@@ -365,6 +368,9 @@ pl:
       unlink_device_learn_more: Szczegółowe informacje znajdziesz __tutaj__.
       visibility: Widoczność
       visibility_hint: Przełączenie w tryb udostępniania umożliwi ustawienie urządzenia jako źródła kopii lustrzanej (mirror).
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Aktualizacja do 2-bitowego wyświetlacza dostępna
         sub_title: Twoje urządzenie może być zaktualizowane, aby być w stanie wyświetlać 4 odcienie szarości zamiast standardowych 2.
@@ -474,6 +480,7 @@ pl:
     index:
       title: Urządzenia
       tagline: Twoje urządzenia TRMNL
+      virtual: Virtual
       add_first_device: Zacznij, dodając swoje pierwsze urządzenie!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -679,6 +686,7 @@ pl:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -269,8 +269,11 @@ pt-BR:
       device_model_switch_warning: Essa é uma operação perigosa, saiba mais __aqui__
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -343,6 +346,9 @@ pt-BR:
       unlink_device_learn_more: Siga o guia completo __aqui__.
       visibility: Visibilidade
       visibility_hint: Torne seu TRMNL espelhável mudando a configuração abaixo.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Atualização para Display de 2 bits Disponível
         sub_title: Seu dispositivo pode ser atualizado para suportar imagens com 4 tons de cinza ao invés de apenas 2.
@@ -452,6 +458,7 @@ pt-BR:
     index:
       title: Dispositivos
       tagline: Seus dispositivos TRMNL
+      virtual: Virtual
       add_first_device: Comece adicionando seu primeiro dispositivo!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -657,6 +664,7 @@ pt-BR:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -269,8 +269,11 @@ raw:
       device_model_switch_warning: devices.edit.device_model_switch_warning
       device_info: devices.edit.device_info
       current_firmware: devices.edit.current_firmware
+      pinned_firmware: devices.edit.pinned_firmware
       unknown: devices.edit.unknown
       never: devices.edit.never
+      last_ping: devices.edit.last_ping
+      wifi_band: devices.edit.wifi_band
       display_calibration: devices.edit.display_calibration
       display_calibration_hint: devices.edit.display_calibration_hint
       display_calibration_pixel_ratio: devices.edit.display_calibration_pixel_ratio
@@ -343,6 +346,9 @@ raw:
       unlink_device_learn_more: devices.edit.unlink_device_learn_more
       visibility: devices.edit.visibility
       visibility_hint: devices.edit.visibility_hint
+      visibility_options:
+        standalone: devices.edit.visibility_options.standalone
+        sharable: devices.edit.visibility_options.sharable
       upgrade_og:
         title: devices.edit.upgrade_og.title
         sub_title: devices.edit.upgrade_og.sub_title
@@ -452,6 +458,7 @@ raw:
     index:
       title: devices.index.title
       tagline: devices.index.tagline
+      virtual: devices.index.virtual
       add_first_device: devices.index.add_first_device
       go_to_settings: devices.index.go_to_settings
       clear_playlist: devices.index.clear_playlist
@@ -657,6 +664,7 @@ raw:
       add_plugin: playlist_items.index.add_plugin
       select: playlist_items.index.select
       exit_select: playlist_items.index.exit_select
+      time_travel: playlist_items.index.time_travel
       time_travel_now: playlist_items.index.time_travel_now
       time_travel_at: playlist_items.index.time_travel_at
       smart_skip: playlist_items.index.smart_skip

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -269,8 +269,11 @@ ro:
       device_model_switch_warning: Aceasta este o operațiune periculoasă, află mai mult __aici__
       device_info: Informații dispozitiv
       current_firmware: Firmware curent
+      pinned_firmware: Pinned firmware
       unknown: Necunoscut
       never: Niciodată
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Calibrare afișaj
       display_calibration_hint: Ajustează fin randarea pentru afișajul tău. Lasă gol pentru a folosi valorile implicite ale modelului.
       display_calibration_pixel_ratio: Raport pixeli
@@ -343,6 +346,9 @@ ro:
       unlink_device_learn_more: Urmează ghidul complet __aici__.
       visibility: Vizibilitate
       visibility_hint: Fă dispozitivul tău TRMNL oglindicibil schimbând setările de mai jos.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Upgrade la afișaj 2-bit disponibil
         sub_title: Dispozitivul tău poate fi actualizat pentru a suporta un afișaj îmbunătățit în nuanțe de gri cu 4 niveluri de culoare în loc de 2.
@@ -452,6 +458,7 @@ ro:
     index:
       title: Dispozitive
       tagline: Dispozitivele tale TRMNL
+      virtual: Virtual
       add_first_device: Începe prin a adăuga primul tău dispozitiv!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -657,6 +664,7 @@ ro:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -291,8 +291,11 @@ ru:
       device_model_switch_warning: Это опасная операция, узнайте больше __здесь__
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -365,6 +368,9 @@ ru:
       unlink_device_learn_more: Следуйте полному руководству __здесь__.
       visibility: Видимость
       visibility_hint: Сделайте ваше устройство TRMNL зеркалируемым, изменив настройки ниже.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Доступно обновление для 2-битного дисплея
         sub_title: Ваше устройство можно обновить для поддержки улучшенного отображения в оттенках серого с 4 уровнями цвета вместо 2.
@@ -474,6 +480,7 @@ ru:
     index:
       title: Устройства
       tagline: Ваши устройства TRMNL
+      virtual: Virtual
       add_first_device: Начните с добавления вашего первого устройства!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -679,6 +686,7 @@ ru:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -280,8 +280,11 @@ sk:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -354,6 +357,9 @@ sk:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -463,6 +469,7 @@ sk:
     index:
       title: Devices
       tagline: Your TRMNL devices
+      virtual: Virtual
       add_first_device: Start by adding your first device!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -668,6 +675,7 @@ sk:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -269,8 +269,11 @@ sv:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -343,6 +346,9 @@ sv:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Visibility
       visibility_hint: Make your TRMNL device mirrorable by changing the settings below.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -452,6 +458,7 @@ sv:
     index:
       title: Devices
       tagline: Your TRMNL devices
+      virtual: Virtual
       add_first_device: Start by adding your first device!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -657,6 +664,7 @@ sv:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -291,8 +291,11 @@ uk:
       device_model_switch_warning: This is a dangerous operation, learn more __here__
       device_info: Device Info
       current_firmware: Current firmware
+      pinned_firmware: Pinned firmware
       unknown: Unknown
       never: Never
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: Display Calibration
       display_calibration_hint: Fine-tune rendering for your display. Leave empty to use model defaults.
       display_calibration_pixel_ratio: Pixel Ratio
@@ -365,6 +368,9 @@ uk:
       unlink_device_learn_more: Follow the full guide __here__.
       visibility: Спільний доступ
       visibility_hint: Зробіть ваш пристрій TRMNL доступним для віддзеркалення, змінивши налаштування нижче.
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: Upgrade to 2-bit Display Available
         sub_title: Your device can be upgraded to support enhanced grayscale display with 4 color levels instead of 2.
@@ -474,6 +480,7 @@ uk:
     index:
       title: Пристрої
       tagline: Ваші пристрої TRMNL
+      virtual: Virtual
       add_first_device: Почніть, додавши свій перший пристрій!
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -679,6 +686,7 @@ uk:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -304,8 +304,11 @@ zh-CN:
       device_model_switch_warning: 这是一个危险操作，__了解详情__。
       device_info: 设备信息
       current_firmware: 当前固件
+      pinned_firmware: Pinned firmware
       unknown: 未知
       never: 从未
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: 显示校准
       display_calibration_hint: 微调显示效果。留空以使用型号默认值。
       display_calibration_pixel_ratio: 像素比
@@ -378,6 +381,9 @@ zh-CN:
       unlink_device_learn_more: __点击此处__阅读完整说明。
       visibility: 隐藏
       visibility_hint: 让 TRMNL 设备显示镜像播放列表
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: 可升级至 2 位显示
         sub_title: 您的设备可升级至增强型灰度显示，支持从 2 级色彩升级至 4 级。
@@ -487,6 +493,7 @@ zh-CN:
     index:
       title: 设备列表
       tagline: 您的 TRMNL 设备
+      virtual: Virtual
       add_first_device: 添加您的第一个 TRMNL 设备！
       go_to_settings: 前往设置
       clear_playlist: 清空播放列表
@@ -692,6 +699,7 @@ zh-CN:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -269,8 +269,11 @@ zh-HK:
       device_model_switch_warning: 這是危險操作，請__按此__了解更多。
       device_info: 裝置資訊
       current_firmware: 現時韌體版本
+      pinned_firmware: Pinned firmware
       unknown: 未知
       never: 從未
+      last_ping: Hardware last ping
+      wifi_band: Wi-Fi band
       display_calibration: 螢幕校準
       display_calibration_hint: 為你的螢幕微調顯示設定，留空則使用型號預設值。
       display_calibration_pixel_ratio: 像素比例
@@ -343,6 +346,9 @@ zh-HK:
       unlink_device_learn_more: __按此__查看完整指南。
       visibility: 共享狀態
       visibility_hint: 調整下方設定使你的TRMNL裝置可被鏡像共享。
+      visibility_options:
+        standalone: Standalone
+        sharable: Sharable
       upgrade_og:
         title: 可升級至 2-bit 顯示
         sub_title: 你的裝置可升級以支援增強的灰階顯示，從2個顏色級別升級至4個。
@@ -452,6 +458,7 @@ zh-HK:
     index:
       title: 裝置
       tagline: 你的TRMNL裝置
+      virtual: Virtual
       add_first_device: 請先新增你的第一部裝置！
       go_to_settings: Go to settings
       clear_playlist: Clear playlist
@@ -657,6 +664,7 @@ zh-HK:
       add_plugin: Add Plugin
       select: Select
       exit_select: Exit select mode
+      time_travel: Time Travel
       time_travel_now: Now
       time_travel_at: "%{day} %{time}"
       smart_skip: Smart Skip


### PR DESCRIPTION
Found several hardcoded English strings: the Time Travel label, the "Virtual" device badge, "Hardware last ping"/"Wi-Fi band"/ "Pinned firmware" on the device edit page, and the mirroring visibility options (Standalone/Sharable).

Added the keys to `web_ui/en.yml` and ran `bin/sync` to propagate them to every other locale.

