### PR TITLE
Added the English keys core is waiting on

### DIFF
--- a/lib/trmnl/i18n/locales/plugin_renders/cs.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/cs.yml
@@ -301,3 +301,25 @@ cs:
       title: Vítejte
       greeting: Ahoj, %{name}
       greeting_blank: Ahoj
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/da.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/da.yml
@@ -301,3 +301,25 @@ da:
       title: Velkommen
       greeting: Hej %{name}
       greeting_blank: Hej
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
@@ -301,3 +301,25 @@ de-AT:
       title: Willkommen
       greeting: Hallo, %{name}
       greeting_blank: Hallo
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/de.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de.yml
@@ -301,3 +301,25 @@ de:
       title: Willkommen
       greeting: Hallo, %{name}
       greeting_blank: Hallo
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/en.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/en.yml
@@ -301,3 +301,25 @@ en:
       title: Welcome
       greeting: Hello, %{name}
       greeting_blank: Hello
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
@@ -301,3 +301,25 @@ es-ES:
       title: Bienvenido
       greeting: Hola, %{name}
       greeting_blank: Hola
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/fr.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/fr.yml
@@ -301,3 +301,25 @@ fr:
       title: Bienvenue
       greeting: Bonjour %{name}
       greeting_blank: Bonjour
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/he.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/he.yml
@@ -301,3 +301,25 @@ he:
       title: ברוכים הבאים
       greeting: שלום, %{name}
       greeting_blank: שלום
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/hu.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/hu.yml
@@ -301,3 +301,25 @@ hu:
       title: Üdvözlünk
       greeting: Szia, %{name}
       greeting_blank: Szia
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/id.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/id.yml
@@ -301,3 +301,25 @@ id:
       title: Selamat datang
       greeting: Halo %{name}
       greeting_blank: Halo
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/is.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/is.yml
@@ -301,3 +301,25 @@ is:
       title: Velkomin
       greeting: Halló, %{name}
       greeting_blank: Halló
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/it.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/it.yml
@@ -301,3 +301,25 @@ it:
       title: Benvenuto/a
       greeting: Ciao, %{name}
       greeting_blank: Ciao
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/ja.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ja.yml
@@ -301,3 +301,25 @@ ja:
       title: ようこそ
       greeting: こんにちは、%{name}さん
       greeting_blank: こんにちは
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/ko.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ko.yml
@@ -301,3 +301,25 @@ ko:
       title: 환영해요
       greeting: 안녕하세요, %{name}님
       greeting_blank: 안녕하세요
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/lt.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/lt.yml
@@ -301,3 +301,25 @@ lt:
       title: Sveiki atvykę
       greeting: Sveiki, %{name}
       greeting_blank: Sveiki
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/nl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/nl.yml
@@ -301,3 +301,25 @@ nl:
       title: Welkom
       greeting: Hallo, %{name}
       greeting_blank: Hallo
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/no.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/no.yml
@@ -301,3 +301,25 @@
       title: Velkommen
       greeting: Hei, %{name}
       greeting_blank: Hei
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/pl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pl.yml
@@ -302,3 +302,25 @@ pl:
       title: Witamy
       greeting: Cześć, %{name}
       greeting_blank: Cześć
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
@@ -301,3 +301,25 @@ pt-BR:
       title: Bem-vindo
       greeting: Olá, %{name}
       greeting_blank: Olá
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/raw.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/raw.yml
@@ -301,3 +301,25 @@ raw:
       title: renders.welcome.title
       greeting: renders.welcome.greeting
       greeting_blank: renders.welcome.greeting_blank
+    homey:
+      'on': renders.homey.on
+      'off': renders.homey.off
+      offline: renders.homey.offline
+      all_offline: renders.homey.all_offline
+      all_offline_hint:
+        one: renders.homey.all_offline_hint.one
+        other: renders.homey.all_offline_hint.other
+      batteries_healthy:
+        one: renders.homey.batteries_healthy.one
+        other: renders.homey.batteries_healthy.other
+      batteries_low:
+        one: renders.homey.batteries_low.one
+        other: renders.homey.batteries_low.other
+      no_batteries: renders.homey.no_batteries
+      no_batteries_hint: renders.homey.no_batteries_hint
+      insights: renders.homey.insights
+      no_chart: renders.homey.no_chart
+      no_insights: renders.homey.no_insights
+      no_insights_hint: renders.homey.no_insights_hint
+      no_devices: renders.homey.no_devices
+      no_devices_hint: renders.homey.no_devices_hint

--- a/lib/trmnl/i18n/locales/plugin_renders/ro.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ro.yml
@@ -301,3 +301,25 @@ ro:
       title: Bun venit
       greeting: Bună, %{name}
       greeting_blank: Bună
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/ru.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ru.yml
@@ -301,3 +301,25 @@ ru:
       title: Добро пожаловать
       greeting: Привет, %{name}
       greeting_blank: Привет
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/sk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sk.yml
@@ -301,3 +301,25 @@ sk:
       title: Vitajte
       greeting: Ahoj, %{name}
       greeting_blank: Ahoj
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/sv.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sv.yml
@@ -301,3 +301,25 @@ sv:
       title: Välkommen
       greeting: Hej, %{name}
       greeting_blank: Hej
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/uk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/uk.yml
@@ -301,3 +301,25 @@ uk:
       title: Ласкаво просимо
       greeting: Привіт, %{name}
       greeting_blank: Привіт
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
@@ -301,3 +301,25 @@ zh-CN:
       title: 欢迎
       greeting: 你好，%{name}
       greeting_blank: 你好
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
@@ -301,3 +301,25 @@ zh-HK:
       title: 歡迎
       greeting: 你好，%{name}
       greeting_blank: 你好
+    homey:
+      'on': 'On'
+      'off': 'Off'
+      offline: Offline
+      all_offline: Every device is offline
+      all_offline_hint:
+        one: One device is unreachable
+        other: All %{count} devices are unreachable
+      batteries_healthy:
+        one: Battery
+        other: Batteries
+      batteries_low:
+        one: Needs a cell
+        other: Need a cell
+      no_batteries: No batteries to watch
+      no_batteries_hint: Nothing here reports a battery level
+      insights: Insights
+      no_chart: No chart
+      no_insights: No series pushed yet
+      no_insights_hint: A Homey app can push an Insights log to chart here
+      no_devices: Waiting for your first devices
+      no_devices_hint: They appear after the first push or cloud sync


### PR DESCRIPTION
Opened automatically from usetrmnl/core. These keys already ship in core's
`config/locales/pending`, which shadows this gem's English until they land
here. Merging lets core drop its copy and lets translators pick the copy up.

Only additions — copy this repository already holds is left alone. The other
locales carry the new keys too, from this repository's own `bin/sync`.