### PR TITLE
Added the English keys core is waiting on

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -942,6 +942,7 @@ cs:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -943,6 +943,7 @@ da:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -942,6 +942,7 @@ de-AT:
       awaiting_connection: Verbinde dein Konto im OAuth-Bereich oben und lade diese Seite dann neu.
       connection_broken: Die OAuth-Verbindung wurde unterbrochen — stelle sie im OAuth-Bereich wieder her und lade diese Seite dann neu.
       unavailable: Optionen konnten nicht geladen werden — Details findest du in den Protokollen der Erweiterung.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: Diese Erweiterung füllt einen Mashup-Slot. Wird sie entfernt, bleibt dieser Slot leer.
       other: Diese Erweiterung füllt %{count} Mashup-Slots. Wird sie entfernt, bleiben diese Slots leer.

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -942,6 +942,7 @@ de:
       awaiting_connection: Verbinde dein Konto im OAuth-Bereich oben und lade diese Seite dann neu.
       connection_broken: Die OAuth-Verbindung wurde unterbrochen — stelle sie im OAuth-Bereich wieder her und lade diese Seite dann neu.
       unavailable: Optionen konnten nicht geladen werden — Details findest du in den Protokollen der Erweiterung.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: Diese Erweiterung füllt einen Mashup-Slot. Wird sie entfernt, bleibt dieser Slot leer.
       other: Diese Erweiterung füllt %{count} Mashup-Slots. Wird sie entfernt, bleiben diese Slots leer.

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -942,6 +942,7 @@ en-AU:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -943,6 +943,7 @@ en-GB:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -942,6 +942,7 @@ en:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -943,6 +943,7 @@ es-ES:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -945,6 +945,7 @@ fr:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -945,6 +945,7 @@ he:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -943,6 +943,7 @@ hu:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -945,6 +945,7 @@ id:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -943,6 +943,7 @@ is:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -943,6 +943,7 @@ it:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -943,6 +943,7 @@ ja:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -943,6 +943,7 @@ ko:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -943,6 +943,7 @@ lt:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -943,6 +943,7 @@ nl:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -943,6 +943,7 @@
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -965,6 +965,7 @@ pl:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -943,6 +943,7 @@ pt-BR:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -943,6 +943,7 @@ raw:
       awaiting_connection: plugin_settings.remote_select.awaiting_connection
       connection_broken: plugin_settings.remote_select.connection_broken
       unavailable: plugin_settings.remote_select.unavailable
+      credentials_rejected: plugin_settings.remote_select.credentials_rejected
     delete_mashup_warning:
       one: plugin_settings.delete_mashup_warning.one
       other: plugin_settings.delete_mashup_warning.other

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -943,6 +943,7 @@ ro:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -965,6 +965,7 @@ ru:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -954,6 +954,7 @@ sk:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -943,6 +943,7 @@ sv:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -965,6 +965,7 @@ uk:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -978,6 +978,7 @@ zh-CN:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -943,6 +943,7 @@ zh-HK:
       awaiting_connection: Connect your account in the OAuth section above, then reload this page.
       connection_broken: OAuth connection is broken — reconnect it in the OAuth section, then reload this page.
       unavailable: Options failed to load — check the plugin's logs for details.
+      credentials_rejected: Those credentials were rejected — check them and reload this page.
     delete_mashup_warning:
       one: This plugin fills a mashup slot. Removing it leaves that slot empty.
       other: This plugin fills %{count} mashup slots. Removing it leaves those slots empty.


### PR DESCRIPTION
Opened automatically from usetrmnl/core. These keys already ship in core's
`config/locales/pending`, which shadows this gem's English until they land
here. Merging lets core drop its copy and lets translators pick the copy up.

Only additions — copy this repository already holds is left alone. The other
locales carry the new keys too, from this repository's own `bin/sync`.