### PR TITLE
Added the English keys core is waiting on

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -1063,6 +1063,7 @@ cs:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -1064,6 +1064,7 @@ da:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -1063,6 +1063,7 @@ de-AT:
       no_render_slot: kein Render-Slot war vor der Frist frei
       render_lock_held: ein anderes Render für dieses Plugin lief bereits
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Bildschirm an Gerät gesendet
       alias: Alias-Bild an Gerät gesendet

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -1063,6 +1063,7 @@ de:
       no_render_slot: kein Render-Slot war vor der Frist frei
       render_lock_held: ein anderes Render für dieses Plugin lief bereits
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Bildschirm an Gerät gesendet
       alias: Alias-Bild an Gerät gesendet

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -1063,6 +1063,7 @@ en-AU:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -1064,6 +1064,7 @@ en-GB:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -1063,6 +1063,7 @@ en:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -1064,6 +1064,7 @@ es-ES:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -1066,6 +1066,7 @@ fr:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -1066,6 +1066,7 @@ he:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -1064,6 +1064,7 @@ hu:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -1066,6 +1066,7 @@ id:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -1064,6 +1064,7 @@ is:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -1064,6 +1064,7 @@ it:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -1064,6 +1064,7 @@ ja:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -1064,6 +1064,7 @@ ko:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -1064,6 +1064,7 @@ lt:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -1064,6 +1064,7 @@ nl:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -1064,6 +1064,7 @@
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -1086,6 +1086,7 @@ pl:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -1064,6 +1064,7 @@ pt-BR:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -1064,6 +1064,7 @@ raw:
       no_render_slot: activity_logs.render_reasons.no_render_slot
       render_lock_held: activity_logs.render_reasons.render_lock_held
       no_document_changed: activity_logs.render_reasons.no_document_changed
+      data_not_refetched: activity_logs.render_reasons.data_not_refetched
     serve_statuses:
       served: activity_logs.serve_statuses.served
       alias: activity_logs.serve_statuses.alias

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -1064,6 +1064,7 @@ ro:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -1086,6 +1086,7 @@ ru:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -1075,6 +1075,7 @@ sk:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -1064,6 +1064,7 @@ sv:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -1086,6 +1086,7 @@ uk:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -1099,6 +1099,7 @@ zh-CN:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -1064,6 +1064,7 @@ zh-HK:
       no_render_slot: no render slot was free before the deadline
       render_lock_held: another render for this plugin was already running
       no_document_changed: no change in the page it renders
+      data_not_refetched: cached data reused, no fetch was due
     serve_statuses:
       served: Screen sent to device
       alias: Alias image sent to device


### PR DESCRIPTION
Opened automatically from usetrmnl/core. These keys already ship in core's
`config/locales/pending`, which shadows this gem's English until they land
here. Merging lets core drop its copy and lets translators pick the copy up.

Only additions — copy this repository already holds is left alone. The other
locales carry the new keys too, from this repository's own `bin/sync`.