### PR TITLE
Add more keys for currently hardcoded strings

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/cs.yml
+++ b/lib/trmnl/i18n/locales/web_ui/cs.yml
@@ -930,6 +930,25 @@ cs:
       learn_more_recipe_long: Tento plugin je komunitní Recept a není spravován společností TRMNL.
       learn_more_third_party_short: 'Poznámka: tento plugin pochází od 3. strany.'
       learn_more_third_party_long: Tento plugin pochází od 3. strany a není spravován společností TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: Soubor ZIP je příliš velký (maximálně %{max_mb} MB)
       missing_entry: Soubor ZIP neobsahuje %{filename}
@@ -960,6 +979,32 @@ cs:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Žádost byla přijata, zkontrolujte svou e-mailovou schránku

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -931,6 +931,25 @@ da:
       learn_more_recipe_long: Dette plugin er en community-opskrift og vedligeholdes ikke af TRMNL.
       learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP-fil er for stor (%{max_mb} MB maksimum)
       missing_entry: ZIP-filen indeholder ikke %{filename}
@@ -961,6 +980,32 @@ da:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Anmodning modtaget, tjek din indbakke

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -930,6 +930,25 @@ de-AT:
       learn_more_recipe_long: Diese Erweiterung ist eine Community-Blaupause und wird nicht von TRMNL gewartet.
       learn_more_third_party_short: 'Hinweis: Diese Erweiterung stammt von einem Drittanbieter.'
       learn_more_third_party_long: Diese Erweiterung stammt von einem Drittanbieter und wird nicht von TRMNL gewartet.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP-Datei ist zu groß (maximal %{max_mb} MB)
       missing_entry: Die ZIP-Datei enthält nicht %{filename}
@@ -960,6 +979,32 @@ de-AT:
     health_status_banner:
       short_heading: Erweiterung-Analyse
       long_heading: Überwache Erweiterungs-Analyse und -Zustände über alle Installationen hinweg
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Anfrage erhalten, bitte Posteingang überprüfen

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -930,6 +930,25 @@ de:
       learn_more_recipe_long: Diese Erweiterung ist eine Community-Blaupause und wird nicht von TRMNL gewartet.
       learn_more_third_party_short: 'Hinweis: Diese Erweiterung stammt von einem Drittanbieter.'
       learn_more_third_party_long: Diese Erweiterung stammt von einem Drittanbieter und wird nicht von TRMNL gewartet.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP-Datei ist zu groß (maximal %{max_mb} MB)
       missing_entry: Die ZIP-Datei enthält nicht %{filename}
@@ -960,6 +979,32 @@ de:
     health_status_banner:
       short_heading: Erweiterung-Analyse
       long_heading: Überwache Erweiterungs-Analyse und -Zustände über alle Installationen hinweg
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Anfrage erhalten, bitte Posteingang überprüfen

--- a/lib/trmnl/i18n/locales/web_ui/en-AU.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-AU.yml
@@ -930,6 +930,25 @@ en-AU:
       learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
       learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -960,6 +979,32 @@ en-AU:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -931,6 +931,25 @@ en-GB:
       learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
       learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -961,6 +980,32 @@ en-GB:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -930,6 +930,24 @@ en:
       learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
       learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -960,6 +978,32 @@ en:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -931,6 +931,25 @@ es-ES:
       learn_more_recipe_long: Este plugin es una receta de la comunidad y no es mantenido por TRMNL.
       learn_more_third_party_short: 'Nota: este plugin es de un tercero.'
       learn_more_third_party_long: Este plugin es de un tercero y no está mantenido por TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: El archivo ZIP es demasiado grande (%{max_mb} MB máximo)
       missing_entry: El archivo ZIP no contiene %{filename}
@@ -961,6 +980,32 @@ es-ES:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Solicitud recibida, compruebe su bandeja de entrada

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -933,6 +933,25 @@ fr:
       learn_more_recipe_long: Ce plugin est une Recette communautaire et n'est pas maintenu par TRMNL.
       learn_more_third_party_short: 'Note : ce plugin est tiers.'
       learn_more_third_party_long: Ce plugin est tiers et n'est pas maintenu par TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: Le fichier ZIP est trop volumineux (%{max_mb} MB maximum)
       missing_entry: Le fichier ZIP ne contient pas %{filename}
@@ -963,6 +982,32 @@ fr:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Demande reçue, vérifiez votre boîte de réception

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -933,6 +933,25 @@ he:
       learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
       learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -963,6 +982,32 @@ he:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -931,6 +931,25 @@ hu:
       learn_more_recipe_long: Ez a bővítmény egy közösségi recept, amelyet nem a TRMNL tart karban.
       learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: A ZIP fájl túl nagy (%{max_mb} MB a maximális méret)
       missing_entry: A ZIP fájl nem tartalmazza a(z) %{filename} fájlt
@@ -961,6 +980,32 @@ hu:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Kérés fogadva, ellenőrizd az e-mail fiókodat

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -933,6 +933,25 @@ id:
       learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
       learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -963,6 +982,32 @@ id:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -931,6 +931,25 @@ is:
       learn_more_recipe_long: Þessi viðbót er frá samfélaginu og er ekki viðhaldið af TRMNL.
       learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP skrá er of stór (%{max_mb} MB hámark)
       missing_entry: ZIP skrá inniheldur ekki %{filename}
@@ -961,6 +980,32 @@ is:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Beiðni móttekin, skoðaðu pósthólfið þitt

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -931,6 +931,25 @@ it:
       learn_more_recipe_long: Questi plugin è una Recipe della comunità e non viene manutenuta da TRMNL.
       learn_more_third_party_short: 'Note: Questo plugin è creato da terzi.'
       learn_more_third_party_long: Questo pliugin è creato da terzi e non viene manutenuto da TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: File ZIP troppo grande (%{max_mb} MB massimi)
       missing_entry: Il file ZIP non contiene %{filename}
@@ -961,6 +980,32 @@ it:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Richiesta ricevuta, controlla la tua posta

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -931,6 +931,25 @@ ja:
       learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
       learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -961,6 +980,32 @@ ja:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: リクエストを受信しました。受信箱を確認してください

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -931,6 +931,25 @@ ko:
       learn_more_recipe_long: 이 플러그인은 커뮤니티 레시피이며 TRMNL이 관리하지 않아요.
       learn_more_third_party_short: '참고: 이 플러그인은 서드파티 제공이에요.'
       learn_more_third_party_long: 이 플러그인은 서드파티가 만들었으며 TRMNL이 관리하지 않아요.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP 파일이 너무 커요 (최대 %{max_mb} MB)
       missing_entry: ZIP 파일에 %{filename}이(가) 없어요
@@ -961,6 +980,32 @@ ko:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: 요청을 받았어요. 이메일을 확인해주세요

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -931,6 +931,25 @@ lt:
       learn_more_recipe_long: Šis įskiepis yra bendruomenės receptas ir jo neprižiūri TRMNL.
       learn_more_third_party_short: 'Pastaba: šis įskiepis yra sukurtas trečiosios šalies.'
       learn_more_third_party_long: Šis įskiepis yra trečiosios šalies ir jo neprižiūri TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP failas yra per didelis (maksimaliai %{max_mb} MB)
       missing_entry: ZIP faile nėra %{filename}
@@ -961,6 +980,32 @@ lt:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Užklausa gauta, patikrinkite savo pašto dėžutę

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -931,6 +931,25 @@ nl:
       learn_more_recipe_long: Deze plugin is een recept uit de community, en wordt niet onderhouden door TRMNL.
       learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP bestand is te groot (%{max_mb} MB max)
       missing_entry: Het ZIP bestand bevat %{filename} niet
@@ -961,6 +980,32 @@ nl:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Request ontvangen, check je inbox

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -931,6 +931,25 @@
       learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
       learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP-filen er for stor (maksimum %{max_mb} MB)
       missing_entry: ZIP-filen inneholder ikke %{filename}
@@ -961,6 +980,32 @@
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Forespørsel mottatt, sjekk innboksen din

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -953,6 +953,25 @@ pl:
       learn_more_recipe_long: Ten plugin jest Recepturą społecznościową i nie jest utrzymywany przez TRMNL.
       learn_more_third_party_short: 'Uwaga: wtyczka stworzona przez osoby trzecie.'
       learn_more_third_party_long: Wtyczka została stworzona przez osoby trzecie i nie jest wspierana przez TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: Archiwum ZIP jest zbyt duże (maksimum %{max_mb} MB)
       missing_entry: Archiwum ZIP nie zawiera %{filename}
@@ -983,6 +1002,32 @@ pl:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Zgłoszenie przyjęte, sprawdź swoją skrzynkę odbiorczą

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -931,6 +931,25 @@ pt-BR:
       learn_more_recipe_long: Esse plugin é uma Receita da comunidade e não é mantido pelo TRMNL.
       learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: O arquivo ZIP é muito grande (máximo de %{max_mb} MB)
       missing_entry: O arquivo ZIP não contém %{filename}
@@ -961,6 +980,32 @@ pt-BR:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Pedido recebido, verifique sua caixa de entrada

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -931,6 +931,25 @@ raw:
       learn_more_recipe_long: plugin_settings.form.learn_more_recipe_long
       learn_more_third_party_short: plugin_settings.form.learn_more_third_party_short
       learn_more_third_party_long: plugin_settings.form.learn_more_third_party_long
+      ai_features_default_on_markup_editor: plugin_settings.form.ai_features_default_on_markup_editor
+      ai_features_default_on_account_settings: plugin_settings.form.ai_features_default_on_account_settings
+      description_hint: plugin_settings.form.description_hint
+      description_placeholder: plugin_settings.form.description_placeholder
+      max_refresh_rate: plugin_settings.form.max_refresh_rate
+      max_refresh_rate_hint: plugin_settings.form.max_refresh_rate_hint
+      recipe_step_acknowledge: plugin_settings.form.recipe_step_acknowledge
+      recipe_step_choose_visibility: plugin_settings.form.recipe_step_choose_visibility
+      recipe_best_practices_acknowledgement: plugin_settings.form.recipe_best_practices_acknowledgement
+      recipe_licensing_note_label: plugin_settings.form.recipe_licensing_note_label
+      recipe_licensing_notice: plugin_settings.form.recipe_licensing_notice
+      upload_image: plugin_settings.form.upload_image
+      upload_image_hint: plugin_settings.form.upload_image_hint
+      upload_image_dropzone: plugin_settings.form.upload_image_dropzone
+      upload_image_caption: plugin_settings.form.upload_image_caption
+      upload_image_caption_for_device: plugin_settings.form.upload_image_caption_for_device
+      webhook_url: plugin_settings.form.webhook_url
+      webhook_url_hint: plugin_settings.form.webhook_url_hint
+      ai_features_default_on_html: plugin_settings.form.ai_features_default_on_html
     import:
       archive_too_large: plugin_settings.import.archive_too_large
       missing_entry: plugin_settings.import.missing_entry
@@ -961,6 +980,32 @@ raw:
     health_status_banner:
       short_heading: plugin_settings.health_status_banner.short_heading
       long_heading: plugin_settings.health_status_banner.long_heading
+      degraded_short: plugin_settings.health_status_banner.degraded_short
+      degraded_long: plugin_settings.health_status_banner.degraded_long
+      erroring_short: plugin_settings.health_status_banner.erroring_short
+      erroring_long: plugin_settings.health_status_banner.erroring_long
+      reset_health: plugin_settings.health_status_banner.reset_health
+    inactive_references_banner:
+      short: plugin_settings.inactive_references_banner.short
+      long: plugin_settings.inactive_references_banner.long
+      hint: plugin_settings.inactive_references_banner.hint
+    uninstall_modal:
+      title: plugin_settings.uninstall_modal.title
+      warning: plugin_settings.uninstall_modal.warning
+      reason_label: plugin_settings.uninstall_modal.reason_label
+      reason_placeholder: plugin_settings.uninstall_modal.reason_placeholder
+      detail_placeholder: plugin_settings.uninstall_modal.detail_placeholder
+      cancel: plugin_settings.uninstall_modal.cancel
+      confirm: plugin_settings.uninstall_modal.confirm
+    mcp_key:
+      title: plugin_settings.mcp_key.title
+      description: plugin_settings.mcp_key.description
+      copy_title: plugin_settings.mcp_key.copy_title
+      revoke: plugin_settings.mcp_key.revoke
+      revoke_confirm: plugin_settings.mcp_key.revoke_confirm
+      client_config: plugin_settings.mcp_key.client_config
+      client_config_hint_html: plugin_settings.mcp_key.client_config_hint_html
+      generate: plugin_settings.mcp_key.generate
   referral_code:
     create:
       request_received: referral_code.create.request_received

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -931,6 +931,25 @@ ro:
       learn_more_recipe_long: Acest plugin este un Rețetar al comunității și nu este menținut de TRMNL.
       learn_more_third_party_short: 'Notă: acest plugin aparține unei terțe părți.'
       learn_more_third_party_long: Acest plugin aparține unei terțe părți și nu este menținut de TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: Fișierul ZIP este prea mare (%{max_mb} MB maxim)
       missing_entry: Fișierul ZIP nu conține %{filename}
@@ -961,6 +980,32 @@ ro:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Cerere primită, verifică inbox-ul

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -953,6 +953,25 @@ ru:
       learn_more_recipe_long: Этот плагин является рецептом сообщества и не поддерживается TRMNL.
       learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP-файл слишком большой (максимум %{max_mb} МБ)
       missing_entry: ZIP-файл не содержит %{filename}
@@ -983,6 +1002,32 @@ ru:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Запрос получен, проверьте свой почтовый ящик

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -942,6 +942,25 @@ sk:
       learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
       learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -972,6 +991,32 @@ sk:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -931,6 +931,25 @@ sv:
       learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
       learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -961,6 +980,32 @@ sv:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -953,6 +953,25 @@ uk:
       learn_more_recipe_long: This plugin is a community Recipe and is not maintained by TRMNL.
       learn_more_third_party_short: 'Note: this plugin is by a 3rd party.'
       learn_more_third_party_long: This plugin is by a 3rd party and not maintained by TRMNL.
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP file is too large (%{max_mb} MB maximum)
       missing_entry: The ZIP file does not contain %{filename}
@@ -983,6 +1002,32 @@ uk:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -966,6 +966,25 @@ zh-CN:
       learn_more_recipe_long: 此插件为社区配方，不由 TRMNL 维护。
       learn_more_third_party_short: 注意：此插件由第三方提供。
       learn_more_third_party_long: 此插件由第三方提供，不由 TRMNL 维护。
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP 文件过大（最大 %{max_mb} MB）
       missing_entry: ZIP 文件不包含 %{filename}
@@ -996,6 +1015,32 @@ zh-CN:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: 已收到请求，请查收邮箱

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -931,6 +931,25 @@ zh-HK:
       learn_more_recipe_long: 此外掛為社群用戶開發的模板，並非由TRMNL維護。
       learn_more_third_party_short: 注意：此外掛由第三方開發。
       learn_more_third_party_long: 此外掛由第三方開發，並非由TRMNL維護。
+      ai_features_default_on_markup_editor: The __agentic markup editor__ is now available to everyone.
+      ai_features_default_on_account_settings: Use it if it helps, or switch it off anytime in __Account Settings__.
+      description_hint: A short tagline for this plugin. Shown in search results if published as a recipe.
+      description_placeholder: Upcoming train departures
+      max_refresh_rate: Max refresh rate
+      max_refresh_rate_hint: Refreshes on-demand when your device checks in — no more often than the rate below. __Learn more__.
+      recipe_step_acknowledge: Acknowledge best practices
+      recipe_step_choose_visibility: Choose visibility
+      recipe_best_practices_acknowledgement: I've read and applied the plugin publishing __best practices__. A real human on the TRMNL team will thoughtfully review my submission and share detailed feedback.
+      recipe_licensing_note_label: Note
+      recipe_licensing_notice: Public plugins are subject to __Plugin Licensing__.
+      upload_image: Upload Image
+      upload_image_hint: Or upload directly from your browser.
+      upload_image_dropzone: Drag & drop, paste, or click to upload
+      upload_image_caption: PNG, JPEG, or WebP · max %{max_size}
+      upload_image_caption_for_device: PNG, JPEG, or WebP · max %{max_size} for device "%{device}"
+      webhook_url: Webhook URL
+      webhook_url_hint: POST raw image data (PNG, JPEG, or WebP) to this URL to update the display.
+      ai_features_default_on_html: The %{markup_editor_link} is now available to everyone. Use it if it helps, or switch it off anytime in %{account_settings_link}.
     import:
       archive_too_large: ZIP檔案太大（最大%{max_mb} MB）
       missing_entry: ZIP檔案未包含「%{filename}」
@@ -961,6 +980,32 @@ zh-HK:
     health_status_banner:
       short_heading: Plugin analytics
       long_heading: Monitor plugin analytics and health across installs
+      degraded_short: This plugin is in a degraded state.
+      degraded_long: Plugin is in a degraded state. Please fix the issue to prevent refresh from stopping.
+      erroring_short: This plugin is currently experiencing an error.
+      erroring_long: Plugin experiencing an error. Please fix the issue to restart refresh.
+      reset_health: Reset Health
+    inactive_references_banner:
+      short: Referenced plugins not syncing.
+      long: 'This plugin references data from plugins that aren''t in any Playlist:'
+      hint: Add them as a hidden item to a Playlist or Mashup to ensure their data stays fresh.
+    uninstall_modal:
+      title: Uninstall plugin?
+      warning: This removes the plugin instance. Mind sharing why? It helps us improve TRMNL, but it's optional.
+      reason_label: Reason (optional)
+      reason_placeholder: Select a reason (optional)
+      detail_placeholder: Tell us more (optional)
+      cancel: Cancel
+      confirm: Uninstall
+    mcp_key:
+      title: MCP API Key
+      description: Use this key to connect AI agents (Claude Desktop, etc.) to manage this plugin's markup.
+      copy_title: Copy full key to clipboard
+      revoke: Revoke Key
+      revoke_confirm: Revoke this MCP key? Any connected agents will lose access.
+      client_config: MCP client config
+      client_config_hint_html: Add %{env_var} to your %{dotenv_file} file. Copy full key with the button above.
+      generate: Generate MCP Key
   referral_code:
     create:
       request_received: 已收到請求，請查看收件箱


### PR DESCRIPTION
Found more hardcoded English strings while auditing the plugin settings edit page and the publish (recipe submission) flow: the publish modal's step labels and best-practices/licensing copy, the "agentic markup editor" notice, the description/webhook-URL/max-refresh-rate/upload-image fields on the general settings card, the MCP API key card, the uninstall modal, and the degraded/erroring/inactive-references banners.

Added the keys to `web_ui/en.yml` and ran `bin/sync` to propagate them (as English fallbacks) to every other locale and to `raw.yml`.

Core-side swap to `t(...)` calls follows once this merges and the gem pin bumps.